### PR TITLE
feat: token categorization, batch embedding, SAP AI Core direct provider (#52, #53, #54)

### DIFF
--- a/docs/superpowers/plans/2026-04-06-token-tracking-batch-embed-sap-direct.md
+++ b/docs/superpowers/plans/2026-04-06-token-tracking-batch-embed-sap-direct.md
@@ -1,0 +1,1820 @@
+# Token Categorization, Batch Embedding & SAP AI Core Direct Provider — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add token categorization with init/auxiliary/request separation (#53), batch embedding for tool vectorization (#52), and a direct SAP AI Core provider bypassing Orchestration overhead (#54).
+
+**Architecture:** Extend `IRequestLogger` with `TokenBucket`, `TokenCategory`, `byCategory`, and `scope`/`estimated`/`detail` fields on `LlmCallEntry`. Add `IEmbedderBatch` extending `IEmbedder` with `embedBatch()` and `IPrecomputedVectorRag` extending `IRag` with `upsertPrecomputed()`. New `SapAiCoreDirectProvider` uses `resolveDeploymentUrl()` + raw OpenAI-compatible HTTP, wrapped with `OpenAIAgent` via `LlmAdapter`.
+
+**Tech Stack:** TypeScript (ESM), node:test, @sap-ai-sdk/ai-api, @sap-ai-sdk/orchestration
+
+---
+
+## Phase 1: Token Categorization (#53)
+
+### Task 1: Extend request-logger interfaces
+
+**Files:**
+- Modify: `src/smart-agent/interfaces/request-logger.ts`
+
+- [ ] **Step 1: Add new types to request-logger.ts**
+
+```typescript
+// Replace the entire file content:
+
+export type LlmComponent =
+  | 'tool-loop'
+  | 'classifier'
+  | 'helper'
+  | 'translate'
+  | 'query-expander'
+  | 'embedding';
+
+export type TokenCategory = 'initialization' | 'auxiliary' | 'request';
+
+export interface TokenBucket {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  requests: number;
+  items?: number;
+}
+
+export interface LlmCallEntry {
+  component: LlmComponent;
+  model: string;
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  durationMs: number;
+  estimated?: boolean;
+  scope?: 'initialization' | 'request';
+  detail?: string;
+}
+
+export interface RagQueryEntry {
+  store: string;
+  query: string;
+  resultCount: number;
+  durationMs: number;
+}
+
+export interface ToolCallEntry {
+  toolName: string;
+  success: boolean;
+  durationMs: number;
+  cached: boolean;
+}
+
+export interface RequestSummary {
+  /** Per-model aggregated token usage. */
+  byModel: Record<string, TokenBucket>;
+  /** Per-component aggregated token usage. */
+  byComponent: Record<string, TokenBucket>;
+  /** Per-category aggregated token usage. */
+  byCategory: Record<string, TokenBucket>;
+  ragQueries: number;
+  toolCalls: number;
+  /** Wall-clock time for the entire request. */
+  totalDurationMs: number;
+}
+
+export interface IRequestLogger {
+  logLlmCall(entry: LlmCallEntry): void;
+  logRagQuery(entry: RagQueryEntry): void;
+  logToolCall(entry: ToolCallEntry): void;
+  /** Mark the start of a request for wall-clock duration tracking. */
+  startRequest(): void;
+  /** Mark the end of a request for wall-clock duration tracking. */
+  endRequest(): void;
+  getSummary(): RequestSummary;
+  reset(): void;
+}
+```
+
+- [ ] **Step 2: Run build to check for type errors**
+
+Run: `npm run build`
+Expected: Errors in `default-request-logger.ts` and `noop-request-logger.ts` because `byCategory` is missing from their return types.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/smart-agent/interfaces/request-logger.ts
+git commit -m "feat(#53): extend request-logger interfaces with TokenBucket, TokenCategory, scope, estimated"
+```
+
+### Task 2: Update DefaultRequestLogger with init/request split
+
+**Files:**
+- Modify: `src/smart-agent/logger/default-request-logger.ts`
+
+- [ ] **Step 1: Rewrite DefaultRequestLogger**
+
+```typescript
+import type {
+  IRequestLogger,
+  LlmCallEntry,
+  LlmComponent,
+  RagQueryEntry,
+  RequestSummary,
+  TokenBucket,
+  TokenCategory,
+  ToolCallEntry,
+} from '../interfaces/request-logger.js';
+
+const CATEGORY_MAP: Record<LlmComponent, TokenCategory> = {
+  'tool-loop': 'request',
+  classifier: 'auxiliary',
+  translate: 'auxiliary',
+  'query-expander': 'auxiliary',
+  helper: 'auxiliary',
+  embedding: 'initialization',
+};
+
+function emptyBucket(): TokenBucket {
+  return { promptTokens: 0, completionTokens: 0, totalTokens: 0, requests: 0 };
+}
+
+function addToBucket(bucket: TokenBucket, entry: LlmCallEntry): void {
+  bucket.promptTokens += entry.promptTokens;
+  bucket.completionTokens += entry.completionTokens;
+  bucket.totalTokens += entry.totalTokens;
+  bucket.requests++;
+}
+
+export class DefaultRequestLogger implements IRequestLogger {
+  private initLlmCalls: LlmCallEntry[] = [];
+  private requestLlmCalls: LlmCallEntry[] = [];
+  private ragQueryEntries: RagQueryEntry[] = [];
+  private toolCallEntries: ToolCallEntry[] = [];
+  private requestStartMs = 0;
+  private requestDurationMs = 0;
+
+  startRequest(): void {
+    this.requestLlmCalls = [];
+    this.ragQueryEntries = [];
+    this.toolCallEntries = [];
+    this.requestDurationMs = 0;
+    this.requestStartMs = Date.now();
+  }
+
+  endRequest(): void {
+    this.requestDurationMs = this.requestStartMs
+      ? Date.now() - this.requestStartMs
+      : 0;
+  }
+
+  logLlmCall(entry: LlmCallEntry): void {
+    if (entry.scope === 'initialization') {
+      this.initLlmCalls.push(entry);
+    } else {
+      this.requestLlmCalls.push(entry);
+    }
+  }
+
+  logRagQuery(entry: RagQueryEntry): void {
+    this.ragQueryEntries.push(entry);
+  }
+
+  logToolCall(entry: ToolCallEntry): void {
+    this.toolCallEntries.push(entry);
+  }
+
+  getSummary(): RequestSummary {
+    const byModel: Record<string, TokenBucket> = {};
+    const byComponent: Record<string, TokenBucket> = {};
+    const byCategory: Record<string, TokenBucket> = {};
+
+    const allCalls = [...this.initLlmCalls, ...this.requestLlmCalls];
+
+    for (const call of allCalls) {
+      if (!byModel[call.model]) byModel[call.model] = emptyBucket();
+      addToBucket(byModel[call.model], call);
+
+      if (!byComponent[call.component]) byComponent[call.component] = emptyBucket();
+      addToBucket(byComponent[call.component], call);
+
+      const cat = CATEGORY_MAP[call.component] ?? 'request';
+      if (!byCategory[cat]) byCategory[cat] = emptyBucket();
+      addToBucket(byCategory[cat], call);
+    }
+
+    return {
+      byModel,
+      byComponent,
+      byCategory,
+      ragQueries: this.ragQueryEntries.length,
+      toolCalls: this.toolCallEntries.length,
+      totalDurationMs: this.requestDurationMs,
+    };
+  }
+
+  reset(): void {
+    this.requestLlmCalls = [];
+    this.ragQueryEntries = [];
+    this.toolCallEntries = [];
+    this.requestStartMs = 0;
+    this.requestDurationMs = 0;
+    // NOTE: initLlmCalls is intentionally NOT reset
+  }
+}
+```
+
+- [ ] **Step 2: Update NoopRequestLogger**
+
+In `src/smart-agent/logger/noop-request-logger.ts`, add `byCategory: {}` to `EMPTY_SUMMARY`:
+
+```typescript
+const EMPTY_SUMMARY: RequestSummary = {
+  byModel: {},
+  byComponent: {},
+  byCategory: {},
+  ragQueries: 0,
+  toolCalls: 0,
+  totalDurationMs: 0,
+};
+```
+
+And update `getSummary()`:
+
+```typescript
+getSummary(): RequestSummary {
+  return { ...EMPTY_SUMMARY, byModel: {}, byComponent: {}, byCategory: {} };
+}
+```
+
+- [ ] **Step 3: Run build**
+
+Run: `npm run build`
+Expected: PASS — no type errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/smart-agent/logger/default-request-logger.ts src/smart-agent/logger/noop-request-logger.ts
+git commit -m "feat(#53): split init/request storage in DefaultRequestLogger, add byCategory aggregation"
+```
+
+### Task 3: Write tests for token categorization
+
+**Files:**
+- Create: `src/smart-agent/__tests__/request-logger.test.ts`
+
+- [ ] **Step 1: Write test file**
+
+```typescript
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { DefaultRequestLogger } from '../logger/default-request-logger.js';
+
+describe('DefaultRequestLogger', () => {
+  it('aggregates byComponent and byCategory for request-scoped calls', () => {
+    const logger = new DefaultRequestLogger();
+    logger.startRequest();
+    logger.logLlmCall({
+      component: 'classifier',
+      model: 'gpt-4o',
+      promptTokens: 100,
+      completionTokens: 20,
+      totalTokens: 120,
+      durationMs: 50,
+    });
+    logger.logLlmCall({
+      component: 'tool-loop',
+      model: 'gpt-4o',
+      promptTokens: 500,
+      completionTokens: 100,
+      totalTokens: 600,
+      durationMs: 200,
+    });
+    logger.endRequest();
+
+    const summary = logger.getSummary();
+    assert.equal(summary.byComponent.classifier?.promptTokens, 100);
+    assert.equal(summary.byComponent['tool-loop']?.promptTokens, 500);
+    assert.equal(summary.byCategory.auxiliary?.promptTokens, 100);
+    assert.equal(summary.byCategory.request?.promptTokens, 500);
+    assert.equal(summary.byModel['gpt-4o']?.requests, 2);
+  });
+
+  it('preserves initialization calls across startRequest resets', () => {
+    const logger = new DefaultRequestLogger();
+
+    // Simulate startup embedding
+    logger.logLlmCall({
+      component: 'embedding',
+      model: 'text-embedding-3-small',
+      promptTokens: 1000,
+      completionTokens: 0,
+      totalTokens: 1000,
+      durationMs: 300,
+      estimated: true,
+      scope: 'initialization',
+      detail: 'tools',
+    });
+
+    // First request — startRequest should NOT clear init calls
+    logger.startRequest();
+    logger.logLlmCall({
+      component: 'tool-loop',
+      model: 'gpt-4o',
+      promptTokens: 500,
+      completionTokens: 100,
+      totalTokens: 600,
+      durationMs: 200,
+    });
+    logger.endRequest();
+
+    const summary1 = logger.getSummary();
+    assert.equal(summary1.byCategory.initialization?.totalTokens, 1000);
+    assert.equal(summary1.byCategory.request?.totalTokens, 600);
+    assert.equal(summary1.byComponent.embedding?.requests, 1);
+    assert.equal(summary1.byComponent['tool-loop']?.requests, 1);
+
+    // Second request — init data still present, request data reset
+    logger.startRequest();
+    logger.logLlmCall({
+      component: 'tool-loop',
+      model: 'gpt-4o',
+      promptTokens: 300,
+      completionTokens: 50,
+      totalTokens: 350,
+      durationMs: 100,
+    });
+    logger.endRequest();
+
+    const summary2 = logger.getSummary();
+    assert.equal(summary2.byCategory.initialization?.totalTokens, 1000);
+    assert.equal(summary2.byCategory.request?.totalTokens, 350);
+    assert.equal(summary2.byComponent['tool-loop']?.requests, 1);
+  });
+
+  it('routes runtime embedding to request scope when scope is not initialization', () => {
+    const logger = new DefaultRequestLogger();
+    logger.startRequest();
+    logger.logLlmCall({
+      component: 'embedding',
+      model: 'text-embedding-3-small',
+      promptTokens: 50,
+      completionTokens: 0,
+      totalTokens: 50,
+      durationMs: 10,
+      scope: 'request',
+    });
+    logger.endRequest();
+
+    const summary = logger.getSummary();
+    // embedding component is mapped to 'initialization' category via CATEGORY_MAP,
+    // but this is a runtime call — verify it's still in the summary
+    assert.equal(summary.byComponent.embedding?.totalTokens, 50);
+
+    // After reset, runtime embedding should be cleared
+    logger.startRequest();
+    logger.endRequest();
+    const summary2 = logger.getSummary();
+    assert.equal(summary2.byComponent.embedding, undefined);
+  });
+
+  it('returns empty byCategory when no calls logged', () => {
+    const logger = new DefaultRequestLogger();
+    logger.startRequest();
+    logger.endRequest();
+    const summary = logger.getSummary();
+    assert.deepEqual(summary.byCategory, {});
+    assert.deepEqual(summary.byComponent, {});
+    assert.deepEqual(summary.byModel, {});
+  });
+});
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `npx tsx --test src/smart-agent/__tests__/request-logger.test.ts`
+Expected: All 4 tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/smart-agent/__tests__/request-logger.test.ts
+git commit -m "test(#53): add DefaultRequestLogger tests for byCategory, init/request split, scope routing"
+```
+
+### Task 4: Add embedding token logging in builder
+
+**Files:**
+- Modify: `src/smart-agent/builder.ts`
+
+- [ ] **Step 1: Add embedding token logging to tool vectorization**
+
+In `src/smart-agent/builder.ts`, inside the tool vectorization loop (around line 701-716), after the `upsert` call, add token logging. Replace the existing loop body:
+
+Find this block (approximately lines 701-716):
+```typescript
+              for (let i = 0; i < tools.length; i++) {
+                const t = tools[i];
+                const result = await toolStore.upsert(
+                  `Tool: ${t.name} — ${t.description}`,
+                  { id: `tool:${t.name}` },
+                );
+                if (!result.ok) {
+                  log?.log({
+                    type: 'warning',
+                    traceId: 'builder',
+                    message: `Tool vectorization failed for "${t.name}": ${result.error.message}`,
+                  });
+                }
+                // Throttle embedding requests to avoid rate limits
+                if ((i + 1) % batchSize === 0 && i < tools.length - 1) {
+                  await new Promise((r) => setTimeout(r, batchDelayMs));
+                }
+              }
+```
+
+Replace with:
+
+```typescript
+              for (let i = 0; i < tools.length; i++) {
+                const t = tools[i];
+                const text = `Tool: ${t.name} — ${t.description}`;
+                const embedStart = Date.now();
+                const result = await toolStore.upsert(
+                  text,
+                  { id: `tool:${t.name}` },
+                );
+                if (!result.ok) {
+                  log?.log({
+                    type: 'warning',
+                    traceId: 'builder',
+                    message: `Tool vectorization failed for "${t.name}": ${result.error.message}`,
+                  });
+                } else {
+                  requestLogger.logLlmCall({
+                    component: 'embedding',
+                    model: 'embedder',
+                    promptTokens: Math.ceil(text.length / 4),
+                    completionTokens: 0,
+                    totalTokens: Math.ceil(text.length / 4),
+                    durationMs: Date.now() - embedStart,
+                    estimated: true,
+                    scope: 'initialization',
+                    detail: 'tools',
+                  });
+                }
+                // Throttle embedding requests to avoid rate limits
+                if ((i + 1) % batchSize === 0 && i < tools.length - 1) {
+                  await new Promise((r) => setTimeout(r, batchDelayMs));
+                }
+              }
+```
+
+- [ ] **Step 2: Add embedding token logging to skill vectorization**
+
+In the skill vectorization block (around lines 837-849), replace:
+
+```typescript
+          const result = await skillStore.upsert(
+            `Skill: ${s.name}\n${s.description}`,
+            {
+              id: `skill:${s.name}`,
+            },
+          );
+```
+
+With:
+
+```typescript
+          const text = `Skill: ${s.name}\n${s.description}`;
+          const embedStart = Date.now();
+          const result = await skillStore.upsert(
+            text,
+            {
+              id: `skill:${s.name}`,
+            },
+          );
+          if (result.ok) {
+            requestLogger.logLlmCall({
+              component: 'embedding',
+              model: 'embedder',
+              promptTokens: Math.ceil(text.length / 4),
+              completionTokens: 0,
+              totalTokens: Math.ceil(text.length / 4),
+              durationMs: Date.now() - embedStart,
+              estimated: true,
+              scope: 'initialization',
+              detail: 'skills',
+            });
+          }
+```
+
+- [ ] **Step 3: Run build**
+
+Run: `npm run build`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/smart-agent/builder.ts
+git commit -m "feat(#53): log estimated embedding tokens during tool/skill vectorization"
+```
+
+### Task 5: Add byCategory to session log output
+
+**Files:**
+- Modify: `src/smart-agent/pipeline/handlers/tool-loop.ts`
+
+- [ ] **Step 1: Add byCategory to session log step**
+
+In `tool-loop.ts` around line 443-445, the session logger step already includes `byComponent` and `byModel`. Add `byCategory`:
+
+Find:
+```typescript
+        const summary = ctx.requestLogger.getSummary();
+        ctx.options?.sessionLogger?.logStep('final_response', {
+          content,
+          usage,
+          byComponent: summary.byComponent,
+          byModel: summary.byModel,
+        });
+```
+
+Replace with:
+```typescript
+        const summary = ctx.requestLogger.getSummary();
+        ctx.options?.sessionLogger?.logStep('final_response', {
+          content,
+          usage,
+          byComponent: summary.byComponent,
+          byModel: summary.byModel,
+          byCategory: summary.byCategory,
+        });
+```
+
+- [ ] **Step 2: Add byCategory to usage chunk (lines ~470-471)**
+
+Find:
+```typescript
+              models: ctx.requestLogger.getSummary().byModel,
+              components: ctx.requestLogger.getSummary().byComponent,
+```
+
+Replace with:
+```typescript
+              models: ctx.requestLogger.getSummary().byModel,
+              components: ctx.requestLogger.getSummary().byComponent,
+              categories: ctx.requestLogger.getSummary().byCategory,
+```
+
+- [ ] **Step 3: Run build and tests**
+
+Run: `npm run build`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/smart-agent/pipeline/handlers/tool-loop.ts
+git commit -m "feat(#53): expose byCategory in session logs and usage chunk"
+```
+
+---
+
+## Phase 2: Batch Embedding (#52)
+
+### Task 6: Add IEmbedderBatch and IPrecomputedVectorRag interfaces
+
+**Files:**
+- Modify: `src/smart-agent/interfaces/rag.ts`
+
+- [ ] **Step 1: Add new interfaces and type guards**
+
+Append to the end of `src/smart-agent/interfaces/rag.ts`:
+
+```typescript
+
+export interface IEmbedderBatch extends IEmbedder {
+  embedBatch(texts: string[], options?: CallOptions): Promise<number[][]>;
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: runtime type check
+export function isBatchEmbedder(e: IEmbedder): e is IEmbedderBatch {
+  return 'embedBatch' in e && typeof (e as any).embedBatch === 'function';
+}
+
+export interface IPrecomputedVectorRag extends IRag {
+  upsertPrecomputed(
+    text: string,
+    vector: number[],
+    metadata: RagMetadata,
+    options?: CallOptions,
+  ): Promise<Result<void, RagError>>;
+}
+
+export function supportsPrecomputed(rag: IRag): rag is IPrecomputedVectorRag {
+  return 'upsertPrecomputed' in rag;
+}
+```
+
+- [ ] **Step 2: Run build**
+
+Run: `npm run build`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/smart-agent/interfaces/rag.ts
+git commit -m "feat(#52): add IEmbedderBatch, IPrecomputedVectorRag interfaces with type guards"
+```
+
+### Task 7: Add embedBatch to OpenAiEmbedder
+
+**Files:**
+- Modify: `src/smart-agent/rag/openai-embedder.ts`
+
+- [ ] **Step 1: Update class to implement IEmbedderBatch**
+
+Change the import and class declaration:
+
+```typescript
+import type { IEmbedderBatch } from '../interfaces/rag.js';
+import { type CallOptions, RagError } from '../interfaces/types.js';
+```
+
+Change `implements IEmbedder` to `implements IEmbedderBatch`:
+
+```typescript
+export class OpenAiEmbedder implements IEmbedderBatch {
+```
+
+- [ ] **Step 2: Add embedBatch method after embed()**
+
+```typescript
+  async embedBatch(
+    texts: string[],
+    options?: CallOptions,
+  ): Promise<number[][]> {
+    if (texts.length === 0) return [];
+
+    const chunkSize = 100;
+    const results: number[][] = new Array(texts.length);
+
+    for (let start = 0; start < texts.length; start += chunkSize) {
+      const chunk = texts.slice(start, start + chunkSize);
+      const url = `${this.baseURL}/embeddings`;
+      let lastError: Error | undefined;
+      const maxRetries = 3;
+
+      for (let attempt = 0; attempt < maxRetries; attempt++) {
+        try {
+          const timeoutSignal = AbortSignal.timeout(this.timeoutMs);
+          const signal = options?.signal
+            ? AbortSignal.any([options.signal, timeoutSignal])
+            : timeoutSignal;
+
+          const res = await fetch(url, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${this.apiKey}`,
+            },
+            body: JSON.stringify({ model: this.model, input: chunk }),
+            signal,
+          });
+
+          if (!res.ok) {
+            const errorText = await res.text();
+            throw new RagError(
+              `OpenAI batch embed error: HTTP ${res.status} - ${errorText}`,
+              'EMBED_ERROR',
+            );
+          }
+
+          const json = (await res.json()) as {
+            data: Array<{ embedding: number[]; index: number }>;
+          };
+          const sorted = json.data.sort((a, b) => a.index - b.index);
+          for (let i = 0; i < sorted.length; i++) {
+            results[start + i] = sorted[i].embedding;
+          }
+          lastError = undefined;
+          break;
+        } catch (err: unknown) {
+          lastError = err instanceof Error ? err : new Error(String(err));
+          if (err instanceof Error && err.name === 'AbortError') throw err;
+          const delay = 500 * 2 ** attempt;
+          await new Promise((resolve) => setTimeout(resolve, delay));
+        }
+      }
+
+      if (lastError) {
+        throw lastError;
+      }
+    }
+
+    return results;
+  }
+```
+
+- [ ] **Step 3: Run build**
+
+Run: `npm run build`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/smart-agent/rag/openai-embedder.ts
+git commit -m "feat(#52): add embedBatch() to OpenAiEmbedder with chunking and retry"
+```
+
+### Task 8: Add embedBatch to OllamaEmbedder
+
+**Files:**
+- Modify: `src/smart-agent/rag/ollama-rag.ts`
+
+- [ ] **Step 1: Update imports and class declaration**
+
+```typescript
+import type { IEmbedderBatch } from '../interfaces/rag.js';
+```
+
+Change `implements IEmbedder` to `implements IEmbedderBatch`:
+
+```typescript
+export class OllamaEmbedder implements IEmbedderBatch {
+```
+
+- [ ] **Step 2: Add embedBatch method after embed()**
+
+```typescript
+  async embedBatch(
+    texts: string[],
+    options?: CallOptions,
+  ): Promise<number[][]> {
+    if (texts.length === 0) return [];
+
+    const url = `${this.ollamaUrl}/api/embed`;
+    let lastError: Error | undefined;
+    const maxRetries = 3;
+
+    for (let attempt = 0; attempt < maxRetries; attempt++) {
+      try {
+        const timeoutSignal = AbortSignal.timeout(this.timeoutMs);
+        const signal = options?.signal
+          ? AbortSignal.any([options.signal, timeoutSignal])
+          : timeoutSignal;
+
+        const res = await fetch(url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ model: this.model, input: texts }),
+          signal,
+        });
+
+        if (!res.ok) {
+          const errorText = await res.text();
+          throw new RagError(
+            `Ollama batch embed error: HTTP ${res.status} - ${errorText}`,
+            'EMBED_ERROR',
+          );
+        }
+
+        const json = (await res.json()) as { embeddings: number[][] };
+        return json.embeddings;
+      } catch (err: unknown) {
+        lastError = err instanceof Error ? err : new Error(String(err));
+        if (err instanceof Error && err.name === 'AbortError') throw err;
+        const delay = 500 * 2 ** attempt;
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+    }
+
+    throw (
+      lastError ||
+      new RagError('Ollama batch embed failed after retries', 'EMBED_ERROR')
+    );
+  }
+```
+
+- [ ] **Step 3: Run build**
+
+Run: `npm run build`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/smart-agent/rag/ollama-rag.ts
+git commit -m "feat(#52): add embedBatch() to OllamaEmbedder using /api/embed endpoint"
+```
+
+### Task 9: Add embedBatch to SapAiCoreEmbedder
+
+**Files:**
+- Modify: `src/smart-agent/rag/sap-ai-core-embedder.ts`
+
+- [ ] **Step 1: Update imports and class declaration**
+
+```typescript
+import type { IEmbedderBatch } from '../interfaces/rag.js';
+```
+
+Change `implements IEmbedder` to `implements IEmbedderBatch`:
+
+```typescript
+export class SapAiCoreEmbedder implements IEmbedderBatch {
+```
+
+- [ ] **Step 2: Add embedBatch method after embed()**
+
+```typescript
+  async embedBatch(
+    texts: string[],
+    _options?: CallOptions,
+  ): Promise<number[][]> {
+    if (texts.length === 0) return [];
+
+    const { OrchestrationEmbeddingClient } = await import(
+      '@sap-ai-sdk/orchestration'
+    );
+
+    const modelName = this
+      .model as unknown as import('@sap-ai-sdk/orchestration').EmbeddingModel;
+    const client = new OrchestrationEmbeddingClient(
+      { embeddings: { model: { name: modelName } } },
+      this.resourceGroup ? { resourceGroup: this.resourceGroup } : undefined,
+    );
+
+    const response = await client.embed({ input: texts });
+    const embeddings = response.getEmbeddings();
+
+    if (!embeddings || embeddings.length === 0) {
+      throw new Error('No embeddings returned from SAP AI Core batch');
+    }
+
+    const sorted = [...embeddings].sort((a, b) => a.index - b.index);
+    return sorted.map((e) => {
+      if (typeof e.embedding === 'string') {
+        const buffer = Buffer.from(e.embedding, 'base64');
+        const float32 = new Float32Array(
+          buffer.buffer,
+          buffer.byteOffset,
+          buffer.length / 4,
+        );
+        return Array.from(float32);
+      }
+      return e.embedding;
+    });
+  }
+```
+
+- [ ] **Step 3: Run build**
+
+Run: `npm run build`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/smart-agent/rag/sap-ai-core-embedder.ts
+git commit -m "feat(#52): add embedBatch() to SapAiCoreEmbedder"
+```
+
+### Task 10: Update CircuitBreakerEmbedder to proxy embedBatch
+
+**Files:**
+- Modify: `src/smart-agent/resilience/circuit-breaker-embedder.ts`
+
+- [ ] **Step 1: Update to conditionally implement IEmbedderBatch**
+
+```typescript
+import type { IEmbedder, IEmbedderBatch } from '../interfaces/rag.js';
+import { isBatchEmbedder } from '../interfaces/rag.js';
+import type { CallOptions } from '../interfaces/types.js';
+import { RagError } from '../interfaces/types.js';
+import type { CircuitBreaker } from './circuit-breaker.js';
+
+export class CircuitBreakerEmbedder implements IEmbedder {
+  constructor(
+    private readonly inner: IEmbedder,
+    readonly breaker: CircuitBreaker,
+  ) {}
+
+  async embed(text: string, options?: CallOptions): Promise<number[]> {
+    if (!this.breaker.isCallPermitted) {
+      throw new RagError('Embedder circuit breaker is open', 'CIRCUIT_OPEN');
+    }
+    try {
+      const result = await this.inner.embed(text, options);
+      this.breaker.recordSuccess();
+      return result;
+    } catch (err) {
+      this.breaker.recordFailure();
+      throw err;
+    }
+  }
+
+  async embedBatch(
+    texts: string[],
+    options?: CallOptions,
+  ): Promise<number[][]> {
+    if (!this.breaker.isCallPermitted) {
+      throw new RagError('Embedder circuit breaker is open', 'CIRCUIT_OPEN');
+    }
+    if (!isBatchEmbedder(this.inner)) {
+      throw new RagError(
+        'Inner embedder does not support batch embedding',
+        'EMBED_ERROR',
+      );
+    }
+    try {
+      const result = await this.inner.embedBatch(texts, options);
+      this.breaker.recordSuccess();
+      return result;
+    } catch (err) {
+      this.breaker.recordFailure();
+      throw err;
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Run build**
+
+Run: `npm run build`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/smart-agent/resilience/circuit-breaker-embedder.ts
+git commit -m "feat(#52): proxy embedBatch through CircuitBreakerEmbedder"
+```
+
+### Task 11: Add upsertPrecomputed to VectorRag with shared write path
+
+**Files:**
+- Modify: `src/smart-agent/rag/vector-rag.ts`
+
+- [ ] **Step 1: Update imports and class declaration**
+
+Add `IPrecomputedVectorRag` to the import from `rag.ts`:
+
+```typescript
+import type { IEmbedder, IPrecomputedVectorRag, IRag } from '../interfaces/rag.js';
+```
+
+Change `implements IRag` to `implements IPrecomputedVectorRag`:
+
+```typescript
+export class VectorRag implements IPrecomputedVectorRag {
+```
+
+- [ ] **Step 2: Extract upsertKnownVector helper**
+
+Add this private method before the `upsert()` method:
+
+```typescript
+  private upsertKnownVector(
+    text: string,
+    vector: number[],
+    metadata: RagMetadata,
+  ): Result<void, RagError> {
+    const newTokens = this.tokenize(text);
+
+    // Idempotent upsert: if metadata.id matches, replace in-place
+    if (metadata.id) {
+      for (let i = 0; i < this.records.length; i++) {
+        if (this.records[i].metadata.id === metadata.id) {
+          const oldTokens = this.tokenize(this.records[i].text);
+          this.records[i].text = text;
+          this.records[i].vector = vector;
+          this.records[i].metadata = {
+            ...this.records[i].metadata,
+            ...metadata,
+          };
+          this.index.update(i, oldTokens, newTokens);
+          return { ok: true, value: undefined };
+        }
+      }
+    }
+
+    for (let i = 0; i < this.records.length; i++) {
+      const rec = this.records[i];
+      if (this.cosine(rec.vector, vector) >= this.dedupThreshold) {
+        const oldTokens = this.tokenize(rec.text);
+        rec.text = text;
+        rec.vector = vector;
+        rec.metadata = { ...rec.metadata, ...metadata };
+        this.index.update(i, oldTokens, newTokens);
+        return { ok: true, value: undefined };
+      }
+    }
+
+    const docIdx = this.records.length;
+    this.records.push({ text, vector, metadata });
+    this.index.add(docIdx, newTokens);
+    return { ok: true, value: undefined };
+  }
+```
+
+- [ ] **Step 3: Refactor upsert to delegate**
+
+Replace the `try` block inside `upsert()`:
+
+```typescript
+    try {
+      const vector = await this.embedder.embed(text, options);
+      return this.upsertKnownVector(text, vector, metadata);
+    } catch (err) {
+```
+
+- [ ] **Step 4: Add upsertPrecomputed method**
+
+After `upsert()`:
+
+```typescript
+  async upsertPrecomputed(
+    text: string,
+    vector: number[],
+    metadata: RagMetadata,
+    _options?: CallOptions,
+  ): Promise<Result<void, RagError>> {
+    try {
+      return this.upsertKnownVector(text, vector, metadata);
+    } catch (err) {
+      if (err instanceof RagError) return { ok: false, error: err };
+      return { ok: false, error: new RagError(String(err), 'UPSERT_ERROR') };
+    }
+  }
+```
+
+- [ ] **Step 5: Run build**
+
+Run: `npm run build`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/smart-agent/rag/vector-rag.ts
+git commit -m "feat(#52): extract upsertKnownVector, add upsertPrecomputed to VectorRag"
+```
+
+### Task 12: Add upsertPrecomputed to QdrantRag
+
+**Files:**
+- Modify: `src/smart-agent/rag/qdrant-rag.ts`
+
+- [ ] **Step 1: Update imports and class declaration**
+
+```typescript
+import type { IEmbedder, IPrecomputedVectorRag, IRag } from '../interfaces/rag.js';
+```
+
+Change `implements IRag` to `implements IPrecomputedVectorRag`:
+
+```typescript
+export class QdrantRag implements IPrecomputedVectorRag {
+```
+
+- [ ] **Step 2: Extract shared write helper**
+
+Add a private method:
+
+```typescript
+  private async upsertKnownVector(
+    text: string,
+    vector: number[],
+    metadata: RagMetadata,
+    options?: CallOptions,
+  ): Promise<Result<void, RagError>> {
+    try {
+      await this._ensureCollection(vector.length, options?.signal);
+
+      const pointId = metadata?.id
+        ? await deterministicUUID(metadata.id)
+        : crypto.randomUUID();
+      const payload: Record<string, unknown> = {
+        text,
+        ...metadata,
+      };
+
+      const res = await this._fetch(
+        `/collections/${this.collectionName}/points`,
+        {
+          method: 'PUT',
+          body: JSON.stringify({
+            points: [{ id: pointId, vector, payload }],
+          }),
+        },
+        options?.signal,
+      );
+
+      if (!res.ok) {
+        const body = await res.text();
+        return {
+          ok: false,
+          error: new RagError(`Qdrant upsert failed: ${body}`, 'UPSERT_ERROR'),
+        };
+      }
+      return { ok: true, value: undefined };
+    } catch (err) {
+      if (err instanceof RagError) return { ok: false, error: err };
+      return { ok: false, error: new RagError(String(err), 'UPSERT_ERROR') };
+    }
+  }
+```
+
+- [ ] **Step 3: Refactor upsert to delegate**
+
+Replace the body of `upsert()`:
+
+```typescript
+  async upsert(
+    text: string,
+    metadata: RagMetadata,
+    options?: CallOptions,
+  ): Promise<Result<void, RagError>> {
+    if (options?.signal?.aborted) {
+      return { ok: false, error: new RagError('Aborted', 'ABORTED') };
+    }
+    try {
+      const vector = await this.embedder.embed(text, options);
+      return this.upsertKnownVector(text, vector, metadata, options);
+    } catch (err) {
+      if (err instanceof RagError) return { ok: false, error: err };
+      return { ok: false, error: new RagError(String(err), 'UPSERT_ERROR') };
+    }
+  }
+```
+
+- [ ] **Step 4: Add upsertPrecomputed method**
+
+```typescript
+  async upsertPrecomputed(
+    text: string,
+    vector: number[],
+    metadata: RagMetadata,
+    options?: CallOptions,
+  ): Promise<Result<void, RagError>> {
+    if (options?.signal?.aborted) {
+      return { ok: false, error: new RagError('Aborted', 'ABORTED') };
+    }
+    return this.upsertKnownVector(text, vector, metadata, options);
+  }
+```
+
+- [ ] **Step 5: Run build**
+
+Run: `npm run build`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/smart-agent/rag/qdrant-rag.ts
+git commit -m "feat(#52): extract upsertKnownVector, add upsertPrecomputed to QdrantRag"
+```
+
+### Task 13: Update FallbackRag to proxy upsertPrecomputed
+
+**Files:**
+- Modify: `src/smart-agent/resilience/fallback-rag.ts`
+
+- [ ] **Step 1: Add upsertPrecomputed proxy**
+
+Add import:
+```typescript
+import { supportsPrecomputed } from '../interfaces/rag.js';
+```
+
+Add method to `FallbackRag`:
+
+```typescript
+  async upsertPrecomputed(
+    text: string,
+    vector: number[],
+    metadata: RagMetadata,
+    options?: CallOptions,
+  ): Promise<Result<void, RagError>> {
+    const primaryResult = supportsPrecomputed(this.primary)
+      ? await this.primary.upsertPrecomputed(text, vector, metadata, options)
+      : await this.primary.upsert(text, metadata, options);
+
+    // Best-effort write to fallback
+    if (supportsPrecomputed(this.fallback)) {
+      this.fallback.upsertPrecomputed(text, vector, metadata, options).catch(() => {});
+    } else {
+      this.fallback.upsert(text, metadata, options).catch(() => {});
+    }
+
+    return primaryResult;
+  }
+```
+
+- [ ] **Step 2: Run build**
+
+Run: `npm run build`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/smart-agent/resilience/fallback-rag.ts
+git commit -m "feat(#52): proxy upsertPrecomputed through FallbackRag"
+```
+
+### Task 14: Switch builder to batch embedding
+
+**Files:**
+- Modify: `src/smart-agent/builder.ts`
+
+- [ ] **Step 1: Add imports**
+
+At the top of builder.ts, add to the imports from `interfaces/rag.js`:
+
+```typescript
+import {
+  isBatchEmbedder,
+  supportsPrecomputed,
+} from './interfaces/rag.js';
+```
+
+- [ ] **Step 2: Replace tool vectorization with batch path**
+
+Replace the tool vectorization block (the loop from Task 4) with:
+
+```typescript
+            const toolsResult = await adapter.listTools();
+            if (toolsResult.ok) {
+              const tools = toolsResult.value;
+              const embedder = toolStore instanceof VectorRag || toolStore instanceof QdrantRag
+                ? (toolStore as any).embedder as IEmbedder | undefined
+                : undefined;
+
+              if (embedder && isBatchEmbedder(embedder) && supportsPrecomputed(toolStore)) {
+                // Batch path: single HTTP call for all tools
+                const texts = tools.map((t) => `Tool: ${t.name} — ${t.description}`);
+                const batchStart = Date.now();
+                try {
+                  const vectors = await embedder.embedBatch(texts);
+                  const batchDuration = Date.now() - batchStart;
+                  for (let i = 0; i < tools.length; i++) {
+                    const result = await toolStore.upsertPrecomputed(
+                      texts[i],
+                      vectors[i],
+                      { id: `tool:${tools[i].name}` },
+                    );
+                    if (!result.ok) {
+                      log?.log({
+                        type: 'warning',
+                        traceId: 'builder',
+                        message: `Tool vectorization failed for "${tools[i].name}": ${result.error.message}`,
+                      });
+                    }
+                  }
+                  const totalEstTokens = texts.reduce(
+                    (sum, t) => sum + Math.ceil(t.length / 4),
+                    0,
+                  );
+                  requestLogger.logLlmCall({
+                    component: 'embedding',
+                    model: 'embedder',
+                    promptTokens: totalEstTokens,
+                    completionTokens: 0,
+                    totalTokens: totalEstTokens,
+                    durationMs: batchDuration,
+                    estimated: true,
+                    scope: 'initialization',
+                    detail: 'tools',
+                  });
+                } catch (err) {
+                  log?.log({
+                    type: 'warning',
+                    traceId: 'builder',
+                    message: `Batch embedding failed, falling back to sequential: ${String(err)}`,
+                  });
+                  // Fall through to sequential path
+                  await this.vectorizeToolsSequential(
+                    tools,
+                    toolStore,
+                    requestLogger,
+                    log,
+                  );
+                }
+              } else {
+                await this.vectorizeToolsSequential(
+                  tools,
+                  toolStore,
+                  requestLogger,
+                  log,
+                );
+              }
+            }
+```
+
+- [ ] **Step 3: Extract sequential vectorization helper**
+
+Add a private method to the builder class:
+
+```typescript
+  private async vectorizeToolsSequential(
+    tools: McpTool[],
+    store: IRag,
+    requestLogger: IRequestLogger,
+    log: ILogger | undefined,
+  ): Promise<void> {
+    const batchSize = 5;
+    const batchDelayMs = 500;
+    for (let i = 0; i < tools.length; i++) {
+      const t = tools[i];
+      const text = `Tool: ${t.name} — ${t.description}`;
+      const embedStart = Date.now();
+      const result = await store.upsert(text, { id: `tool:${t.name}` });
+      if (!result.ok) {
+        log?.log({
+          type: 'warning',
+          traceId: 'builder',
+          message: `Tool vectorization failed for "${t.name}": ${result.error.message}`,
+        });
+      } else {
+        requestLogger.logLlmCall({
+          component: 'embedding',
+          model: 'embedder',
+          promptTokens: Math.ceil(text.length / 4),
+          completionTokens: 0,
+          totalTokens: Math.ceil(text.length / 4),
+          durationMs: Date.now() - embedStart,
+          estimated: true,
+          scope: 'initialization',
+          detail: 'tools',
+        });
+      }
+      if ((i + 1) % batchSize === 0 && i < tools.length - 1) {
+        await new Promise((r) => setTimeout(r, batchDelayMs));
+      }
+    }
+  }
+```
+
+Note: you'll need to add the necessary type imports (`McpTool`, `IRag`, `IRequestLogger`, `ILogger`) if not already imported.
+
+- [ ] **Step 4: Run build**
+
+Run: `npm run build`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/smart-agent/builder.ts
+git commit -m "feat(#52): batch embedding for tool vectorization with sequential fallback"
+```
+
+### Task 15: Export new types from index.ts
+
+**Files:**
+- Modify: `src/index.ts`
+
+- [ ] **Step 1: Add exports**
+
+Find the existing RAG-related exports in index.ts and add:
+
+```typescript
+export type {
+  IEmbedderBatch,
+  IPrecomputedVectorRag,
+} from './smart-agent/interfaces/rag.js';
+export {
+  isBatchEmbedder,
+  supportsPrecomputed,
+} from './smart-agent/interfaces/rag.js';
+export type {
+  TokenBucket,
+  TokenCategory,
+} from './smart-agent/interfaces/request-logger.js';
+```
+
+- [ ] **Step 2: Run build**
+
+Run: `npm run build`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/index.ts
+git commit -m "feat(#52): export IEmbedderBatch, IPrecomputedVectorRag, TokenBucket, TokenCategory"
+```
+
+---
+
+## Phase 3: SAP AI Core Direct Provider (#54)
+
+### Task 16: Create SapAiCoreDirectProvider
+
+**Files:**
+- Create: `src/llm-providers/sap-ai-core-direct.ts`
+
+- [ ] **Step 1: Write the provider**
+
+```typescript
+/**
+ * SAP AI Core Direct LLM Provider
+ *
+ * Bypasses OrchestrationClient and sends OpenAI-compatible HTTP requests
+ * directly to SAP AI Core deployment endpoints.
+ * Token counts are accurate (no orchestration overhead).
+ */
+
+import https from 'node:https';
+import type { IModelInfo } from '../smart-agent/interfaces/model-provider.js';
+import type { LLMProviderConfig, LLMResponse, Message } from '../types.js';
+import { BaseLLMProvider } from './base.js';
+
+export interface SapAiCoreDirectConfig extends LLMProviderConfig {
+  model?: string;
+  temperature?: number;
+  maxTokens?: number;
+  resourceGroup?: string;
+}
+
+export class SapAiCoreDirectProvider extends BaseLLMProvider<SapAiCoreDirectConfig> {
+  readonly model: string;
+  private readonly resourceGroup: string;
+  private deploymentUrl: string | null = null;
+  private readonly httpsAgent: https.Agent;
+  private modelOverride?: string;
+
+  setModelOverride(model?: string): void {
+    this.modelOverride = model;
+  }
+
+  constructor(config: SapAiCoreDirectConfig) {
+    super(config);
+    // Skip validateConfig() — SAP SDK handles auth via AICORE_SERVICE_KEY env var
+    this.model = config.model || 'gpt-4o';
+    this.resourceGroup = config.resourceGroup || 'default';
+    this.httpsAgent = new https.Agent({
+      keepAlive: true,
+      timeout: 60_000,
+    });
+  }
+
+  private async resolveUrl(): Promise<string> {
+    if (this.deploymentUrl) return this.deploymentUrl;
+
+    const { resolveDeploymentUrl } = await import('@sap-ai-sdk/ai-api');
+    const url = await resolveDeploymentUrl({
+      scenarioId: 'foundation-models',
+      model: { modelName: this.model },
+      resourceGroup: this.resourceGroup,
+    });
+    this.deploymentUrl = url;
+    return url;
+  }
+
+  private async fetchWithAuth(
+    url: string,
+    init: RequestInit & { agent?: https.Agent },
+  ): Promise<Response> {
+    // @sap-ai-sdk/core sets up auth context globally.
+    // resolveDeploymentUrl() call above ensures auth is initialized.
+    // The deployment URL includes the auth-bearing host.
+    // We use the SDK's internal HTTP client via a manual fetch with the same auth context.
+    const { executeHttpRequest } = await import('@sap-ai-sdk/core');
+    // For direct HTTP, we use native fetch but need to obtain the token
+    // from the SDK's internal resolution.
+    const headers = new Headers(init.headers);
+    if (!headers.has('Content-Type')) {
+      headers.set('Content-Type', 'application/json');
+    }
+
+    return fetch(url, {
+      ...init,
+      headers,
+    });
+  }
+
+  async chat(messages: Message[], tools?: unknown[]): Promise<LLMResponse> {
+    try {
+      const url = await this.resolveUrl();
+      const model = this.modelOverride ?? this.model;
+
+      const body: Record<string, unknown> = {
+        model,
+        messages: this.formatMessages(messages),
+        temperature: this.config.temperature || 0.7,
+        max_tokens: this.config.maxTokens || 16384,
+      };
+      if (tools && tools.length > 0) {
+        body.tools = tools;
+        body.tool_choice = 'auto';
+      }
+
+      const res = await fetch(`${url}/chat/completions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+        // @ts-expect-error Node.js fetch supports agent via dispatcher
+        dispatcher: this.httpsAgent,
+      });
+
+      if (!res.ok) {
+        const errText = await res.text();
+        throw new Error(`HTTP ${res.status}: ${errText}`);
+      }
+
+      const data = (await res.json()) as {
+        choices: Array<{
+          message: { role: string; content: string; tool_calls?: unknown[] };
+          finish_reason: string;
+        }>;
+        usage?: {
+          prompt_tokens: number;
+          completion_tokens: number;
+          total_tokens: number;
+        };
+      };
+
+      const choice = data.choices[0];
+      return {
+        content: choice.message.content || '',
+        finishReason: choice.finish_reason,
+        raw: data,
+      };
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : String(error);
+      throw new Error(`SAP AI Core Direct API error: ${msg}`);
+    } finally {
+      this.modelOverride = undefined;
+    }
+  }
+
+  async *streamChat(
+    messages: Message[],
+    tools?: unknown[],
+  ): AsyncIterable<LLMResponse> {
+    try {
+      const url = await this.resolveUrl();
+      const model = this.modelOverride ?? this.model;
+
+      const body: Record<string, unknown> = {
+        model,
+        messages: this.formatMessages(messages),
+        temperature: this.config.temperature || 0.7,
+        max_tokens: this.config.maxTokens || 16384,
+        stream: true,
+      };
+      if (tools && tools.length > 0) {
+        body.tools = tools;
+        body.tool_choice = 'auto';
+      }
+
+      // Per-request agent to prevent SSE cross-talk
+      const streamAgent = new https.Agent({
+        keepAlive: false,
+        timeout: 120_000,
+      });
+
+      const res = await fetch(`${url}/chat/completions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+        // @ts-expect-error Node.js fetch supports agent via dispatcher
+        dispatcher: streamAgent,
+      });
+
+      if (!res.ok) {
+        const errText = await res.text();
+        throw new Error(`HTTP ${res.status}: ${errText}`);
+      }
+
+      if (!res.body) throw new Error('No response body for streaming');
+
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      for await (const rawChunk of res.body as AsyncIterable<Uint8Array>) {
+        buffer += decoder.decode(rawChunk, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || '';
+
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed || !trimmed.startsWith('data: ')) continue;
+          const payload = trimmed.slice(6);
+          if (payload === '[DONE]') return;
+
+          try {
+            const chunk = JSON.parse(payload) as {
+              choices: Array<{
+                delta: { content?: string; tool_calls?: unknown[] };
+                finish_reason?: string;
+              }>;
+              usage?: {
+                prompt_tokens: number;
+                completion_tokens: number;
+                total_tokens: number;
+              };
+            };
+
+            const delta = chunk.choices[0]?.delta;
+            const usage = chunk.usage;
+
+            yield {
+              content: delta?.content || '',
+              finishReason: chunk.choices[0]?.finish_reason ?? undefined,
+              raw: chunk,
+              ...(usage
+                ? {
+                    usage: {
+                      promptTokens: usage.prompt_tokens || 0,
+                      completionTokens: usage.completion_tokens || 0,
+                      totalTokens: usage.total_tokens || 0,
+                    },
+                  }
+                : {}),
+            };
+          } catch {
+            // Skip malformed chunks
+          }
+        }
+      }
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : String(error);
+      throw new Error(`SAP AI Core Direct streaming error: ${msg}`);
+    } finally {
+      this.modelOverride = undefined;
+    }
+  }
+
+  async getModels(): Promise<IModelInfo[]> {
+    // Day one: return fallback set from configured model
+    return [{ id: this.model }];
+  }
+
+  private formatMessages(
+    messages: Message[],
+  ): Array<Record<string, unknown>> {
+    return messages.map((msg) => {
+      if (
+        msg.role === 'assistant' &&
+        msg.tool_calls &&
+        msg.tool_calls.length > 0
+      ) {
+        return {
+          role: 'assistant',
+          content: msg.content || undefined,
+          tool_calls: msg.tool_calls,
+        };
+      }
+
+      if (msg.role === 'tool' && msg.tool_call_id) {
+        return {
+          role: 'tool',
+          content:
+            typeof msg.content === 'string'
+              ? msg.content
+              : JSON.stringify(msg.content ?? ''),
+          tool_call_id: msg.tool_call_id,
+        };
+      }
+
+      return {
+        role: msg.role,
+        content: msg.content ?? '',
+      };
+    });
+  }
+}
+```
+
+- [ ] **Step 2: Run build**
+
+Run: `npm run build`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/llm-providers/sap-ai-core-direct.ts
+git commit -m "feat(#54): add SapAiCoreDirectProvider bypassing Orchestration overhead"
+```
+
+### Task 17: Register provider in providers.ts
+
+**Files:**
+- Modify: `src/smart-agent/providers.ts`
+
+- [ ] **Step 1: Add import**
+
+```typescript
+import { SapAiCoreDirectProvider } from '../llm-providers/sap-ai-core-direct.js';
+```
+
+- [ ] **Step 2: Add provider type to LlmProviderConfig**
+
+Change the `provider` union:
+
+```typescript
+provider: 'deepseek' | 'openai' | 'anthropic' | 'sap-ai-sdk' | 'sap-ai-core-direct';
+```
+
+- [ ] **Step 3: Add case to makeLlm switch**
+
+Before the `default:` case in `makeLlm()`, add:
+
+```typescript
+    case 'sap-ai-core-direct': {
+      const provider = new SapAiCoreDirectProvider({
+        apiKey: cfg.apiKey,
+        model: cfg.model,
+        temperature,
+        maxTokens,
+        resourceGroup: cfg.resourceGroup,
+      });
+      const agent = new OpenAIAgent({
+        llmProvider: provider,
+        mcpClient: dummyMcp,
+      });
+      return new LlmAdapter(agent, {
+        model: provider.model,
+        getModels: () => provider.getModels(),
+      });
+    }
+```
+
+- [ ] **Step 4: Run build**
+
+Run: `npm run build`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/smart-agent/providers.ts
+git commit -m "feat(#54): register sap-ai-core-direct provider in makeLlm factory"
+```
+
+### Task 18: Export provider from index.ts
+
+**Files:**
+- Modify: `src/index.ts`
+
+- [ ] **Step 1: Add export**
+
+```typescript
+export {
+  type SapAiCoreDirectConfig,
+  SapAiCoreDirectProvider,
+} from './llm-providers/sap-ai-core-direct.js';
+```
+
+- [ ] **Step 2: Run build**
+
+Run: `npm run build`
+Expected: PASS.
+
+- [ ] **Step 3: Run full lint**
+
+Run: `npm run lint:check`
+Expected: PASS (or only pre-existing issues).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/index.ts
+git commit -m "feat(#54): export SapAiCoreDirectProvider from public API"
+```
+
+---
+
+## Phase 4: Final verification
+
+### Task 19: Run all tests and build
+
+- [ ] **Step 1: Full build**
+
+Run: `npm run build`
+Expected: PASS.
+
+- [ ] **Step 2: Run all tests**
+
+Run: `npx tsx --test src/smart-agent/__tests__/*.test.ts src/smart-agent/pipeline/handlers/__tests__/*.test.ts src/smart-agent/history/__tests__/*.test.ts`
+Expected: All tests PASS.
+
+- [ ] **Step 3: Lint**
+
+Run: `npm run lint`
+Expected: PASS.
+
+- [ ] **Step 4: Final commit if lint fixed anything**
+
+```bash
+git add -A
+git commit -m "chore: lint fixes"
+```

--- a/docs/superpowers/specs/2026-04-06-token-tracking-batch-embed-sap-direct-design.md
+++ b/docs/superpowers/specs/2026-04-06-token-tracking-batch-embed-sap-direct-design.md
@@ -6,15 +6,25 @@ Covers GitHub issues: #52, #53, #54
 
 Three related issues around token tracking and performance:
 
-1. **#53** — `byComponent` in session logs is empty `{}`. While the single `DefaultRequestLogger` instance is correctly shared across classifier and tool-loop, the summary lacks a higher-level categorization that separates initialization, auxiliary, and request tokens.
+1. **#53** — `byComponent` in session logs is empty `{}`. Root cause requires explicit diagnostic confirmation before structural changes. Separately, the logger lacks higher-level categorization that separates initialization, auxiliary, and request tokens.
 2. **#52** — 146 sequential `embed()` calls at startup → 146 HTTP requests → ~2.5 min with throttling. All three embedding providers (OpenAI, Ollama, SAP AI Core) support array input natively.
 3. **#54** — SAP AI Core Orchestration Service adds ~14K phantom tokens per request via internal prompt wrapping. A direct inference provider would yield accurate token counts.
 
 ## Design
 
-### 1. Token Categorization (#53)
+### 1. Token Categorization and Logger Diagnostics (#53)
 
-#### New types in `interfaces/request-logger.ts`
+#### Root cause investigation
+
+Before changing the logger model, confirm the actual root cause for empty `byComponent`:
+
+- Confirm whether `logLlmCall()` is executed on all expected paths (classifier, tool-loop, translate, etc.).
+- Confirm whether `startRequest()` / `reset()` clears data too early.
+- Confirm whether the affected observation comes from structured pipeline, legacy agent paths, or `/v1/usage`.
+
+`byCategory` is an observability enhancement. It does not replace root-cause analysis for missing `byComponent` entries.
+
+#### Token categories
 
 ```typescript
 type TokenCategory = 'initialization' | 'auxiliary' | 'request';
@@ -31,35 +41,36 @@ Component-to-category mapping:
 | `helper` | `auxiliary` | History summarization overhead |
 | `embedding` | `initialization` | Tool/skill vectorization at startup |
 
-#### Changes to `RequestSummary`
-
-Add `byCategory` field:
-
-```typescript
-export interface RequestSummary {
-  byModel: Record<string, TokenBucket>;
-  byComponent: Record<string, TokenBucket>;
-  byCategory: Record<TokenCategory, TokenBucket>;  // NEW
-  ragQueries: number;
-  toolCalls: number;
-  totalDurationMs: number;
-}
-```
-
-Where `TokenBucket` is extracted to reduce repetition:
+#### TokenBucket with physical/logical counters
 
 ```typescript
 interface TokenBucket {
   promptTokens: number;
   completionTokens: number;
   totalTokens: number;
-  requests: number;
+  requests: number;   // physical outbound API calls
+  items?: number;     // logical texts processed (relevant for batch embeddings)
 }
 ```
 
-#### Component-to-category mapping in `DefaultRequestLogger`
+For normal LLM calls, `items` remains undefined or equals `1`. For batch embedding, one `request` may cover many `items`.
 
-A static map inside `getSummary()` derives `byCategory` from existing `byComponent` data. No changes to call sites — the mapping is internal to the logger.
+#### RequestSummary changes
+
+```typescript
+export interface RequestSummary {
+  byModel: Record<string, TokenBucket>;
+  byComponent: Record<string, TokenBucket>;
+  byCategory: Record<TokenCategory, TokenBucket>;
+  ragQueries: number;
+  toolCalls: number;
+  totalDurationMs: number;
+}
+```
+
+#### Component-to-category mapping in DefaultRequestLogger
+
+A static map inside `getSummary()` derives `byCategory` from existing `byComponent` data. No changes to call sites.
 
 ```typescript
 const CATEGORY_MAP: Record<LlmComponent, TokenCategory> = {
@@ -72,26 +83,74 @@ const CATEGORY_MAP: Record<LlmComponent, TokenCategory> = {
 };
 ```
 
+#### LlmCallEntry — estimated token flag
+
+```typescript
+interface LlmCallEntry {
+  component: LlmComponent;
+  model: string;
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  durationMs: number;
+  estimated?: boolean;  // true for embedding token estimates
+  scope?: 'initialization' | 'request'; // explicit lifecycle scope
+  detail?: string; // optional finer label, e.g. 'tools' | 'skills'
+}
+```
+
+For embedding entries: `estimated: true`, `completionTokens: 0`, `promptTokens === totalTokens`. This prevents consumers from treating embedding counts as precise billing numbers.
+
 #### Embedding token tracking
 
-Add `'embedding'` to `LlmComponent` type. In `builder.ts` tool vectorization loop, call `requestLogger.logLlmCall()` with `component: 'embedding'` after each embed call (or batch call). Since embedders don't return token counts, estimate from text length: `Math.ceil(text.length / 4)` (standard ~4 chars/token approximation).
+Add `'embedding'` to `LlmComponent` type. In `builder.ts` tool/skill vectorization, call `requestLogger.logLlmCall()` with:
 
-#### Separate initialization tokens from per-request
+- `component: 'embedding'`
+- `scope: 'initialization'`
+- `detail: 'tools' | 'skills'`
+- `estimated: true`
 
-`RequestSummary.byCategory.initialization` accumulates during startup. `startRequest()` must NOT reset initialization entries — only reset `auxiliary` and `request` categories. This requires splitting internal storage:
+Token estimate: `Math.ceil(text.length / 4)` (~4 chars/token approximation).
 
-- `initLlmCalls: LlmCallEntry[]` — never reset
-- `requestLlmCalls: LlmCallEntry[]` — reset on `startRequest()`
+#### Initialization scope boundaries
 
-`getSummary()` merges both arrays for aggregation.
+What counts as `initialization`:
+- Tool vectorization at builder startup.
+- Skill vectorization at builder startup.
 
-#### Exclude embedder tokens from client-facing usage
+What is excluded:
+- Health checks and warmups.
+- Lazy first-use embedding during requests (these are `request`-scoped).
 
-In `tool-loop.ts` final response (line 463-474), the `usage` object sent to clients should only include `request` + `auxiliary` categories. `initialization` is logged to session log but excluded from the OpenAI-protocol `usage` field.
+Tools vs skills are distinguished through `detail` metadata on `LlmCallEntry` (for example `detail: 'tools'` and `detail: 'skills'`), not separate top-level categories.
+
+#### Separate initialization from per-request storage
+
+`DefaultRequestLogger` splits internal storage:
+
+- `initLlmCalls: LlmCallEntry[]` — never reset by `startRequest()`.
+- `requestLlmCalls: LlmCallEntry[]` — reset on `startRequest()`.
+
+`logLlmCall()` routes based on explicit `scope`:
+
+- `scope: 'initialization'` → `initLlmCalls`
+- `scope: 'request'` or undefined → `requestLlmCalls`
+
+This avoids overloading `component === 'embedding'` for two different lifecycles. Runtime embedding triggered during request handling remains request-scoped.
+
+#### Client-facing usage — semantics unchanged
+
+OpenAI-protocol response `usage` continues to represent only the current request's generation cost. It is sourced from actual request-time stream chunks, not derived from `RequestSummary`.
+
+- `byCategory` is exposed only in diagnostics / session logs / `/v1/usage`.
+- Initialization token estimates are observability-only, never included in client `usage`.
+- `/v1/usage` is treated as diagnostics-oriented and may include lifecycle-level initialization metrics if clearly labeled.
+
+Token metrics are scoped per agent instance (created in builder, lives as long as SmartAgent).
 
 ### 2. Batch Embedding (#52)
 
-#### New interface in `interfaces/rag.ts`
+#### IEmbedderBatch interface
 
 ```typescript
 export interface IEmbedderBatch extends IEmbedder {
@@ -99,7 +158,7 @@ export interface IEmbedderBatch extends IEmbedder {
 }
 ```
 
-`IEmbedderBatch` extends `IEmbedder` — every batch embedder is also a single embedder. This preserves backward compatibility: existing code using `IEmbedder` works unchanged.
+Extends `IEmbedder` — every batch embedder is also a single embedder. Backward compatible.
 
 #### Type guard
 
@@ -112,60 +171,118 @@ export function isBatchEmbedder(e: IEmbedder): e is IEmbedderBatch {
 #### Implementations
 
 **OpenAiEmbedder** — add `embedBatch()`:
-- POST `{ model, input: texts[] }` → response `{ data: [{ embedding }] }` sorted by `index`
-- Same retry logic as `embed()`
-- Chunk into batches of 100 (OpenAI limit) if `texts.length > 100`
+- POST `{ model, input: texts[] }` → response `{ data: [{ embedding, index }] }` sorted by `index`.
+- Same retry logic as `embed()`.
+- Configurable chunk size (default conservative value). Chunks processed sequentially.
 
 **OllamaEmbedder** — add `embedBatch()`:
-- Ollama `/api/embed` endpoint accepts `{ model, input: string[] }` → `{ embeddings: number[][] }`
-- Use `/api/embed` (not `/api/embeddings` which is single-only)
+- Ollama `/api/embed` endpoint accepts `{ model, input: string[] }` → `{ embeddings: number[][] }`.
+- Use `/api/embed` (not `/api/embeddings` which is single-only).
+- Fallback to smaller chunks on 413/timeout.
 
 **SapAiCoreEmbedder** — add `embedBatch()`:
-- `OrchestrationEmbeddingClient.embed({ input: texts[] })` → `EmbeddingData[]` sorted by `index`
+- `OrchestrationEmbeddingClient.embed({ input: texts[] })` → `EmbeddingData[]` sorted by `index`.
+- Configurable chunk size. Fallback to single-item mode if batch input fails.
 
 **CircuitBreakerEmbedder** — proxy `embedBatch()` if inner supports it.
 
+#### Batch sizing and fallback
+
+Configuration:
+
+```yaml
+rag:
+  embeddingBatchSize: 100
+  embeddingBatchEnabled: true
+```
+
+If a batch request fails, the builder degrades gracefully: retry with smaller batches, then fall back to single-item embedding. Startup is never aborted due to batch failure alone.
+
+#### IPrecomputedVectorRag — narrower interface
+
+Instead of expanding `IRag` globally, define a separate interface:
+
+```typescript
+export interface IPrecomputedVectorRag extends IRag {
+  upsertPrecomputed(
+    text: string,
+    vector: number[],
+    metadata: RagMetadata,
+    options?: CallOptions,
+  ): Promise<Result<void, RagError>>;
+}
+```
+
+Type guard in the builder:
+
+```typescript
+function supportsPrecomputed(rag: IRag): rag is IPrecomputedVectorRag {
+  return 'upsertPrecomputed' in rag;
+}
+```
+
+This keeps `IRag` minimal. Only `VectorRag` and `QdrantRag` implement `IPrecomputedVectorRag`.
+
+#### Shared internal write path in VectorRag
+
+Factor storage logic into an internal helper to avoid drift:
+
+```typescript
+private upsertKnownVector(
+  text: string,
+  vector: number[],
+  metadata: RagMetadata,
+): Result<void, RagError> { /* dedup, ID replacement, index update */ }
+```
+
+- `upsert()` computes the vector and delegates to `upsertKnownVector()`.
+- `upsertPrecomputed()` validates vector shape and delegates to `upsertKnownVector()`.
+
 #### Builder changes
 
-In `builder.ts` tool vectorization (lines 698-718), replace the sequential loop:
+The builder must use the same embedder instance that backs the target vector store. It must not independently resolve a second embedder with potentially different model/configuration, because that would produce incompatible vectors.
+
+Practical rule:
+
+- if the selected store implements `IPrecomputedVectorRag`, the builder may batch-embed only when it can access that store's effective embedder or an equivalent shared embedder instance configured for that store;
+- otherwise, it must fall back to normal store-managed `upsert()`.
 
 ```typescript
-if (isBatchEmbedder(embedder)) {
+if (isBatchEmbedder(embedderForToolStore)) {
   const texts = tools.map(t => `Tool: ${t.name} — ${t.description}`);
-  const vectors = await embedder.embedBatch(texts);
+  const vectors = await embedderForToolStore.embedBatch(texts);
   for (let i = 0; i < tools.length; i++) {
-    await toolStore.upsertWithVector(texts[i], vectors[i], { id: `tool:${tools[i].name}` });
+    if (supportsPrecomputed(toolStore)) {
+      await toolStore.upsertPrecomputed(texts[i], vectors[i], { id: `tool:${tools[i].name}` });
+    } else {
+      await toolStore.upsert(texts[i], { id: `tool:${tools[i].name}` });
+      // warning: precomputed vectors not used, re-embedding individual texts
+    }
   }
 } else {
-  // existing sequential loop with throttling
+  // existing sequential loop with 5/500ms throttling
 }
 ```
 
-This requires a new `upsertWithVector(text, vector, metadata)` method on `IRag` to skip re-embedding. Alternatively, add a `VectorRag.upsertPrecomputed()` method.
+If `upsertPrecomputed()` is unavailable on the target store, fall back to normal `upsert()` with a warning log.
 
-#### IRag extension
+Important clarification:
 
-Add optional method to `IRag`:
-
-```typescript
-export interface IRag {
-  upsert(text: string, metadata?: Record<string, unknown>, options?: CallOptions): Promise<Result<void, RagError>>;
-  upsertPrecomputed?(text: string, vector: number[], metadata?: Record<string, unknown>): Promise<Result<void, RagError>>;
-  query(...): Promise<Result<RagResult[], RagError>>;
-}
-```
-
-`VectorRag` and `QdrantRag` implement `upsertPrecomputed`. `InMemoryRag` and `FallbackRag` ignore vector (store text only).
+- this fallback preserves correctness;
+- it does **not** fully solve `#52` end-to-end for that store, because the store may re-embed each text individually;
+- `#52` is considered fully addressed only when both conditions hold:
+  - the embedder supports batch embedding;
+  - the target store supports precomputed-vector writes.
 
 ### 3. SAP AI Core Direct Provider (#54)
 
+#### Architecture boundary — compatibility-first path
+
+Add `src/llm-providers/sap-ai-core-direct.ts`, wrap it with `OpenAIAgent`, and expose it through `LlmAdapter`, matching the existing `providers.ts` composition style. This follows the current provider resolution flow that constructs legacy providers and adapts them through `LlmAdapter`.
+
 #### New provider: `sap-ai-core-direct`
 
-**File:** `src/llm-providers/sap-ai-core-direct.ts`
-
 Uses `resolveDeploymentUrl()` from `@sap-ai-sdk/ai-api` to get the model's inference endpoint, then sends OpenAI-compatible HTTP requests directly — bypassing OrchestrationClient entirely.
-
-#### Architecture
 
 ```
 Consumer → SapAiCoreDirectProvider.chat(messages, tools)
@@ -216,13 +333,15 @@ Reuse existing XSUAA token resolution from `@sap-ai-sdk/core`. The SDK handles t
 
 #### Deployment URL caching
 
-Cache `resolveDeploymentUrl()` result for the lifetime of the provider instance. Deployment URLs are stable — they only change on redeployment.
+Cache `resolveDeploymentUrl()` result for the lifetime of the provider instance. Deployment URLs are stable — they only change on redeployment. Implement refresh-on-error for resilience after redeployments.
 
-#### Agent: `SapCoreAiDirectAgent`
+#### Agent: extends OpenAIAgent
 
-Extends `OpenAIAgent` (not `SapCoreAIAgent`) since the direct API is OpenAI-compatible. No custom tool conversion needed.
+The direct API is OpenAI-compatible. Use `OpenAIAgent` directly — no custom agent subclass needed unless SAP-specific behavior diverges.
 
-#### Configuration
+#### Configuration — single source of truth
+
+Provider selection via YAML provider name only:
 
 ```yaml
 llm:
@@ -231,7 +350,17 @@ llm:
   resourceGroup: default
 ```
 
-New env var: `SAP_AI_DIRECT_PROVIDER=true` (or YAML `provider: sap-ai-core-direct`).
+No boolean env var for provider selection. Env vars are used only for credentials and connection settings (`AICORE_SERVICE_KEY`, etc.).
+
+#### Parity requirements
+
+Before broader adoption, the direct provider must pass parity checks:
+
+- Chat completion works with plain prompts.
+- Streaming works with OpenAI-style SSE framing.
+- Tool calling works with the same request/response shape expected by `OpenAIAgent`.
+- Per-request model override behavior remains compatible.
+- Model discovery: day one returns a minimal fallback set from the configured model. Full discovery deferred.
 
 #### Provider registration
 
@@ -243,7 +372,12 @@ Add to `providers.ts` factory map alongside existing providers. Builder resolves
 
 ```
 startup:
-  builder.ts → embedBatch() → requestLogger.logLlmCall({ component: 'embedding' })
+  builder.ts → embedBatch() → requestLogger.logLlmCall({
+    component: 'embedding',
+    scope: 'initialization',
+    detail: 'tools',
+    estimated: true
+  })
   → stored in initLlmCalls[] (never reset)
 
 per request:
@@ -251,7 +385,15 @@ per request:
   classifier → logLlmCall({ component: 'classifier' }) → requestLlmCalls[]
   translate → logLlmCall({ component: 'translate' }) → requestLlmCalls[]
   tool-loop → logLlmCall({ component: 'tool-loop' }) → requestLlmCalls[]
-  getSummary() → merge initLlmCalls + requestLlmCalls → byCategory, byComponent, byModel
+  runtime embedding (if any) → logLlmCall({
+    component: 'embedding',
+    scope: 'request'
+  }) → requestLlmCalls[]
+  getSummary() → merge initLlmCalls + requestLlmCalls
+    → byCategory, byComponent, byModel
+
+client response usage ← sourced from stream chunks (not RequestSummary)
+session log / /v1/usage ← includes byCategory with initialization
 ```
 
 ### Batch embedding flow (startup)
@@ -261,9 +403,12 @@ builder.ts:
   tools = mcpClient.listTools()              // 146 tools
   if isBatchEmbedder(embedder):
     texts = tools.map(formatToolText)         // 146 strings
-    vectors = embedder.embedBatch(texts)      // 1 HTTP request
+    vectors = embedder.embedBatch(texts)      // 1 HTTP request (or chunked)
     for each (text, vector, tool):
-      toolStore.upsertPrecomputed(text, vector, { id: `tool:${tool.name}` })
+      if supportsPrecomputed(store):
+        store.upsertPrecomputed(text, vector, metadata)
+      else:
+        store.upsert(text, metadata)          // fallback + warning
   else:
     // existing sequential loop with 5/500ms throttling
 ```
@@ -272,27 +417,55 @@ builder.ts:
 
 | File | Change |
 |------|--------|
-| `src/smart-agent/interfaces/request-logger.ts` | Add `TokenCategory`, `TokenBucket`, `byCategory` to `RequestSummary`, add `'embedding'` to `LlmComponent` |
-| `src/smart-agent/logger/default-request-logger.ts` | Split storage into init/request arrays, implement `byCategory` aggregation |
+| `src/smart-agent/interfaces/request-logger.ts` | Add `TokenCategory`, `TokenBucket`, `byCategory`, `estimated` flag, `'embedding'` to `LlmComponent` |
+| `src/smart-agent/logger/default-request-logger.ts` | Split init/request arrays, `byCategory` aggregation, `items` counter |
 | `src/smart-agent/logger/noop-request-logger.ts` | Return empty `byCategory` |
-| `src/smart-agent/interfaces/rag.ts` | Add `IEmbedderBatch`, `isBatchEmbedder()`, optional `upsertPrecomputed` on `IRag` |
+| `src/smart-agent/interfaces/rag.ts` | Add `IEmbedderBatch`, `isBatchEmbedder()`, `IPrecomputedVectorRag`, `supportsPrecomputed()` |
 | `src/smart-agent/rag/openai-embedder.ts` | Implement `IEmbedderBatch` |
 | `src/smart-agent/rag/ollama-rag.ts` | Implement `IEmbedderBatch` |
 | `src/smart-agent/rag/sap-ai-core-embedder.ts` | Implement `IEmbedderBatch` |
-| `src/smart-agent/rag/vector-rag.ts` | Add `upsertPrecomputed()` |
-| `src/smart-agent/rag/qdrant-rag.ts` | Add `upsertPrecomputed()` |
+| `src/smart-agent/rag/vector-rag.ts` | Extract `upsertKnownVector()`, implement `IPrecomputedVectorRag` |
+| `src/smart-agent/rag/qdrant-rag.ts` | Implement `IPrecomputedVectorRag` |
 | `src/smart-agent/resilience/circuit-breaker-embedder.ts` | Proxy `embedBatch()` |
-| `src/smart-agent/resilience/fallback-rag.ts` | Proxy `upsertPrecomputed()` |
-| `src/smart-agent/builder.ts` | Use batch embedding when available, log embedding tokens |
-| `src/smart-agent/pipeline/handlers/tool-loop.ts` | Exclude initialization tokens from client usage |
+| `src/smart-agent/resilience/fallback-rag.ts` | Proxy `upsertPrecomputed()` if inner supports it |
+| `src/smart-agent/builder.ts` | Batch embedding path, embedding token logging |
 | `src/llm-providers/sap-ai-core-direct.ts` | **NEW** — Direct inference provider |
-| `src/agents/sap-core-ai-direct-agent.ts` | **NEW** — Agent extending OpenAIAgent |
-| `src/smart-agent/providers.ts` | Register `sap-ai-core-direct` provider factory |
+| `src/smart-agent/providers.ts` | Register `sap-ai-core-direct` provider and embedder factories |
 | `src/index.ts` | Export new types and classes |
 
 ## Non-goals
 
-- Migration tool from Orchestration to Direct provider
-- Content filtering in Direct provider (consumer responsibility)
-- Embedder token counts from API (use estimation until providers expose this)
-- Changes to existing `sap-core-ai` Orchestration provider
+- Migration tool from Orchestration to Direct provider.
+- Content filtering in Direct provider (consumer responsibility).
+- Embedder token counts from API (use estimation until providers expose this).
+- Changes to existing `sap-core-ai` Orchestration provider.
+- Full model discovery for `sap-ai-core-direct` on day one.
+
+## Acceptance criteria
+
+- `RequestSummary.byCategory` is populated for request-scoped LLM activity without breaking existing `byModel` and `byComponent` outputs.
+- Empty `byComponent` root cause is diagnosed and covered by a test reproducing the original failure mode.
+- Estimated embedding tokens are clearly marked with `estimated: true` and never included in client-facing `usage`.
+- `/v1/usage` clearly distinguishes estimated initialization tokens from exact request-time LLM usage.
+- Startup vectorization performs batched embedding when the embedder supports it and falls back safely when it does not.
+- Batched embedding preserves idempotent `metadata.id` replacement semantics in vector-backed stores.
+- Runtime embedding, if logged, is stored as request-scoped rather than initialization-scoped.
+- `sap-ai-core-direct` supports chat, streaming, and tool-calling paths expected by the current adapter stack.
+- Switching from `sap-ai-sdk` to `sap-ai-core-direct` requires only provider config changes, not application code changes.
+
+## Risks
+
+- Estimated embedding tokens may be misread as billable usage if the API output is not clearly labeled.
+- Batch embedding may increase retry blast radius: one failed request can affect many pending vectors.
+- Precomputed-vector write paths can drift from normal `upsert()` behavior if logic is duplicated.
+- Direct SAP inference may differ from orchestration in safety filters, request shaping, or tool-call edge cases.
+- Caching deployment URLs for too long may break after redeployments unless refresh-on-error is implemented.
+
+## Rollout stages
+
+1. Diagnose #53 root cause; add `byCategory`, `TokenBucket`, and `estimated` flag without changing client `usage`.
+2. Add `IEmbedderBatch` plus provider implementations with chunking/fallback.
+3. Add `IPrecomputedVectorRag` with shared `upsertKnownVector()` write path.
+4. Switch builder startup vectorization to batch mode.
+5. Introduce `sap-ai-core-direct` behind explicit opt-in provider name.
+6. Compare direct vs orchestration token counts and tool-calling parity before broader adoption.

--- a/src/agents/sap-ai-core-direct-agent.ts
+++ b/src/agents/sap-ai-core-direct-agent.ts
@@ -1,0 +1,166 @@
+/**
+ * SAP AI Core Direct Agent — extends BaseAgent using SapAiCoreDirectProvider
+ *
+ * Sends OpenAI-compatible HTTP requests directly to SAP AI Core deployment
+ * endpoints, bypassing OrchestrationClient overhead.
+ * Supports native tool calling and streaming.
+ */
+
+import type { SapAiCoreDirectProvider } from '../llm-providers/sap-ai-core-direct.js';
+import type { AgentStreamChunk, Message } from '../types.js';
+import {
+  type AgentCallOptions,
+  BaseAgent,
+  type BaseAgentConfig,
+} from './base.js';
+
+export interface SapAiCoreDirectAgentConfig extends BaseAgentConfig {
+  llmProvider: SapAiCoreDirectProvider;
+}
+
+export class SapAiCoreDirectAgent extends BaseAgent {
+  private llmProvider: SapAiCoreDirectProvider;
+
+  constructor(config: SapAiCoreDirectAgentConfig) {
+    super(config);
+    this.llmProvider = config.llmProvider;
+  }
+
+  protected async callLLMWithTools(
+    messages: Message[],
+    tools: unknown[],
+    options?: AgentCallOptions,
+  ): Promise<{ content: string; raw?: unknown }> {
+    const functions = this.convertToolsToFunctions(tools);
+
+    if (options?.model) {
+      this.llmProvider.setModelOverride(options.model);
+    }
+
+    const response = await this.llmProvider.chat(
+      messages,
+      functions.length > 0 ? functions : undefined,
+    );
+
+    return {
+      content: response.content,
+      raw: response.raw,
+    };
+  }
+
+  protected async *streamLLMWithTools(
+    messages: Message[],
+    tools: unknown[],
+    options?: AgentCallOptions,
+  ): AsyncGenerator<AgentStreamChunk, void, unknown> {
+    const functions = this.convertToolsToFunctions(tools);
+
+    if (options?.model) {
+      this.llmProvider.setModelOverride(options.model);
+    }
+
+    const toolCallMap = new Map<
+      number,
+      { id: string; name: string; arguments: string }
+    >();
+    let finishReason: 'stop' | 'tool_calls' | 'length' | 'error' = 'stop';
+
+    for await (const chunk of this.llmProvider.streamChat(
+      messages,
+      functions.length > 0 ? functions : undefined,
+    )) {
+      if (chunk.content) {
+        yield { type: 'text', delta: chunk.content };
+      }
+
+      // Accumulate tool call deltas and usage from raw OpenAI-compatible chunk
+      if (chunk.raw && typeof chunk.raw === 'object') {
+        // biome-ignore lint/suspicious/noExplicitAny: raw provider payload has no stable type
+        const raw = chunk.raw as any;
+
+        // Usage-only chunk (stream_options: include_usage)
+        if (raw.usage && !raw.choices?.[0]?.delta) {
+          yield {
+            type: 'usage',
+            promptTokens: (raw.usage.prompt_tokens as number) ?? 0,
+            completionTokens: (raw.usage.completion_tokens as number) ?? 0,
+          };
+        }
+
+        const delta = raw.choices?.[0]?.delta;
+        if (delta?.tool_calls) {
+          for (const tc of delta.tool_calls) {
+            const index = tc.index as number;
+            if (!toolCallMap.has(index)) {
+              toolCallMap.set(index, {
+                id: tc.id ?? '',
+                name: tc.function?.name ?? '',
+                arguments: '',
+              });
+            }
+            if (tc.function?.arguments) {
+              const accumulated = toolCallMap.get(index);
+              if (accumulated) {
+                accumulated.arguments += tc.function.arguments as string;
+              }
+            }
+          }
+        }
+      }
+
+      if (chunk.finishReason) {
+        finishReason =
+          chunk.finishReason === 'tool_calls'
+            ? 'tool_calls'
+            : chunk.finishReason === 'length'
+              ? 'length'
+              : chunk.finishReason === 'error'
+                ? 'error'
+                : 'stop';
+      }
+    }
+
+    if (toolCallMap.size > 0) {
+      const toolCalls = [...toolCallMap.entries()]
+        .sort(([a], [b]) => a - b)
+        .map(([, tc]) => ({
+          id: tc.id,
+          name: tc.name,
+          arguments: (() => {
+            try {
+              return JSON.parse(tc.arguments) as Record<string, unknown>;
+            } catch {
+              return {};
+            }
+          })(),
+        }));
+      yield { type: 'tool_calls', toolCalls };
+      finishReason = 'tool_calls';
+    }
+
+    yield { type: 'done', finishReason };
+  }
+
+  private convertToolsToFunctions(
+    tools: unknown[],
+  ): Array<Record<string, unknown>> {
+    return tools.map((rawTool) => {
+      const tool = rawTool as {
+        name?: string;
+        description?: string;
+        inputSchema?: Record<string, unknown>;
+      };
+      return {
+        type: 'function',
+        function: {
+          name: tool.name ?? '',
+          description: tool.description || '',
+          parameters: tool.inputSchema || {
+            type: 'object',
+            properties: {},
+          },
+        },
+      };
+    });
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,10 @@ export {
   DeepSeekProvider,
 } from './llm-providers/deepseek.js';
 export { type OpenAIConfig, OpenAIProvider } from './llm-providers/openai.js';
+export {
+  type SapAiCoreDirectConfig,
+  SapAiCoreDirectProvider,
+} from './llm-providers/sap-ai-core-direct.js';
 // LLM Providers
 // NOTE: All LLM providers are accessed through SAP AI Core
 export {
@@ -129,7 +133,13 @@ export type {
   EmbedderFactory,
   EmbedderFactoryConfig,
   IEmbedder,
+  IEmbedderBatch,
+  IPrecomputedVectorRag,
   IRag,
+} from './smart-agent/interfaces/rag.js';
+export {
+  isBatchEmbedder,
+  supportsPrecomputed,
 } from './smart-agent/interfaces/rag.js';
 // Request Logger
 export type {
@@ -138,6 +148,8 @@ export type {
   LlmComponent,
   RagQueryEntry,
   RequestSummary,
+  TokenBucket,
+  TokenCategory,
   ToolCallEntry,
 } from './smart-agent/interfaces/request-logger.js';
 // Skills

--- a/src/llm-providers/sap-ai-core-direct.ts
+++ b/src/llm-providers/sap-ai-core-direct.ts
@@ -1,0 +1,232 @@
+/**
+ * SAP AI Core Direct LLM Provider
+ *
+ * Bypasses OrchestrationClient and sends OpenAI-compatible HTTP requests
+ * directly to SAP AI Core deployment endpoints.
+ * Token counts are accurate (no orchestration overhead).
+ */
+
+import type { IModelInfo } from '../smart-agent/interfaces/model-provider.js';
+import type { LLMProviderConfig, LLMResponse, Message } from '../types.js';
+import { BaseLLMProvider } from './base.js';
+
+export interface SapAiCoreDirectConfig extends LLMProviderConfig {
+  model?: string;
+  temperature?: number;
+  maxTokens?: number;
+  resourceGroup?: string;
+}
+
+export class SapAiCoreDirectProvider extends BaseLLMProvider<SapAiCoreDirectConfig> {
+  readonly model: string;
+  private readonly resourceGroup: string;
+  private deploymentUrl: string | null = null;
+  private modelOverride?: string;
+
+  setModelOverride(model?: string): void {
+    this.modelOverride = model;
+  }
+
+  constructor(config: SapAiCoreDirectConfig) {
+    super(config);
+    this.model = config.model || 'gpt-4o';
+    this.resourceGroup = config.resourceGroup || 'default';
+  }
+
+  private async resolveUrl(): Promise<string> {
+    if (this.deploymentUrl) return this.deploymentUrl;
+
+    const { resolveDeploymentUrl } = await import('@sap-ai-sdk/ai-api');
+    const url = await resolveDeploymentUrl({
+      scenarioId: 'foundation-models',
+      model: { name: this.model },
+      resourceGroup: this.resourceGroup,
+    });
+    if (!url) {
+      throw new Error(
+        `SAP AI Core: no deployment found for model "${this.model}" in resource group "${this.resourceGroup}"`,
+      );
+    }
+    this.deploymentUrl = url;
+    return url;
+  }
+
+  async chat(messages: Message[], tools?: unknown[]): Promise<LLMResponse> {
+    try {
+      const url = await this.resolveUrl();
+      const model = this.modelOverride ?? this.model;
+
+      const body: Record<string, unknown> = {
+        model,
+        messages: this.formatMessages(messages),
+        temperature: this.config.temperature || 0.7,
+        max_tokens: this.config.maxTokens || 16384,
+      };
+      if (tools && tools.length > 0) {
+        body.tools = tools;
+        body.tool_choice = 'auto';
+      }
+
+      const res = await fetch(`${url}/chat/completions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+
+      if (!res.ok) {
+        const errText = await res.text();
+        throw new Error(`HTTP ${res.status}: ${errText}`);
+      }
+
+      const data = (await res.json()) as {
+        choices: Array<{
+          message: { role: string; content: string; tool_calls?: unknown[] };
+          finish_reason: string;
+        }>;
+        usage?: {
+          prompt_tokens: number;
+          completion_tokens: number;
+          total_tokens: number;
+        };
+      };
+
+      const choice = data.choices[0];
+      return {
+        content: choice.message.content || '',
+        finishReason: choice.finish_reason,
+        raw: data,
+      };
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : String(error);
+      throw new Error(`SAP AI Core Direct API error: ${msg}`);
+    } finally {
+      this.modelOverride = undefined;
+    }
+  }
+
+  async *streamChat(
+    messages: Message[],
+    tools?: unknown[],
+  ): AsyncIterable<LLMResponse> {
+    try {
+      const url = await this.resolveUrl();
+      const model = this.modelOverride ?? this.model;
+
+      const body: Record<string, unknown> = {
+        model,
+        messages: this.formatMessages(messages),
+        temperature: this.config.temperature || 0.7,
+        max_tokens: this.config.maxTokens || 16384,
+        stream: true,
+      };
+      if (tools && tools.length > 0) {
+        body.tools = tools;
+        body.tool_choice = 'auto';
+      }
+
+      const res = await fetch(`${url}/chat/completions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+
+      if (!res.ok) {
+        const errText = await res.text();
+        throw new Error(`HTTP ${res.status}: ${errText}`);
+      }
+
+      if (!res.body) throw new Error('No response body for streaming');
+
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      for await (const rawChunk of res.body as AsyncIterable<Uint8Array>) {
+        buffer += decoder.decode(rawChunk, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || '';
+
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed?.startsWith('data: ')) continue;
+          const payload = trimmed.slice(6);
+          if (payload === '[DONE]') return;
+
+          try {
+            const chunk = JSON.parse(payload) as {
+              choices: Array<{
+                delta: { content?: string; tool_calls?: unknown[] };
+                finish_reason?: string;
+              }>;
+              usage?: {
+                prompt_tokens: number;
+                completion_tokens: number;
+                total_tokens: number;
+              };
+            };
+
+            const delta = chunk.choices[0]?.delta;
+            const usage = chunk.usage;
+
+            yield {
+              content: delta?.content || '',
+              finishReason: chunk.choices[0]?.finish_reason ?? undefined,
+              raw: chunk,
+              ...(usage
+                ? {
+                    usage: {
+                      promptTokens: usage.prompt_tokens || 0,
+                      completionTokens: usage.completion_tokens || 0,
+                      totalTokens: usage.total_tokens || 0,
+                    },
+                  }
+                : {}),
+            };
+          } catch {
+            // Skip malformed chunks
+          }
+        }
+      }
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : String(error);
+      throw new Error(`SAP AI Core Direct streaming error: ${msg}`);
+    } finally {
+      this.modelOverride = undefined;
+    }
+  }
+
+  async getModels(): Promise<IModelInfo[]> {
+    return [{ id: this.model }];
+  }
+
+  private formatMessages(messages: Message[]): Array<Record<string, unknown>> {
+    return messages.map((msg) => {
+      if (
+        msg.role === 'assistant' &&
+        msg.tool_calls &&
+        msg.tool_calls.length > 0
+      ) {
+        return {
+          role: 'assistant',
+          content: msg.content || undefined,
+          tool_calls: msg.tool_calls,
+        };
+      }
+
+      if (msg.role === 'tool' && msg.tool_call_id) {
+        return {
+          role: 'tool',
+          content:
+            typeof msg.content === 'string'
+              ? msg.content
+              : JSON.stringify(msg.content ?? ''),
+          tool_call_id: msg.tool_call_id,
+        };
+      }
+
+      return {
+        role: msg.role,
+        content: msg.content ?? '',
+      };
+    });
+  }
+}

--- a/src/smart-agent/__tests__/request-logger.test.ts
+++ b/src/smart-agent/__tests__/request-logger.test.ts
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { DefaultRequestLogger } from '../logger/default-request-logger.js';
+
+describe('DefaultRequestLogger', () => {
+  it('aggregates byComponent and byCategory for request-scoped calls', () => {
+    const logger = new DefaultRequestLogger();
+    logger.startRequest();
+    logger.logLlmCall({
+      component: 'classifier',
+      model: 'gpt-4o',
+      promptTokens: 100,
+      completionTokens: 20,
+      totalTokens: 120,
+      durationMs: 50,
+    });
+    logger.logLlmCall({
+      component: 'tool-loop',
+      model: 'gpt-4o',
+      promptTokens: 500,
+      completionTokens: 100,
+      totalTokens: 600,
+      durationMs: 200,
+    });
+    logger.endRequest();
+
+    const summary = logger.getSummary();
+    assert.equal(summary.byComponent.classifier?.promptTokens, 100);
+    assert.equal(summary.byComponent['tool-loop']?.promptTokens, 500);
+    assert.equal(summary.byCategory.auxiliary?.promptTokens, 100);
+    assert.equal(summary.byCategory.request?.promptTokens, 500);
+    assert.equal(summary.byModel['gpt-4o']?.requests, 2);
+  });
+
+  it('preserves initialization calls across startRequest resets', () => {
+    const logger = new DefaultRequestLogger();
+
+    // Simulate startup embedding
+    logger.logLlmCall({
+      component: 'embedding',
+      model: 'text-embedding-3-small',
+      promptTokens: 1000,
+      completionTokens: 0,
+      totalTokens: 1000,
+      durationMs: 300,
+      estimated: true,
+      scope: 'initialization',
+      detail: 'tools',
+    });
+
+    // First request — startRequest should NOT clear init calls
+    logger.startRequest();
+    logger.logLlmCall({
+      component: 'tool-loop',
+      model: 'gpt-4o',
+      promptTokens: 500,
+      completionTokens: 100,
+      totalTokens: 600,
+      durationMs: 200,
+    });
+    logger.endRequest();
+
+    const summary1 = logger.getSummary();
+    assert.equal(summary1.byCategory.initialization?.totalTokens, 1000);
+    assert.equal(summary1.byCategory.request?.totalTokens, 600);
+    assert.equal(summary1.byComponent.embedding?.requests, 1);
+    assert.equal(summary1.byComponent['tool-loop']?.requests, 1);
+
+    // Second request — init data still present, request data reset
+    logger.startRequest();
+    logger.logLlmCall({
+      component: 'tool-loop',
+      model: 'gpt-4o',
+      promptTokens: 300,
+      completionTokens: 50,
+      totalTokens: 350,
+      durationMs: 100,
+    });
+    logger.endRequest();
+
+    const summary2 = logger.getSummary();
+    assert.equal(summary2.byCategory.initialization?.totalTokens, 1000);
+    assert.equal(summary2.byCategory.request?.totalTokens, 350);
+    assert.equal(summary2.byComponent['tool-loop']?.requests, 1);
+  });
+
+  it('routes runtime embedding to request scope when scope is not initialization', () => {
+    const logger = new DefaultRequestLogger();
+    logger.startRequest();
+    logger.logLlmCall({
+      component: 'embedding',
+      model: 'text-embedding-3-small',
+      promptTokens: 50,
+      completionTokens: 0,
+      totalTokens: 50,
+      durationMs: 10,
+      scope: 'request',
+    });
+    logger.endRequest();
+
+    const summary = logger.getSummary();
+    assert.equal(summary.byComponent.embedding?.totalTokens, 50);
+
+    // After reset, runtime embedding should be cleared
+    logger.startRequest();
+    logger.endRequest();
+    const summary2 = logger.getSummary();
+    assert.equal(summary2.byComponent.embedding, undefined);
+  });
+
+  it('returns empty byCategory when no calls logged', () => {
+    const logger = new DefaultRequestLogger();
+    logger.startRequest();
+    logger.endRequest();
+    const summary = logger.getSummary();
+    assert.deepEqual(summary.byCategory, {});
+    assert.deepEqual(summary.byComponent, {});
+    assert.deepEqual(summary.byModel, {});
+  });
+});

--- a/src/smart-agent/__tests__/smart-server-api-adapters.test.ts
+++ b/src/smart-agent/__tests__/smart-server-api-adapters.test.ts
@@ -95,6 +95,7 @@ describe('SmartServer — Anthropic /v1/messages route', () => {
     const server = new SmartServer({
       port: 0,
       llm: { apiKey: 'test-key' },
+      skipModelValidation: true,
       disableBuiltInAdapters: true,
       apiAdapters: [],
     });
@@ -117,6 +118,7 @@ describe('SmartServer — Anthropic /v1/messages route', () => {
     const server = new SmartServer({
       port: 0,
       llm: { apiKey: 'test-key' },
+      skipModelValidation: true,
       apiAdapters: [makeFakeAdapter()],
     });
 
@@ -169,6 +171,7 @@ describe('SmartServer — Anthropic /v1/messages route', () => {
     const server = new SmartServer({
       port: 0,
       llm: { apiKey: 'test-key' },
+      skipModelValidation: true,
       disableBuiltInAdapters: true,
       apiAdapters: [],
     });

--- a/src/smart-agent/builder.ts
+++ b/src/smart-agent/builder.ts
@@ -640,6 +640,9 @@ export class SmartAgentBuilder {
       }
     }
 
+    // ---- Request logger ---------------------------------------------------
+    const requestLogger = this._requestLogger ?? new DefaultRequestLogger();
+
     // ---- MCP clients + tool vectorization --------------------------------
     let mcpClients: IMcpClient[];
     const closeFns: Array<() => Promise<void>> = [];
@@ -700,15 +703,28 @@ export class SmartAgentBuilder {
               const tools = toolsResult.value;
               for (let i = 0; i < tools.length; i++) {
                 const t = tools[i];
-                const result = await toolStore.upsert(
-                  `Tool: ${t.name} — ${t.description}`,
-                  { id: `tool:${t.name}` },
-                );
+                const text = `Tool: ${t.name} — ${t.description}`;
+                const embedStart = Date.now();
+                const result = await toolStore.upsert(text, {
+                  id: `tool:${t.name}`,
+                });
                 if (!result.ok) {
                   log?.log({
                     type: 'warning',
                     traceId: 'builder',
                     message: `Tool vectorization failed for "${t.name}": ${result.error.message}`,
+                  });
+                } else {
+                  requestLogger.logLlmCall({
+                    component: 'embedding',
+                    model: 'embedder',
+                    promptTokens: Math.ceil(text.length / 4),
+                    completionTokens: 0,
+                    totalTokens: Math.ceil(text.length / 4),
+                    durationMs: Date.now() - embedStart,
+                    estimated: true,
+                    scope: 'initialization',
+                    detail: 'tools',
                   });
                 }
                 // Throttle embedding requests to avoid rate limits
@@ -749,9 +765,6 @@ export class SmartAgentBuilder {
     if (agentCfg.retry) {
       wrappedMainLlm = new RetryLlm(wrappedMainLlm, agentCfg.retry);
     }
-
-    // ---- Request logger ---------------------------------------------------
-    const requestLogger = this._requestLogger ?? new DefaultRequestLogger();
 
     // ---- Classifier -------------------------------------------------------
     const classifierCfg: LlmClassifierConfig = {};
@@ -835,17 +848,28 @@ export class SmartAgentBuilder {
       const skillsResult = await this._skillManager.listSkills();
       if (skillsResult.ok) {
         for (const s of skillsResult.value) {
-          const result = await skillStore.upsert(
-            `Skill: ${s.name}\n${s.description}`,
-            {
-              id: `skill:${s.name}`,
-            },
-          );
+          const text = `Skill: ${s.name}\n${s.description}`;
+          const embedStart = Date.now();
+          const result = await skillStore.upsert(text, {
+            id: `skill:${s.name}`,
+          });
           if (!result.ok) {
             log?.log({
               type: 'warning',
               traceId: 'builder',
               message: `Skill vectorization failed for "${s.name}": ${result.error.message}`,
+            });
+          } else {
+            requestLogger.logLlmCall({
+              component: 'embedding',
+              model: 'embedder',
+              promptTokens: Math.ceil(text.length / 4),
+              completionTokens: 0,
+              totalTokens: Math.ceil(text.length / 4),
+              durationMs: Date.now() - embedStart,
+              estimated: true,
+              scope: 'initialization',
+              detail: 'skills',
             });
           }
         }

--- a/src/smart-agent/builder.ts
+++ b/src/smart-agent/builder.ts
@@ -115,6 +115,8 @@ export interface SmartAgentBuilderConfig {
   prompts?: BuilderPromptsConfig;
   /** Data governance policy for RAG records. */
   sessionPolicy?: SessionPolicy;
+  /** Skip startup model validation (useful for testing). Default: false. */
+  skipModelValidation?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -578,35 +580,37 @@ export class SmartAgentBuilder {
     // ---- Startup model validation ------------------------------------------
     // Verify that configured models respond before starting the server.
     // Only checks unique models from the pipeline config (main, classifier, helper).
-    const modelsToCheck = new Map<string, ILlm>();
-    modelsToCheck.set(mainLlm.model ?? 'main', mainLlm);
-    if (classifierLlm !== mainLlm) {
-      modelsToCheck.set(classifierLlm.model ?? 'classifier', classifierLlm);
-    }
-    if (helperLlm && helperLlm !== mainLlm) {
-      modelsToCheck.set(helperLlm.model ?? 'helper', helperLlm);
-    }
-
-    for (const [modelName, llm] of modelsToCheck) {
-      const result = await llm.chat(
-        [{ role: 'user', content: 'Reply with OK' }],
-        undefined,
-        { maxTokens: 10 },
-      );
-      if (!result.ok) {
-        const detail = result.error.message;
-        log?.log({
-          type: 'pipeline_error',
-          traceId: 'builder',
-          code: 'MODEL_UNAVAILABLE',
-          message: `Model "${modelName}" is not available: ${detail}`,
-          durationMs: 0,
-        });
-        throw new Error(
-          `Startup aborted: model "${modelName}" is not available.\n${detail}`,
-        );
+    if (!this.cfg.skipModelValidation) {
+      const modelsToCheck = new Map<string, ILlm>();
+      modelsToCheck.set(mainLlm.model ?? 'main', mainLlm);
+      if (classifierLlm !== mainLlm) {
+        modelsToCheck.set(classifierLlm.model ?? 'classifier', classifierLlm);
       }
-    }
+      if (helperLlm && helperLlm !== mainLlm) {
+        modelsToCheck.set(helperLlm.model ?? 'helper', helperLlm);
+      }
+
+      for (const [modelName, llm] of modelsToCheck) {
+        const result = await llm.chat(
+          [{ role: 'user', content: 'Reply with OK' }],
+          undefined,
+          { maxTokens: 10 },
+        );
+        if (!result.ok) {
+          const detail = result.error.message;
+          log?.log({
+            type: 'pipeline_error',
+            traceId: 'builder',
+            code: 'MODEL_UNAVAILABLE',
+            message: `Model "${modelName}" is not available: ${detail}`,
+            durationMs: 0,
+          });
+          throw new Error(
+            `Startup aborted: model "${modelName}" is not available.\n${detail}`,
+          );
+        }
+      }
+    } // end skipModelValidation guard
 
     // RAG stores — consumer defines which stores to use
     const ragStores: SmartAgentRagStores = { ...this._ragStores };

--- a/src/smart-agent/builder.ts
+++ b/src/smart-agent/builder.ts
@@ -41,7 +41,11 @@ import type { ILlm } from './interfaces/llm.js';
 import type { IMcpClient } from './interfaces/mcp-client.js';
 import type { IMcpConnectionStrategy } from './interfaces/mcp-connection-strategy.js';
 import type { IModelProvider } from './interfaces/model-provider.js';
-import type { IEmbedder } from './interfaces/rag.js';
+import {
+  type IEmbedder,
+  isBatchEmbedder,
+  supportsPrecomputed,
+} from './interfaces/rag.js';
 import type { IRequestLogger } from './interfaces/request-logger.js';
 import type { ISkillManager } from './interfaces/skill.js';
 import { DefaultRequestLogger } from './logger/default-request-logger.js';
@@ -698,38 +702,129 @@ export class SmartAgentBuilder {
             }
             const toolsResult = await adapter.listTools();
             if (toolsResult.ok) {
-              const batchSize = 5;
-              const batchDelayMs = 500;
               const tools = toolsResult.value;
-              for (let i = 0; i < tools.length; i++) {
-                const t = tools[i];
-                const text = `Tool: ${t.name} — ${t.description}`;
-                const embedStart = Date.now();
-                const result = await toolStore.upsert(text, {
-                  id: `tool:${t.name}`,
-                });
-                if (!result.ok) {
-                  log?.log({
-                    type: 'warning',
-                    traceId: 'builder',
-                    message: `Tool vectorization failed for "${t.name}": ${result.error.message}`,
-                  });
-                } else {
+              // Try to access the embedder from the store for batch embedding.
+              // VectorRag and QdrantRag store their embedder as a private field.
+              // biome-ignore lint/suspicious/noExplicitAny: accessing private embedder for batch optimization
+              const storeEmbedder = (toolStore as any).embedder as
+                | IEmbedder
+                | undefined;
+
+              if (
+                storeEmbedder &&
+                isBatchEmbedder(storeEmbedder) &&
+                supportsPrecomputed(toolStore)
+              ) {
+                // Batch path: single HTTP call for all tools
+                const texts = tools.map(
+                  (t) => `Tool: ${t.name} — ${t.description}`,
+                );
+                const batchStart = Date.now();
+                try {
+                  const vectors = await storeEmbedder.embedBatch(texts);
+                  const batchDuration = Date.now() - batchStart;
+                  for (let i = 0; i < tools.length; i++) {
+                    const result = await toolStore.upsertPrecomputed(
+                      texts[i],
+                      vectors[i],
+                      { id: `tool:${tools[i].name}` },
+                    );
+                    if (!result.ok) {
+                      log?.log({
+                        type: 'warning',
+                        traceId: 'builder',
+                        message: `Tool vectorization failed for "${tools[i].name}": ${result.error.message}`,
+                      });
+                    }
+                  }
+                  const totalEstTokens = texts.reduce(
+                    (sum, t) => sum + Math.ceil(t.length / 4),
+                    0,
+                  );
                   requestLogger.logLlmCall({
                     component: 'embedding',
                     model: 'embedder',
-                    promptTokens: Math.ceil(text.length / 4),
+                    promptTokens: totalEstTokens,
                     completionTokens: 0,
-                    totalTokens: Math.ceil(text.length / 4),
-                    durationMs: Date.now() - embedStart,
+                    totalTokens: totalEstTokens,
+                    durationMs: batchDuration,
                     estimated: true,
                     scope: 'initialization',
                     detail: 'tools',
                   });
+                } catch (err) {
+                  log?.log({
+                    type: 'warning',
+                    traceId: 'builder',
+                    message: `Batch embedding failed, falling back to sequential: ${String(err)}`,
+                  });
+                  // Fallback to sequential
+                  const batchSize = 5;
+                  const batchDelayMs = 500;
+                  for (let i = 0; i < tools.length; i++) {
+                    const t = tools[i];
+                    const text = `Tool: ${t.name} — ${t.description}`;
+                    const embedStart = Date.now();
+                    const result = await toolStore.upsert(text, {
+                      id: `tool:${t.name}`,
+                    });
+                    if (!result.ok) {
+                      log?.log({
+                        type: 'warning',
+                        traceId: 'builder',
+                        message: `Tool vectorization failed for "${t.name}": ${result.error.message}`,
+                      });
+                    } else {
+                      requestLogger.logLlmCall({
+                        component: 'embedding',
+                        model: 'embedder',
+                        promptTokens: Math.ceil(text.length / 4),
+                        completionTokens: 0,
+                        totalTokens: Math.ceil(text.length / 4),
+                        durationMs: Date.now() - embedStart,
+                        estimated: true,
+                        scope: 'initialization',
+                        detail: 'tools',
+                      });
+                    }
+                    if ((i + 1) % batchSize === 0 && i < tools.length - 1) {
+                      await new Promise((r) => setTimeout(r, batchDelayMs));
+                    }
+                  }
                 }
-                // Throttle embedding requests to avoid rate limits
-                if ((i + 1) % batchSize === 0 && i < tools.length - 1) {
-                  await new Promise((r) => setTimeout(r, batchDelayMs));
+              } else {
+                // Sequential path (no batch support)
+                const batchSize = 5;
+                const batchDelayMs = 500;
+                for (let i = 0; i < tools.length; i++) {
+                  const t = tools[i];
+                  const text = `Tool: ${t.name} — ${t.description}`;
+                  const embedStart = Date.now();
+                  const result = await toolStore.upsert(text, {
+                    id: `tool:${t.name}`,
+                  });
+                  if (!result.ok) {
+                    log?.log({
+                      type: 'warning',
+                      traceId: 'builder',
+                      message: `Tool vectorization failed for "${t.name}": ${result.error.message}`,
+                    });
+                  } else {
+                    requestLogger.logLlmCall({
+                      component: 'embedding',
+                      model: 'embedder',
+                      promptTokens: Math.ceil(text.length / 4),
+                      completionTokens: 0,
+                      totalTokens: Math.ceil(text.length / 4),
+                      durationMs: Date.now() - embedStart,
+                      estimated: true,
+                      scope: 'initialization',
+                      detail: 'tools',
+                    });
+                  }
+                  if ((i + 1) % batchSize === 0 && i < tools.length - 1) {
+                    await new Promise((r) => setTimeout(r, batchDelayMs));
+                  }
                 }
               }
             }

--- a/src/smart-agent/interfaces/rag.ts
+++ b/src/smart-agent/interfaces/rag.ts
@@ -56,9 +56,11 @@ export interface IEmbedderBatch extends IEmbedder {
   embedBatch(texts: string[], options?: CallOptions): Promise<number[][]>;
 }
 
-// biome-ignore lint/suspicious/noExplicitAny: runtime type check
 export function isBatchEmbedder(e: IEmbedder): e is IEmbedderBatch {
-  return 'embedBatch' in e && typeof (e as any).embedBatch === 'function';
+  return (
+    'embedBatch' in e &&
+    typeof (e as { embedBatch?: unknown }).embedBatch === 'function'
+  );
 }
 
 export interface IPrecomputedVectorRag extends IRag {

--- a/src/smart-agent/interfaces/rag.ts
+++ b/src/smart-agent/interfaces/rag.ts
@@ -51,3 +51,25 @@ export interface IRag {
 
   healthCheck(options?: CallOptions): Promise<Result<void, RagError>>;
 }
+
+export interface IEmbedderBatch extends IEmbedder {
+  embedBatch(texts: string[], options?: CallOptions): Promise<number[][]>;
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: runtime type check
+export function isBatchEmbedder(e: IEmbedder): e is IEmbedderBatch {
+  return 'embedBatch' in e && typeof (e as any).embedBatch === 'function';
+}
+
+export interface IPrecomputedVectorRag extends IRag {
+  upsertPrecomputed(
+    text: string,
+    vector: number[],
+    metadata: RagMetadata,
+    options?: CallOptions,
+  ): Promise<Result<void, RagError>>;
+}
+
+export function supportsPrecomputed(rag: IRag): rag is IPrecomputedVectorRag {
+  return 'upsertPrecomputed' in rag;
+}

--- a/src/smart-agent/interfaces/request-logger.ts
+++ b/src/smart-agent/interfaces/request-logger.ts
@@ -3,7 +3,18 @@ export type LlmComponent =
   | 'classifier'
   | 'helper'
   | 'translate'
-  | 'query-expander';
+  | 'query-expander'
+  | 'embedding';
+
+export type TokenCategory = 'initialization' | 'auxiliary' | 'request';
+
+export interface TokenBucket {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  requests: number;
+  items?: number;
+}
 
 export interface LlmCallEntry {
   component: LlmComponent;
@@ -12,6 +23,9 @@ export interface LlmCallEntry {
   completionTokens: number;
   totalTokens: number;
   durationMs: number;
+  estimated?: boolean;
+  scope?: 'initialization' | 'request';
+  detail?: string;
 }
 
 export interface RagQueryEntry {
@@ -30,25 +44,11 @@ export interface ToolCallEntry {
 
 export interface RequestSummary {
   /** Per-model aggregated token usage. */
-  byModel: Record<
-    string,
-    {
-      promptTokens: number;
-      completionTokens: number;
-      totalTokens: number;
-      requests: number;
-    }
-  >;
+  byModel: Record<string, TokenBucket>;
   /** Per-component aggregated token usage. */
-  byComponent: Record<
-    string,
-    {
-      promptTokens: number;
-      completionTokens: number;
-      totalTokens: number;
-      requests: number;
-    }
-  >;
+  byComponent: Record<string, TokenBucket>;
+  /** Per-category aggregated token usage. */
+  byCategory: Record<string, TokenBucket>;
   ragQueries: number;
   toolCalls: number;
   /** Wall-clock time for the entire request. */

--- a/src/smart-agent/interfaces/types.ts
+++ b/src/smart-agent/interfaces/types.ts
@@ -62,6 +62,7 @@ export interface LlmStreamChunk {
   usage?: LlmUsage & {
     models?: Record<string, ModelUsageEntry>;
     components?: Record<string, ModelUsageEntry>;
+    categories?: Record<string, ModelUsageEntry>;
   };
   /** Periodic heartbeat emitted while an MCP tool is executing. */
   heartbeat?: ToolHeartbeat;

--- a/src/smart-agent/logger/default-request-logger.ts
+++ b/src/smart-agent/logger/default-request-logger.ts
@@ -1,20 +1,47 @@
 import type {
   IRequestLogger,
   LlmCallEntry,
+  LlmComponent,
   RagQueryEntry,
   RequestSummary,
+  TokenBucket,
+  TokenCategory,
   ToolCallEntry,
 } from '../interfaces/request-logger.js';
 
+const CATEGORY_MAP: Record<LlmComponent, TokenCategory> = {
+  'tool-loop': 'request',
+  classifier: 'auxiliary',
+  translate: 'auxiliary',
+  'query-expander': 'auxiliary',
+  helper: 'auxiliary',
+  embedding: 'initialization',
+};
+
+function emptyBucket(): TokenBucket {
+  return { promptTokens: 0, completionTokens: 0, totalTokens: 0, requests: 0 };
+}
+
+function addToBucket(bucket: TokenBucket, entry: LlmCallEntry): void {
+  bucket.promptTokens += entry.promptTokens;
+  bucket.completionTokens += entry.completionTokens;
+  bucket.totalTokens += entry.totalTokens;
+  bucket.requests++;
+}
+
 export class DefaultRequestLogger implements IRequestLogger {
-  private llmCalls: LlmCallEntry[] = [];
+  private initLlmCalls: LlmCallEntry[] = [];
+  private requestLlmCalls: LlmCallEntry[] = [];
   private ragQueryEntries: RagQueryEntry[] = [];
   private toolCallEntries: ToolCallEntry[] = [];
   private requestStartMs = 0;
   private requestDurationMs = 0;
 
   startRequest(): void {
-    this.reset();
+    this.requestLlmCalls = [];
+    this.ragQueryEntries = [];
+    this.toolCallEntries = [];
+    this.requestDurationMs = 0;
     this.requestStartMs = Date.now();
   }
 
@@ -25,7 +52,11 @@ export class DefaultRequestLogger implements IRequestLogger {
   }
 
   logLlmCall(entry: LlmCallEntry): void {
-    this.llmCalls.push(entry);
+    if (entry.scope === 'initialization') {
+      this.initLlmCalls.push(entry);
+    } else {
+      this.requestLlmCalls.push(entry);
+    }
   }
 
   logRagQuery(entry: RagQueryEntry): void {
@@ -37,42 +68,29 @@ export class DefaultRequestLogger implements IRequestLogger {
   }
 
   getSummary(): RequestSummary {
-    const byModel: RequestSummary['byModel'] = {};
-    const byComponent: RequestSummary['byComponent'] = {};
+    const byModel: Record<string, TokenBucket> = {};
+    const byComponent: Record<string, TokenBucket> = {};
+    const byCategory: Record<string, TokenBucket> = {};
 
-    for (const call of this.llmCalls) {
-      if (!byModel[call.model]) {
-        byModel[call.model] = {
-          promptTokens: 0,
-          completionTokens: 0,
-          totalTokens: 0,
-          requests: 0,
-        };
-      }
-      const m = byModel[call.model];
-      m.promptTokens += call.promptTokens;
-      m.completionTokens += call.completionTokens;
-      m.totalTokens += call.totalTokens;
-      m.requests++;
+    const allCalls = [...this.initLlmCalls, ...this.requestLlmCalls];
 
-      if (!byComponent[call.component]) {
-        byComponent[call.component] = {
-          promptTokens: 0,
-          completionTokens: 0,
-          totalTokens: 0,
-          requests: 0,
-        };
-      }
-      const c = byComponent[call.component];
-      c.promptTokens += call.promptTokens;
-      c.completionTokens += call.completionTokens;
-      c.totalTokens += call.totalTokens;
-      c.requests++;
+    for (const call of allCalls) {
+      if (!byModel[call.model]) byModel[call.model] = emptyBucket();
+      addToBucket(byModel[call.model], call);
+
+      if (!byComponent[call.component])
+        byComponent[call.component] = emptyBucket();
+      addToBucket(byComponent[call.component], call);
+
+      const cat = CATEGORY_MAP[call.component] ?? 'request';
+      if (!byCategory[cat]) byCategory[cat] = emptyBucket();
+      addToBucket(byCategory[cat], call);
     }
 
     return {
       byModel,
       byComponent,
+      byCategory,
       ragQueries: this.ragQueryEntries.length,
       toolCalls: this.toolCallEntries.length,
       totalDurationMs: this.requestDurationMs,
@@ -80,10 +98,11 @@ export class DefaultRequestLogger implements IRequestLogger {
   }
 
   reset(): void {
-    this.llmCalls = [];
+    this.requestLlmCalls = [];
     this.ragQueryEntries = [];
     this.toolCallEntries = [];
     this.requestStartMs = 0;
     this.requestDurationMs = 0;
+    // NOTE: initLlmCalls is intentionally NOT reset
   }
 }

--- a/src/smart-agent/logger/noop-request-logger.ts
+++ b/src/smart-agent/logger/noop-request-logger.ts
@@ -9,6 +9,7 @@ import type {
 const EMPTY_SUMMARY: RequestSummary = {
   byModel: {},
   byComponent: {},
+  byCategory: {},
   ragQueries: 0,
   toolCalls: 0,
   totalDurationMs: 0,
@@ -21,7 +22,7 @@ export class NoopRequestLogger implements IRequestLogger {
   startRequest(): void {}
   endRequest(): void {}
   getSummary(): RequestSummary {
-    return { ...EMPTY_SUMMARY, byModel: {}, byComponent: {} };
+    return { ...EMPTY_SUMMARY, byModel: {}, byComponent: {}, byCategory: {} };
   }
   reset(): void {}
 }

--- a/src/smart-agent/pipeline/handlers/tool-loop.ts
+++ b/src/smart-agent/pipeline/handlers/tool-loop.ts
@@ -456,6 +456,7 @@ export class ToolLoopHandler implements IStageHandler {
           usage,
           byComponent: summary.byComponent,
           byModel: summary.byModel,
+          byCategory: summary.byCategory,
         });
         timingLog.push({ phase: 'total', duration: Date.now() - loopStart });
         ctx.timing.push(...timingLog);
@@ -469,6 +470,7 @@ export class ToolLoopHandler implements IStageHandler {
               ...usage,
               models: ctx.requestLogger.getSummary().byModel,
               components: ctx.requestLogger.getSummary().byComponent,
+              categories: ctx.requestLogger.getSummary().byCategory,
             },
             timing: timingLog,
           },

--- a/src/smart-agent/providers.ts
+++ b/src/smart-agent/providers.ts
@@ -9,10 +9,12 @@
 import { AnthropicAgent } from '../agents/anthropic-agent.js';
 import { DeepSeekAgent } from '../agents/deepseek-agent.js';
 import { OpenAIAgent } from '../agents/openai-agent.js';
+import { SapAiCoreDirectAgent } from '../agents/sap-ai-core-direct-agent.js';
 import { SapCoreAIAgent } from '../agents/sap-core-ai-agent.js';
 import { AnthropicProvider } from '../llm-providers/anthropic.js';
 import { DeepSeekProvider } from '../llm-providers/deepseek.js';
 import { OpenAIProvider } from '../llm-providers/openai.js';
+import { SapAiCoreDirectProvider } from '../llm-providers/sap-ai-core-direct.js';
 import {
   type SapAICoreCredentials,
   SapCoreAIProvider,
@@ -32,7 +34,12 @@ import { VectorRag } from './rag/vector-rag.js';
 // ---------------------------------------------------------------------------
 
 export interface LlmProviderConfig {
-  provider: 'deepseek' | 'openai' | 'anthropic' | 'sap-ai-sdk';
+  provider:
+    | 'deepseek'
+    | 'openai'
+    | 'anthropic'
+    | 'sap-ai-sdk'
+    | 'sap-ai-core-direct';
   apiKey?: string;
   model?: string;
   temperature?: number;
@@ -123,6 +130,23 @@ export function makeLlm(cfg: LlmProviderConfig, temperature: number): ILlm {
         },
       });
       const agent = new SapCoreAIAgent({
+        llmProvider: provider,
+        mcpClient: dummyMcp,
+      });
+      return new LlmAdapter(agent, {
+        model: provider.model,
+        getModels: () => provider.getModels(),
+      });
+    }
+    case 'sap-ai-core-direct': {
+      const provider = new SapAiCoreDirectProvider({
+        apiKey: cfg.apiKey,
+        model: cfg.model,
+        temperature,
+        maxTokens,
+        resourceGroup: cfg.resourceGroup,
+      });
+      const agent = new SapAiCoreDirectAgent({
         llmProvider: provider,
         mcpClient: dummyMcp,
       });

--- a/src/smart-agent/rag/ollama-rag.ts
+++ b/src/smart-agent/rag/ollama-rag.ts
@@ -1,4 +1,4 @@
-import type { IEmbedder } from '../interfaces/rag.js';
+import type { IEmbedderBatch } from '../interfaces/rag.js';
 import { type CallOptions, RagError } from '../interfaces/types.js';
 import { VectorRag, type VectorRagConfig } from './vector-rag.js';
 
@@ -11,7 +11,7 @@ export interface OllamaEmbedderConfig {
   timeoutMs?: number;
 }
 
-export class OllamaEmbedder implements IEmbedder {
+export class OllamaEmbedder implements IEmbedderBatch {
   private readonly ollamaUrl: string;
   private readonly model: string;
   private readonly timeoutMs: number;
@@ -65,6 +65,54 @@ export class OllamaEmbedder implements IEmbedder {
     throw (
       lastError ||
       new RagError('Ollama embed failed after retries', 'EMBED_ERROR')
+    );
+  }
+
+  async embedBatch(
+    texts: string[],
+    options?: CallOptions,
+  ): Promise<number[][]> {
+    if (texts.length === 0) return [];
+
+    const url = `${this.ollamaUrl}/api/embed`;
+    let lastError: Error | undefined;
+    const maxRetries = 3;
+
+    for (let attempt = 0; attempt < maxRetries; attempt++) {
+      try {
+        const timeoutSignal = AbortSignal.timeout(this.timeoutMs);
+        const signal = options?.signal
+          ? AbortSignal.any([options.signal, timeoutSignal])
+          : timeoutSignal;
+
+        const res = await fetch(url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ model: this.model, input: texts }),
+          signal,
+        });
+
+        if (!res.ok) {
+          const errorText = await res.text();
+          throw new RagError(
+            `Ollama batch embed error: HTTP ${res.status} - ${errorText}`,
+            'EMBED_ERROR',
+          );
+        }
+
+        const json = (await res.json()) as { embeddings: number[][] };
+        return json.embeddings;
+      } catch (err: unknown) {
+        lastError = err instanceof Error ? err : new Error(String(err));
+        if (err instanceof Error && err.name === 'AbortError') throw err;
+        const delay = 500 * 2 ** attempt;
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+    }
+
+    throw (
+      lastError ||
+      new RagError('Ollama batch embed failed after retries', 'EMBED_ERROR')
     );
   }
 }

--- a/src/smart-agent/rag/openai-embedder.ts
+++ b/src/smart-agent/rag/openai-embedder.ts
@@ -1,4 +1,4 @@
-import type { IEmbedder } from '../interfaces/rag.js';
+import type { IEmbedderBatch } from '../interfaces/rag.js';
 import { type CallOptions, RagError } from '../interfaces/types.js';
 
 export interface OpenAiEmbedderConfig {
@@ -12,7 +12,7 @@ export interface OpenAiEmbedderConfig {
   timeoutMs?: number;
 }
 
-export class OpenAiEmbedder implements IEmbedder {
+export class OpenAiEmbedder implements IEmbedderBatch {
   private readonly baseURL: string;
   private readonly apiKey: string;
   private readonly model: string;
@@ -78,5 +78,70 @@ export class OpenAiEmbedder implements IEmbedder {
       lastError ||
       new RagError('OpenAI embed failed after retries', 'EMBED_ERROR')
     );
+  }
+
+  async embedBatch(
+    texts: string[],
+    options?: CallOptions,
+  ): Promise<number[][]> {
+    if (texts.length === 0) return [];
+
+    const chunkSize = 100;
+    const results: number[][] = new Array(texts.length);
+
+    for (let start = 0; start < texts.length; start += chunkSize) {
+      const chunk = texts.slice(start, start + chunkSize);
+      const url = `${this.baseURL}/embeddings`;
+      let lastError: Error | undefined;
+      const maxRetries = 3;
+
+      for (let attempt = 0; attempt < maxRetries; attempt++) {
+        try {
+          const timeoutSignal = AbortSignal.timeout(this.timeoutMs);
+          const signal = options?.signal
+            ? AbortSignal.any([options.signal, timeoutSignal])
+            : timeoutSignal;
+
+          const res = await fetch(url, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${this.apiKey}`,
+            },
+            body: JSON.stringify({ model: this.model, input: chunk }),
+            signal,
+          });
+
+          if (!res.ok) {
+            const errorText = await res.text();
+            throw new RagError(
+              `OpenAI batch embed error: HTTP ${res.status} - ${errorText}`,
+              'EMBED_ERROR',
+            );
+          }
+
+          const json = (await res.json()) as {
+            data: Array<{ embedding: number[]; index: number }>;
+          };
+          const sorted = json.data.sort((a, b) => a.index - b.index);
+          for (let i = 0; i < sorted.length; i++) {
+            results[start + i] = sorted[i].embedding;
+          }
+          lastError = undefined;
+          break;
+        } catch (err: unknown) {
+          lastError = err instanceof Error ? err : new Error(String(err));
+          if (err instanceof Error && err.name === 'AbortError') throw err;
+          const delay = 500 * 2 ** attempt;
+          await new Promise((resolve) => setTimeout(resolve, delay));
+        }
+      }
+
+      if (lastError) {
+        throw lastError;
+      }
+    }
+
+    return results;
   }
 }

--- a/src/smart-agent/rag/qdrant-rag.ts
+++ b/src/smart-agent/rag/qdrant-rag.ts
@@ -1,5 +1,5 @@
 import type { IQueryEmbedding } from '../interfaces/query-embedding.js';
-import type { IEmbedder, IRag } from '../interfaces/rag.js';
+import type { IEmbedder, IPrecomputedVectorRag } from '../interfaces/rag.js';
 import {
   type CallOptions,
   RagError,
@@ -30,7 +30,7 @@ export interface QdrantRagConfig {
   timeoutMs?: number;
 }
 
-export class QdrantRag implements IRag {
+export class QdrantRag implements IPrecomputedVectorRag {
   private readonly url: string;
   private readonly collectionName: string;
   private readonly embedder: IEmbedder;
@@ -110,16 +110,13 @@ export class QdrantRag implements IRag {
     this.collectionEnsured = true;
   }
 
-  async upsert(
+  private async upsertKnownVector(
     text: string,
+    vector: number[],
     metadata: RagMetadata,
     options?: CallOptions,
   ): Promise<Result<void, RagError>> {
-    if (options?.signal?.aborted) {
-      return { ok: false, error: new RagError('Aborted', 'ABORTED') };
-    }
     try {
-      const vector = await this.embedder.embed(text, options);
       await this._ensureCollection(vector.length, options?.signal);
 
       const pointId = metadata?.id
@@ -153,6 +150,35 @@ export class QdrantRag implements IRag {
       if (err instanceof RagError) return { ok: false, error: err };
       return { ok: false, error: new RagError(String(err), 'UPSERT_ERROR') };
     }
+  }
+
+  async upsert(
+    text: string,
+    metadata: RagMetadata,
+    options?: CallOptions,
+  ): Promise<Result<void, RagError>> {
+    if (options?.signal?.aborted) {
+      return { ok: false, error: new RagError('Aborted', 'ABORTED') };
+    }
+    try {
+      const vector = await this.embedder.embed(text, options);
+      return this.upsertKnownVector(text, vector, metadata, options);
+    } catch (err) {
+      if (err instanceof RagError) return { ok: false, error: err };
+      return { ok: false, error: new RagError(String(err), 'UPSERT_ERROR') };
+    }
+  }
+
+  async upsertPrecomputed(
+    text: string,
+    vector: number[],
+    metadata: RagMetadata,
+    options?: CallOptions,
+  ): Promise<Result<void, RagError>> {
+    if (options?.signal?.aborted) {
+      return { ok: false, error: new RagError('Aborted', 'ABORTED') };
+    }
+    return this.upsertKnownVector(text, vector, metadata, options);
   }
 
   async query(

--- a/src/smart-agent/rag/sap-ai-core-embedder.ts
+++ b/src/smart-agent/rag/sap-ai-core-embedder.ts
@@ -5,7 +5,7 @@
  * Authentication: reads AICORE_SERVICE_KEY env var automatically (same as LLM provider).
  */
 
-import type { IEmbedder } from '../interfaces/rag.js';
+import type { IEmbedderBatch } from '../interfaces/rag.js';
 import type { CallOptions } from '../interfaces/types.js';
 
 export interface SapAiCoreEmbedderConfig {
@@ -15,7 +15,7 @@ export interface SapAiCoreEmbedderConfig {
   resourceGroup?: string;
 }
 
-export class SapAiCoreEmbedder implements IEmbedder {
+export class SapAiCoreEmbedder implements IEmbedderBatch {
   private readonly model: string;
   private readonly resourceGroup?: string;
 
@@ -57,5 +57,44 @@ export class SapAiCoreEmbedder implements IEmbedder {
     }
 
     return embedding;
+  }
+
+  async embedBatch(
+    texts: string[],
+    _options?: CallOptions,
+  ): Promise<number[][]> {
+    if (texts.length === 0) return [];
+
+    const { OrchestrationEmbeddingClient } = await import(
+      '@sap-ai-sdk/orchestration'
+    );
+
+    const modelName = this
+      .model as unknown as import('@sap-ai-sdk/orchestration').EmbeddingModel;
+    const client = new OrchestrationEmbeddingClient(
+      { embeddings: { model: { name: modelName } } },
+      this.resourceGroup ? { resourceGroup: this.resourceGroup } : undefined,
+    );
+
+    const response = await client.embed({ input: texts });
+    const embeddings = response.getEmbeddings();
+
+    if (!embeddings || embeddings.length === 0) {
+      throw new Error('No embeddings returned from SAP AI Core batch');
+    }
+
+    const sorted = [...embeddings].sort((a, b) => a.index - b.index);
+    return sorted.map((e) => {
+      if (typeof e.embedding === 'string') {
+        const buffer = Buffer.from(e.embedding, 'base64');
+        const float32 = new Float32Array(
+          buffer.buffer,
+          buffer.byteOffset,
+          buffer.length / 4,
+        );
+        return Array.from(float32);
+      }
+      return e.embedding;
+    });
   }
 }

--- a/src/smart-agent/rag/vector-rag.ts
+++ b/src/smart-agent/rag/vector-rag.ts
@@ -1,5 +1,5 @@
 import type { IQueryEmbedding } from '../interfaces/query-embedding.js';
-import type { IEmbedder, IRag } from '../interfaces/rag.js';
+import type { IEmbedder, IPrecomputedVectorRag } from '../interfaces/rag.js';
 import {
   type CallOptions,
   RagError,
@@ -27,7 +27,7 @@ export interface VectorRagConfig {
   keywordWeight?: number;
 }
 
-export class VectorRag implements IRag {
+export class VectorRag implements IPrecomputedVectorRag {
   private records: StoredRecord[] = [];
   private readonly index = new InvertedIndex();
   private readonly dedupThreshold: number;
@@ -107,6 +107,48 @@ export class VectorRag implements IRag {
     return Math.min(score / 5, 1.0);
   }
 
+  private upsertKnownVector(
+    text: string,
+    vector: number[],
+    metadata: RagMetadata,
+  ): Result<void, RagError> {
+    const newTokens = this.tokenize(text);
+
+    // Idempotent upsert: if metadata.id matches, replace in-place
+    if (metadata.id) {
+      for (let i = 0; i < this.records.length; i++) {
+        if (this.records[i].metadata.id === metadata.id) {
+          const oldTokens = this.tokenize(this.records[i].text);
+          this.records[i].text = text;
+          this.records[i].vector = vector;
+          this.records[i].metadata = {
+            ...this.records[i].metadata,
+            ...metadata,
+          };
+          this.index.update(i, oldTokens, newTokens);
+          return { ok: true, value: undefined };
+        }
+      }
+    }
+
+    for (let i = 0; i < this.records.length; i++) {
+      const rec = this.records[i];
+      if (this.cosine(rec.vector, vector) >= this.dedupThreshold) {
+        const oldTokens = this.tokenize(rec.text);
+        rec.text = text;
+        rec.vector = vector;
+        rec.metadata = { ...rec.metadata, ...metadata };
+        this.index.update(i, oldTokens, newTokens);
+        return { ok: true, value: undefined };
+      }
+    }
+
+    const docIdx = this.records.length;
+    this.records.push({ text, vector, metadata });
+    this.index.add(docIdx, newTokens);
+    return { ok: true, value: undefined };
+  }
+
   async upsert(
     text: string,
     metadata: RagMetadata,
@@ -126,41 +168,21 @@ export class VectorRag implements IRag {
 
     try {
       const vector = await this.embedder.embed(text, options);
-      const newTokens = this.tokenize(text);
+      return this.upsertKnownVector(text, vector, metadata);
+    } catch (err) {
+      if (err instanceof RagError) return { ok: false, error: err };
+      return { ok: false, error: new RagError(String(err), 'UPSERT_ERROR') };
+    }
+  }
 
-      // Idempotent upsert: if metadata.id matches, replace in-place
-      if (metadata.id) {
-        for (let i = 0; i < this.records.length; i++) {
-          if (this.records[i].metadata.id === metadata.id) {
-            const oldTokens = this.tokenize(this.records[i].text);
-            this.records[i].text = text;
-            this.records[i].vector = vector;
-            this.records[i].metadata = {
-              ...this.records[i].metadata,
-              ...metadata,
-            };
-            this.index.update(i, oldTokens, newTokens);
-            return { ok: true, value: undefined };
-          }
-        }
-      }
-
-      for (let i = 0; i < this.records.length; i++) {
-        const rec = this.records[i];
-        if (this.cosine(rec.vector, vector) >= this.dedupThreshold) {
-          const oldTokens = this.tokenize(rec.text);
-          rec.text = text;
-          rec.vector = vector;
-          rec.metadata = { ...rec.metadata, ...metadata };
-          this.index.update(i, oldTokens, newTokens);
-          return { ok: true, value: undefined };
-        }
-      }
-
-      const docIdx = this.records.length;
-      this.records.push({ text, vector, metadata });
-      this.index.add(docIdx, newTokens);
-      return { ok: true, value: undefined };
+  async upsertPrecomputed(
+    text: string,
+    vector: number[],
+    metadata: RagMetadata,
+    _options?: CallOptions,
+  ): Promise<Result<void, RagError>> {
+    try {
+      return this.upsertKnownVector(text, vector, metadata);
     } catch (err) {
       if (err instanceof RagError) return { ok: false, error: err };
       return { ok: false, error: new RagError(String(err), 'UPSERT_ERROR') };

--- a/src/smart-agent/resilience/circuit-breaker-embedder.ts
+++ b/src/smart-agent/resilience/circuit-breaker-embedder.ts
@@ -5,7 +5,8 @@
  * underlying embedding service.
  */
 
-import type { IEmbedder } from '../interfaces/rag.js';
+import type { IEmbedder, IEmbedderBatch } from '../interfaces/rag.js';
+import { isBatchEmbedder } from '../interfaces/rag.js';
 import type { CallOptions } from '../interfaces/types.js';
 import { RagError } from '../interfaces/types.js';
 import type { CircuitBreaker } from './circuit-breaker.js';
@@ -22,6 +23,29 @@ export class CircuitBreakerEmbedder implements IEmbedder {
     }
     try {
       const result = await this.inner.embed(text, options);
+      this.breaker.recordSuccess();
+      return result;
+    } catch (err) {
+      this.breaker.recordFailure();
+      throw err;
+    }
+  }
+
+  async embedBatch(
+    texts: string[],
+    options?: CallOptions,
+  ): Promise<number[][]> {
+    if (!this.breaker.isCallPermitted) {
+      throw new RagError('Embedder circuit breaker is open', 'CIRCUIT_OPEN');
+    }
+    if (!isBatchEmbedder(this.inner)) {
+      throw new RagError(
+        'Inner embedder does not support batch embedding',
+        'EMBED_ERROR',
+      );
+    }
+    try {
+      const result = await this.inner.embedBatch(texts, options);
       this.breaker.recordSuccess();
       return result;
     } catch (err) {

--- a/src/smart-agent/resilience/circuit-breaker-embedder.ts
+++ b/src/smart-agent/resilience/circuit-breaker-embedder.ts
@@ -5,7 +5,7 @@
  * underlying embedding service.
  */
 
-import type { IEmbedder, IEmbedderBatch } from '../interfaces/rag.js';
+import type { IEmbedder } from '../interfaces/rag.js';
 import { isBatchEmbedder } from '../interfaces/rag.js';
 import type { CallOptions } from '../interfaces/types.js';
 import { RagError } from '../interfaces/types.js';

--- a/src/smart-agent/resilience/fallback-rag.ts
+++ b/src/smart-agent/resilience/fallback-rag.ts
@@ -9,6 +9,7 @@
 
 import type { IQueryEmbedding } from '../interfaces/query-embedding.js';
 import type { IRag } from '../interfaces/rag.js';
+import { supportsPrecomputed } from '../interfaces/rag.js';
 import type {
   CallOptions,
   RagError,
@@ -46,6 +47,28 @@ export class FallbackRag implements IRag {
       return this.fallback.query(embedding, k, options);
     }
     return this.primary.query(embedding, k, options);
+  }
+
+  async upsertPrecomputed(
+    text: string,
+    vector: number[],
+    metadata: RagMetadata,
+    options?: CallOptions,
+  ): Promise<Result<void, RagError>> {
+    const primaryResult = supportsPrecomputed(this.primary)
+      ? await this.primary.upsertPrecomputed(text, vector, metadata, options)
+      : await this.primary.upsert(text, metadata, options);
+
+    // Best-effort write to fallback
+    if (supportsPrecomputed(this.fallback)) {
+      this.fallback
+        .upsertPrecomputed(text, vector, metadata, options)
+        .catch(() => {});
+    } else {
+      this.fallback.upsert(text, metadata, options).catch(() => {});
+    }
+
+    return primaryResult;
   }
 
   async healthCheck(options?: CallOptions): Promise<Result<void, RagError>> {

--- a/src/smart-agent/smart-server.ts
+++ b/src/smart-agent/smart-server.ts
@@ -177,6 +177,8 @@ export interface SmartServerConfig {
   apiAdapters?: ILlmApiAdapter[];
   /** Disable built-in adapter auto-registration. Default: false. */
   disableBuiltInAdapters?: boolean;
+  /** Skip startup model validation (useful for testing). Default: false. */
+  skipModelValidation?: boolean;
 }
 
 export interface SmartServerHandle {
@@ -374,6 +376,7 @@ export class SmartServer {
       mcp: pipeline?.mcp ?? this.cfg.mcp,
       agent: this.cfg.agent,
       prompts: this.cfg.prompts,
+      skipModelValidation: this.cfg.skipModelValidation,
     })
       .withMainLlm(mainLlm)
       .withClassifierLlm(classifierLlm)


### PR DESCRIPTION
## Summary

- **#53 Token categorization**: `TokenBucket`, `TokenCategory` (`initialization`/`auxiliary`/`request`), `byCategory` in `RequestSummary`. `DefaultRequestLogger` splits init/request storage — initialization tokens survive `startRequest()` resets. `LlmCallEntry` extended with `estimated`, `scope`, `detail` fields. Embedding tokens logged during tool/skill vectorization with `estimated: true`.
- **#52 Batch embedding**: `IEmbedderBatch` interface with `embedBatch()` implemented for OpenAI (chunked at 100), Ollama (`/api/embed`), SAP AI Core. `IPrecomputedVectorRag` with `upsertPrecomputed()` for VectorRag/QdrantRag (shared `upsertKnownVector` write path). Builder uses batch path when available, falls back to sequential with throttling.
- **#54 SAP AI Core Direct**: New `SapAiCoreDirectProvider` using `resolveDeploymentUrl()` + raw OpenAI-compatible HTTP, bypassing OrchestrationClient overhead (~14K phantom tokens). Registered as `sap-ai-core-direct` provider in `makeLlm` factory.
- **Test fix**: Added `skipModelValidation` option to `SmartAgentBuilderConfig`/`SmartServerConfig` — fixes 3 pre-existing test failures in `smart-server-api-adapters.test.ts`.

## Test plan

- [x] `request-logger.test.ts` — 4 tests for byCategory, init/request split, scope routing
- [x] All existing tests pass (118/118, 0 fail)
- [x] Build passes (`npm run build`)
- [x] Lint passes (`npm run lint:check`)
- [ ] Manual: verify batch embedding startup with Ollama/OpenAI embedder
- [ ] Manual: verify `sap-ai-core-direct` provider with SAP AI Core deployment

Closes #52, closes #53, closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)