### PR TITLE
fix(#55): log SSE stream disconnect cause error

### DIFF
--- a/src/llm-providers/sap-core-ai.ts
+++ b/src/llm-providers/sap-core-ai.ts
@@ -204,7 +204,13 @@ export class SapCoreAIProvider extends BaseLLMProvider<SapCoreAIConfig> {
       }
     } catch (error: unknown) {
       const detail = SapCoreAIProvider.extractErrorDetail(error);
-      this.log?.error('SAP AI SDK streaming error', { error: detail });
+      // biome-ignore lint/suspicious/noExplicitAny: ErrorWithCause shape from @sap-ai-sdk/core
+      const cause = (error as any)?.cause;
+      this.log?.error('SAP AI SDK streaming error', {
+        error: detail,
+        cause: cause?.message || cause,
+        causeCode: cause?.code,
+      });
       throw new Error(`SAP AI SDK streaming error: ${detail}`);
     } finally {
       this.modelOverride = undefined;


### PR DESCRIPTION
## Summary

- Log the original `cause` error from `@sap-ai-sdk/core` `ErrorWithCause` in `SapCoreAIProvider.streamChat()` catch block
- Now logs `cause.message` and `cause.code` (e.g. `ECONNRESET`, `ETIMEDOUT`) for diagnosing SSE stream disconnects

## Test plan

- [x] Build passes
- [x] Lint passes
- [ ] Deploy and reproduce SSE disconnect — verify cause error appears in logs

Refs #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)