### PR TITLE
fix(#69): ContextAssembler recency window for client history

### DIFF
--- a/src/smart-agent/builder.ts
+++ b/src/smart-agent/builder.ts
@@ -905,6 +905,7 @@ export class SmartAgentBuilder {
       maxTokens: agentCfg.contextBudgetTokens,
       showReasoning: agentCfg.showReasoning,
       reasoningInstruction: this.cfg.prompts?.reasoning,
+      historyRecencyWindow: agentCfg.historyRecencyWindow,
     };
     if (this.cfg.prompts?.system)
       assemblerCfg.systemPromptPreamble = this.cfg.prompts.system;

--- a/src/smart-agent/config.ts
+++ b/src/smart-agent/config.ts
@@ -72,7 +72,7 @@ agent:
   ragQueryK: 10
   # contextBudgetTokens: 4000          # Max tokens for RAG context in system prompt (0 = no limit)
   # semanticHistoryEnabled: false      # Enable semantic history via RAG
-  # historyRecencyWindow: 3            # Last N turns always in context
+  # historyRecencyWindow: 4            # Last N messages from client history in LLM context
   # historyTurnSummaryPrompt: "..."    # LLM prompt for turn summarization
   showReasoning: false                # Explain strategy at start of response
   historyAutoSummarizeLimit: 10       # History length to trigger compression

--- a/src/smart-agent/context/context-assembler.ts
+++ b/src/smart-agent/context/context-assembler.ts
@@ -39,6 +39,13 @@ export interface ContextAssemblerConfig {
    * Unknown keys are title-cased automatically.
    */
   sectionHeaders?: Record<string, string>;
+  /**
+   * Maximum number of recent messages to include from client history.
+   * Only the last N non-system messages are passed to the LLM.
+   * Older messages are excluded — they are available via RAG if needed.
+   * When undefined, all messages are included (backward compatible).
+   */
+  historyRecencyWindow?: number;
 }
 
 export const DEFAULT_REASONING_INSTRUCTION = `IMPORTANT: Always start your response with a brief <reasoning> block.
@@ -182,6 +189,7 @@ export class ContextAssembler implements IContextAssembler {
   private readonly showReasoning: boolean;
   private readonly reasoningInstruction: string | undefined;
   private readonly sectionHeaders: Record<string, string>;
+  private readonly historyRecencyWindow: number | undefined;
 
   constructor(config?: ContextAssemblerConfig) {
     this.maxTokens = config?.maxTokens;
@@ -193,6 +201,7 @@ export class ContextAssembler implements IContextAssembler {
       ...DEFAULT_SECTION_HEADERS,
       ...config?.sectionHeaders,
     };
+    this.historyRecencyWindow = config?.historyRecencyWindow;
   }
 
   async assemble(
@@ -268,8 +277,16 @@ export class ContextAssembler implements IContextAssembler {
         }
       }
 
-      if (regularMessages.length > 0) {
-        messages.push(...regularMessages);
+      // Apply recency window — keep only the last N messages from client history.
+      // Older messages are excluded; they are available via RAG stores if needed.
+      const windowedMessages =
+        this.historyRecencyWindow !== undefined &&
+        regularMessages.length > this.historyRecencyWindow
+          ? regularMessages.slice(-this.historyRecencyWindow)
+          : regularMessages;
+
+      if (windowedMessages.length > 0) {
+        messages.push(...windowedMessages);
       } else {
         messages.push({ role: 'user', content: action.text });
       }


### PR DESCRIPTION
## Summary

- `ContextAssembler` now applies `historyRecencyWindow` — only last N non-system messages from client history are included in LLM context
- Older messages excluded; available via RAG stores if needed
- Backward compatible — when not set, all messages included (existing behavior)
- YAML: `agent.historyRecencyWindow: 4`

Prevents LLM from re-processing old context (e.g. re-analyzing a dump when user just asks "show me that program").

## Test plan

- [x] Build passes
- [x] Lint passes  
- [x] 118/118 tests pass
- [ ] Manual: verify multi-turn conversation with historyRecencyWindow set

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)