### PR TITLE
feat(#58): IToolResultCompactor strategy for tool-loop history compaction

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -159,6 +159,7 @@ export type {
   ISkillMeta,
   ISkillResource,
 } from './smart-agent/interfaces/skill.js';
+export type { IToolResultCompactor } from './smart-agent/interfaces/tool-result-compactor.js';
 // Smart Agent shared types (needed by plugin authors)
 export type {
   CallOptions,
@@ -216,6 +217,7 @@ export {
   loadPlugins,
   mergePluginExports,
 } from './smart-agent/plugins/index.js';
+export { TruncatingToolResultCompactor } from './smart-agent/policy/truncating-tool-result-compactor.js';
 export {
   type EmbedderResolutionConfig,
   type EmbedderResolutionOptions,

--- a/src/smart-agent/agent.ts
+++ b/src/smart-agent/agent.ts
@@ -13,6 +13,7 @@ import type { IMcpConnectionStrategy } from './interfaces/mcp-connection-strateg
 import type { IEmbedder, IRag } from './interfaces/rag.js';
 import type { IRequestLogger } from './interfaces/request-logger.js';
 import type { ISkillManager } from './interfaces/skill.js';
+import type { IToolResultCompactor } from './interfaces/tool-result-compactor.js';
 import type {
   CallOptions,
   LlmFinishReason,
@@ -105,6 +106,7 @@ export interface SmartAgentDeps {
   connectionStrategy?: IMcpConnectionStrategy;
   historyMemory?: IHistoryMemory;
   historySummarizer?: IHistorySummarizer;
+  toolResultCompactor?: IToolResultCompactor;
 }
 export interface SmartAgentConfig {
   maxIterations: number;
@@ -1817,6 +1819,7 @@ export class SmartAgent {
       embedder: this.deps.embedder,
       historyMemory: this.deps.historyMemory,
       historySummarizer: this.deps.historySummarizer,
+      toolResultCompactor: this.deps.toolResultCompactor,
 
       // Mutable state
       inputText: text,

--- a/src/smart-agent/builder.ts
+++ b/src/smart-agent/builder.ts
@@ -48,6 +48,7 @@ import {
 } from './interfaces/rag.js';
 import type { IRequestLogger } from './interfaces/request-logger.js';
 import type { ISkillManager } from './interfaces/skill.js';
+import type { IToolResultCompactor } from './interfaces/tool-result-compactor.js';
 import { DefaultRequestLogger } from './logger/default-request-logger.js';
 import type { ILogger } from './logger/types.js';
 import type { IMetrics } from './metrics/types.js';
@@ -198,6 +199,7 @@ export class SmartAgentBuilder {
   private _connectionStrategy?: IMcpConnectionStrategy;
   private _historySummarizer?: IHistorySummarizer;
   private _historyMemory?: IHistoryMemory;
+  private _toolResultCompactor?: IToolResultCompactor;
 
   constructor(cfg: SmartAgentBuilderConfig = {}) {
     this.cfg = cfg;
@@ -372,6 +374,12 @@ export class SmartAgentBuilder {
   /** Override the history summarizer used for semantic history compression. */
   withHistorySummarizer(summarizer: IHistorySummarizer): this {
     this._historySummarizer = summarizer;
+    return this;
+  }
+
+  /** Set a strategy for compacting old tool results in tool-loop history. */
+  withToolResultCompactor(compactor: IToolResultCompactor): this {
+    this._toolResultCompactor = compactor;
     return this;
   }
 
@@ -1027,6 +1035,9 @@ export class SmartAgentBuilder {
         ...(connectionStrategy ? { connectionStrategy } : {}),
         ...(historyMemory ? { historyMemory } : {}),
         ...(historySummarizer ? { historySummarizer } : {}),
+        ...(this._toolResultCompactor
+          ? { toolResultCompactor: this._toolResultCompactor }
+          : {}),
         requestLogger,
       },
       agentCfg,

--- a/src/smart-agent/interfaces/tool-result-compactor.ts
+++ b/src/smart-agent/interfaces/tool-result-compactor.ts
@@ -1,0 +1,11 @@
+import type { Message } from '../../types.js';
+
+/**
+ * Strategy for compacting tool results in tool-loop message history.
+ *
+ * Called before each LLM iteration (after the first) to reduce payload size.
+ * Implementations decide which tool results to keep full and which to truncate.
+ */
+export interface IToolResultCompactor {
+  compact(messages: Message[], currentIteration: number): Message[];
+}

--- a/src/smart-agent/pipeline/context.ts
+++ b/src/smart-agent/pipeline/context.ts
@@ -33,6 +33,7 @@ import type { IQueryEmbedding } from '../interfaces/query-embedding.js';
 import type { IEmbedder } from '../interfaces/rag.js';
 import type { IRequestLogger } from '../interfaces/request-logger.js';
 import type { ISkill, ISkillManager } from '../interfaces/skill.js';
+import type { IToolResultCompactor } from '../interfaces/tool-result-compactor.js';
 import type {
   CallOptions,
   LlmStreamChunk,
@@ -96,6 +97,7 @@ export interface PipelineContext {
   readonly embedder: IEmbedder | undefined;
   readonly historyMemory: IHistoryMemory | undefined;
   readonly historySummarizer: IHistorySummarizer | undefined;
+  readonly toolResultCompactor: IToolResultCompactor | undefined;
 
   // -- Mutable state (populated by stages) ----------------------------------
 

--- a/src/smart-agent/pipeline/handlers/tool-loop.ts
+++ b/src/smart-agent/pipeline/handlers/tool-loop.ts
@@ -305,6 +305,11 @@ export class ToolLoopHandler implements IStageHandler {
       let iterCompletionTokens = 0;
       let iterTotalTokens = 0;
 
+      // Compact old tool results to prevent payload overflow on later iterations
+      if (iteration > 0 && ctx.toolResultCompactor) {
+        messages = ctx.toolResultCompactor.compact(messages, iteration);
+      }
+
       ctx.options?.sessionLogger?.logStep(`llm_request_iter_${iteration + 1}`, {
         messages,
         tools: currentTools,

--- a/src/smart-agent/policy/truncating-tool-result-compactor.ts
+++ b/src/smart-agent/policy/truncating-tool-result-compactor.ts
@@ -1,0 +1,45 @@
+import type { Message } from '../../types.js';
+import type { IToolResultCompactor } from '../interfaces/tool-result-compactor.js';
+
+/**
+ * Keeps the last `keep` tool-result messages at full length.
+ * Older tool results exceeding `threshold` chars are truncated to `previewLength`
+ * chars with a truncation notice.
+ */
+export class TruncatingToolResultCompactor implements IToolResultCompactor {
+  private readonly keep: number;
+  private readonly threshold: number;
+  private readonly previewLength: number;
+
+  constructor(opts?: {
+    keep?: number;
+    threshold?: number;
+    previewLength?: number;
+  }) {
+    this.keep = opts?.keep ?? 3;
+    this.threshold = opts?.threshold ?? 300;
+    this.previewLength = opts?.previewLength ?? 200;
+  }
+
+  compact(messages: Message[], _currentIteration: number): Message[] {
+    const toolIndices: number[] = [];
+    for (let i = 0; i < messages.length; i++) {
+      if (messages[i].role === 'tool') {
+        toolIndices.push(i);
+      }
+    }
+
+    if (toolIndices.length <= this.keep) return messages;
+
+    const cutoff = toolIndices[toolIndices.length - this.keep];
+    const compactSet = new Set(toolIndices.filter((idx) => idx < cutoff));
+
+    return messages.map((msg, i) => {
+      if (!compactSet.has(i)) return msg;
+      const text = typeof msg.content === 'string' ? msg.content : '';
+      if (text.length <= this.threshold) return msg;
+      const summary = `${text.slice(0, this.previewLength)}\n… [truncated, ${text.length} chars total]`;
+      return { ...msg, content: summary };
+    });
+  }
+}


### PR DESCRIPTION
## Summary

- New `IToolResultCompactor` interface — strategy for compacting old tool results in tool-loop message history
- Default `TruncatingToolResultCompactor` — keeps last N (default 3) tool results full, truncates older ones to 200 chars with notice
- Injected via `builder.withToolResultCompactor()` — fully optional, no compaction when not configured
- Tool-loop calls `compactor.compact(messages, iteration)` before each LLM call (iteration > 0)

Prevents SAP AI Core HTTP 500 when large tool results (e.g. 5KB XML from SearchObject) accumulate across tool-loop iterations.

## Test plan

- [x] Build passes
- [x] Lint passes
- [x] All 118 tests pass
- [ ] Manual: verify with SearchObject returning large XML — iteration 2+ should no longer 500

Refs #58, refs #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)