### PR TITLE
fix(#71): configurable health check timeout + healthCheck proxy in ILlm decorators

### DIFF
--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -1062,16 +1062,30 @@ pipeline:
 
 `makeLlm()` forwards `baseURL` to `OpenAIProvider`, `AnthropicProvider`, and `DeepSeekProvider`. When omitted, each provider uses its default API URL.
 
-### Health check timeout (`healthTimeoutMs`)
+### Health Check Timeout
 
-`SmartAgent.healthCheck()` probes LLM, RAG, and MCP with a single timeout. The default is 5 000 ms, which may be too short for slow providers (SAP AI Core Orchestration typically takes 5–8 s).
+The `/v1/health` endpoint runs LLM, RAG, and MCP probes under a shared timeout. The default is 5000 ms. For providers with high latency (e.g., SAP AI Core Orchestration with OAuth), increase the timeout:
+
+**YAML:**
 
 ```yaml
 agent:
-  healthTimeoutMs: 15000   # 15 s — recommended for SAP AI Core
+  healthTimeoutMs: 15000
 ```
 
-`NonStreamingLlm` now proxies `healthCheck()` to the inner LLM, so the lightweight `getModels()` path is used instead of the `chat('ping')` fallback.
+**Builder:**
+
+```typescript
+new SmartAgentBuilder()
+  .withHealthTimeout(15_000)
+  .build();
+```
+
+All ILlm decorators (`NonStreamingLlm`, `RetryLlm`, `CircuitBreakerLlm`, `RateLimiterLlm`) now proxy `healthCheck()` to the inner LLM, so the lightweight `getModels()` path is used instead of the `chat('ping')` fallback.
+
+> **Note:** When increasing `healthTimeoutMs`, ensure that Kubernetes readiness/liveness probe `timeoutSeconds` and load balancer health check timeouts are also adjusted accordingly. The infrastructure timeout must be greater than `healthTimeoutMs` to avoid false negatives.
+
+> **Verification:** Unit tests cover timeout configuration and signal merging, but they use fast in-memory stubs. After changing `healthTimeoutMs` in production, manually verify `/v1/health` against your actual provider to confirm the timeout is sufficient. For SAP AI Core, a cold-start health check (first call after deploy, when the OAuth token is not yet cached) is the slowest path — test that scenario specifically.
 
 ## ILlmRateLimiter — Rate Limiting
 
@@ -1267,6 +1281,7 @@ const handle = await new SmartAgentBuilder({
   .withQueryExpansion(true)          // expand queries with synonyms
   .withShowReasoning(false)
   .withHeartbeatInterval(3000)
+  .withHealthTimeout(15_000)           // health check probe timeout (default: 5000)
   .build();
 
 // Use the agent

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcp-abap-adt/llm-agent",
-  "version": "5.17.0",
+  "version": "5.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/llm-agent",
-      "version": "5.17.0",
+      "version": "5.18.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.28.0",
@@ -17,7 +17,8 @@
       },
       "bin": {
         "claude-via-agent": "tools/claude-via-agent.sh",
-        "llm-agent": "dist/smart-agent/cli.js"
+        "llm-agent": "dist/smart-agent/cli.js",
+        "llm-agent-check": "dist/smart-agent/check-models-cli.js"
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.9",

--- a/src/smart-agent/adapters/non-streaming-llm.ts
+++ b/src/smart-agent/adapters/non-streaming-llm.ts
@@ -30,13 +30,6 @@ export class NonStreamingLlm implements ILlm {
     return this.inner.model;
   }
 
-  async healthCheck(options?: CallOptions): Promise<Result<boolean, LlmError>> {
-    if (this.inner.healthCheck) {
-      return this.inner.healthCheck(options);
-    }
-    return { ok: true, value: true };
-  }
-
   chat(
     messages: Message[],
     tools?: LlmTool[],

--- a/src/smart-agent/adapters/non-streaming-llm.ts
+++ b/src/smart-agent/adapters/non-streaming-llm.ts
@@ -18,7 +18,13 @@ import type {
 } from '../interfaces/types.js';
 
 export class NonStreamingLlm implements ILlm {
-  constructor(private readonly inner: ILlm) {}
+  healthCheck?: ILlm['healthCheck'];
+
+  constructor(private readonly inner: ILlm) {
+    if (inner.healthCheck) {
+      this.healthCheck = inner.healthCheck.bind(inner);
+    }
+  }
 
   get model(): string | undefined {
     return this.inner.model;

--- a/src/smart-agent/agent.ts
+++ b/src/smart-agent/agent.ts
@@ -132,7 +132,7 @@ export interface SmartAgentConfig {
   sessionTokenBudget?: number;
   /** Interval (ms) for SSE heartbeat comments during MCP tool execution. Default: 5000. */
   heartbeatIntervalMs?: number;
-  /** Timeout (ms) for health check probes (LLM, RAG, MCP). Default: 5000. Increase for slow providers (e.g. SAP AI Core). */
+  /** Timeout (ms) for health-check probes (LLM, RAG, MCP). Default: 5000. */
   healthTimeoutMs?: number;
 
   // -- Pipeline stage toggles -----------------------------------------------
@@ -279,11 +279,13 @@ export class SmartAgent {
       OrchestratorError
     >
   > {
-    const healthTimeoutMs = this.config.healthTimeoutMs ?? 5_000;
-    const healthSignal = AbortSignal.timeout(healthTimeoutMs);
+    const HEALTH_TIMEOUT_MS = this.config.healthTimeoutMs ?? 5_000;
+    const { signal: timeoutSignal, clear: clearTimeout_ } =
+      createTimeoutSignal(HEALTH_TIMEOUT_MS);
+    const merged = mergeSignals(timeoutSignal, options?.signal);
     const healthOptions: CallOptions = {
       ...options,
-      signal: healthSignal,
+      signal: merged.signal,
       maxTokens: 1,
     };
 
@@ -359,6 +361,7 @@ export class SmartAgent {
     } catch {
       // AbortSignal timeout — leave mcp as empty
     }
+    clearTimeout_();
     return { ok: true, value: results };
   }
 

--- a/src/smart-agent/builder.ts
+++ b/src/smart-agent/builder.ts
@@ -450,6 +450,12 @@ export class SmartAgentBuilder {
     return this;
   }
 
+  /** Set the health check probe timeout in milliseconds. Default: 5000. */
+  withHealthTimeout(ms: number): this {
+    this._agentOverrides.healthTimeoutMs = ms;
+    return this;
+  }
+
   /** Enable or disable the classification pipeline stage. When disabled, input is treated as a single action. */
   withClassification(enabled: boolean): this {
     this._agentOverrides.classificationEnabled = enabled;

--- a/src/smart-agent/config.ts
+++ b/src/smart-agent/config.ts
@@ -87,6 +87,7 @@ agent:
   # llmCallStrategy: streaming       # streaming | non-streaming | fallback
   # streamMode: full                 # full | final — streaming behavior for tool loops
   # heartbeatIntervalMs: 5000       # SSE heartbeat interval during tool execution (ms)
+  # healthTimeoutMs: 5000            # Health check probe timeout (ms); increase for slow providers (SAP AI Core: 15000)
   # retry:                           # LLM retry config for 429/5xx errors
   #   maxAttempts: 3
   #   backoffMs: 1000
@@ -443,6 +444,11 @@ export function resolveSmartServerConfig(
             heartbeatIntervalMs: Number(
               get(yaml, 'agent', 'heartbeatIntervalMs'),
             ),
+          }
+        : {}),
+      ...(get(yaml, 'agent', 'healthTimeoutMs') !== undefined
+        ? {
+            healthTimeoutMs: Number(get(yaml, 'agent', 'healthTimeoutMs')),
           }
         : {}),
       ...(get(yaml, 'agent', 'retry') !== undefined

--- a/src/smart-agent/health/__tests__/health-timeout.test.ts
+++ b/src/smart-agent/health/__tests__/health-timeout.test.ts
@@ -2,8 +2,38 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import { SmartAgent } from '../../agent.js';
 import type { ILlm } from '../../interfaces/llm.js';
+import type {
+  CallOptions,
+  LlmResponse,
+  LlmStreamChunk,
+  Result,
+} from '../../interfaces/types.js';
 import { LlmError } from '../../interfaces/types.js';
 import { makeDefaultDeps } from '../../testing/index.js';
+
+function makeSlowLlm(delayMs: number): ILlm {
+  return {
+    async chat(): Promise<Result<LlmResponse, LlmError>> {
+      await new Promise((r) => setTimeout(r, delayMs));
+      return { ok: true, value: { content: 'pong', finishReason: 'stop' } };
+    },
+    async *streamChat(): AsyncIterable<Result<LlmStreamChunk, LlmError>> {
+      yield { ok: true, value: { content: 'pong', finishReason: 'stop' } };
+    },
+    async healthCheck(
+      options?: CallOptions,
+    ): Promise<Result<boolean, LlmError>> {
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(resolve, delayMs);
+        options?.signal?.addEventListener('abort', () => {
+          clearTimeout(timer);
+          reject(new DOMException('Aborted', 'AbortError'));
+        });
+      });
+      return { ok: true, value: true };
+    },
+  };
+}
 
 describe('SmartAgent.healthCheck — configurable timeout', () => {
   it('uses default 5000ms when healthTimeoutMs is not set', async () => {
@@ -60,5 +90,28 @@ describe('SmartAgent.healthCheck — configurable timeout', () => {
     assert.ok(result.ok);
     // LLM probe should fail because the signal is already aborted
     assert.equal(result.value.llm, false);
+  });
+});
+
+describe('SmartAgent.healthCheck — slow provider simulation', () => {
+  it('times out with default 5000ms when provider takes 6s', async () => {
+    const { deps } = makeDefaultDeps();
+    deps.mainLlm = makeSlowLlm(6_000);
+    const agent = new SmartAgent(deps, { maxIterations: 5 });
+    const result = await agent.healthCheck();
+    assert.ok(result.ok);
+    assert.equal(result.value.llm, false); // timed out
+  });
+
+  it('succeeds with healthTimeoutMs: 15000 when provider takes 6s', async () => {
+    const { deps } = makeDefaultDeps();
+    deps.mainLlm = makeSlowLlm(6_000);
+    const agent = new SmartAgent(deps, {
+      maxIterations: 5,
+      healthTimeoutMs: 15_000,
+    });
+    const result = await agent.healthCheck();
+    assert.ok(result.ok);
+    assert.equal(result.value.llm, true); // completed within timeout
   });
 });

--- a/src/smart-agent/health/__tests__/health-timeout.test.ts
+++ b/src/smart-agent/health/__tests__/health-timeout.test.ts
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { SmartAgent } from '../../agent.js';
+import type { ILlm } from '../../interfaces/llm.js';
+import { LlmError } from '../../interfaces/types.js';
+import { makeDefaultDeps } from '../../testing/index.js';
+
+describe('SmartAgent.healthCheck — configurable timeout', () => {
+  it('uses default 5000ms when healthTimeoutMs is not set', async () => {
+    const { deps } = makeDefaultDeps();
+    const agent = new SmartAgent(deps, { maxIterations: 5 });
+    const result = await agent.healthCheck();
+    assert.ok(result.ok);
+    assert.ok(result.value.llm);
+  });
+
+  it('uses custom healthTimeoutMs from config', async () => {
+    const { deps } = makeDefaultDeps();
+    const agent = new SmartAgent(deps, {
+      maxIterations: 5,
+      healthTimeoutMs: 15_000,
+    });
+    const result = await agent.healthCheck();
+    assert.ok(result.ok);
+    assert.ok(result.value.llm);
+  });
+
+  it('respects an incoming caller AbortSignal', async () => {
+    // Create an ILlm that honours the abort signal in healthCheck
+    const abortAwareLlm: ILlm = {
+      async chat(_msgs, _tools, opts) {
+        if (opts?.signal?.aborted) {
+          return { ok: false, error: new LlmError('Aborted', 'ABORTED') };
+        }
+        return {
+          ok: true,
+          value: { content: 'ok', finishReason: 'stop' as const },
+        };
+      },
+      async *streamChat() {
+        yield {
+          ok: true as const,
+          value: { content: 'ok', finishReason: 'stop' as const },
+        };
+      },
+      async healthCheck(opts) {
+        if (opts?.signal?.aborted) {
+          return { ok: false, error: new LlmError('Aborted', 'ABORTED') };
+        }
+        return { ok: true, value: true };
+      },
+    };
+
+    const { deps } = makeDefaultDeps();
+    deps.mainLlm = abortAwareLlm;
+    const agent = new SmartAgent(deps, { maxIterations: 5 });
+    const ctrl = new AbortController();
+    ctrl.abort();
+    const result = await agent.healthCheck({ signal: ctrl.signal });
+    assert.ok(result.ok);
+    // LLM probe should fail because the signal is already aborted
+    assert.equal(result.value.llm, false);
+  });
+});

--- a/src/smart-agent/resilience/__tests__/health-check-proxy.test.ts
+++ b/src/smart-agent/resilience/__tests__/health-check-proxy.test.ts
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { NonStreamingLlm } from '../../adapters/non-streaming-llm.js';
+import type { ILlm } from '../../interfaces/llm.js';
+import { makeLlm } from '../../testing/index.js';
+import { CircuitBreaker } from '../circuit-breaker.js';
+import { CircuitBreakerLlm } from '../circuit-breaker-llm.js';
+import { RateLimiterLlm } from '../rate-limiter-llm.js';
+import { RetryLlm } from '../retry-llm.js';
+
+/** Minimal ILlm stub WITHOUT healthCheck. */
+function makeLlmWithoutHealthCheck(): ILlm {
+  return {
+    async chat() {
+      return {
+        ok: true,
+        value: { content: 'ok', finishReason: 'stop' as const },
+      };
+    },
+    async *streamChat() {
+      yield {
+        ok: true as const,
+        value: { content: 'ok', finishReason: 'stop' as const },
+      };
+    },
+  };
+}
+
+/** Minimal rate limiter stub. */
+const noopLimiter = { acquire: async () => {} };
+
+describe('ILlm decorator healthCheck proxying', () => {
+  const decorators = [
+    {
+      name: 'NonStreamingLlm',
+      wrap: (inner: ILlm) => new NonStreamingLlm(inner),
+    },
+    {
+      name: 'RetryLlm',
+      wrap: (inner: ILlm) => new RetryLlm(inner),
+    },
+    {
+      name: 'CircuitBreakerLlm',
+      wrap: (inner: ILlm) => new CircuitBreakerLlm(inner, new CircuitBreaker()),
+    },
+    {
+      name: 'RateLimiterLlm',
+      wrap: (inner: ILlm) => new RateLimiterLlm(inner, noopLimiter),
+    },
+  ];
+
+  for (const { name, wrap } of decorators) {
+    it(`${name} forwards healthCheck when inner implements it`, async () => {
+      const inner = makeLlm([{ content: 'ok' }]);
+      const decorated = wrap(inner);
+      assert.ok(decorated.healthCheck, `${name} should expose healthCheck`);
+      const result = await decorated.healthCheck?.();
+      assert.ok(result.ok);
+      assert.equal(result.value, true);
+    });
+
+    it(`${name} omits healthCheck when inner does not implement it`, () => {
+      const inner = makeLlmWithoutHealthCheck();
+      const decorated = wrap(inner);
+      assert.equal(
+        decorated.healthCheck,
+        undefined,
+        `${name} should not expose healthCheck`,
+      );
+    });
+  }
+});

--- a/src/smart-agent/resilience/circuit-breaker-llm.ts
+++ b/src/smart-agent/resilience/circuit-breaker-llm.ts
@@ -18,10 +18,16 @@ import {
 import type { CircuitBreaker } from './circuit-breaker.js';
 
 export class CircuitBreakerLlm implements ILlm {
+  healthCheck?: ILlm['healthCheck'];
+
   constructor(
     private readonly inner: ILlm,
     readonly breaker: CircuitBreaker,
-  ) {}
+  ) {
+    if (inner.healthCheck) {
+      this.healthCheck = inner.healthCheck.bind(inner);
+    }
+  }
 
   get model(): string | undefined {
     return this.inner.model;

--- a/src/smart-agent/resilience/rate-limiter-llm.ts
+++ b/src/smart-agent/resilience/rate-limiter-llm.ts
@@ -18,10 +18,16 @@ import type {
 } from '../interfaces/types.js';
 
 export class RateLimiterLlm implements ILlm {
+  healthCheck?: ILlm['healthCheck'];
+
   constructor(
     private readonly inner: ILlm,
     private readonly limiter: ILlmRateLimiter,
-  ) {}
+  ) {
+    if (inner.healthCheck) {
+      this.healthCheck = inner.healthCheck.bind(inner);
+    }
+  }
 
   get model(): string | undefined {
     return this.inner.model;

--- a/src/smart-agent/resilience/retry-llm.ts
+++ b/src/smart-agent/resilience/retry-llm.ts
@@ -37,12 +37,16 @@ const DEFAULT_OPTIONS: RetryOptions = {
 
 export class RetryLlm implements ILlm {
   private readonly opts: RetryOptions;
+  healthCheck?: ILlm['healthCheck'];
 
   constructor(
     private readonly inner: ILlm,
     options?: Partial<RetryOptions>,
   ) {
     this.opts = { ...DEFAULT_OPTIONS, ...options };
+    if (inner.healthCheck) {
+      this.healthCheck = inner.healthCheck.bind(inner);
+    }
   }
 
   get model(): string | undefined {


### PR DESCRIPTION
## Summary

- Add `healthTimeoutMs?: number` to `SmartAgentConfig` (default 5000, configurable via YAML, builder, or direct construction)
- Merge internal timeout signal with caller-provided `AbortSignal` so health checks respect external cancellation
- Proxy `healthCheck()` in all four ILlm decorators (`NonStreamingLlm`, `RetryLlm`, `CircuitBreakerLlm`, `RateLimiterLlm`) so the lightweight `getModels()` path works end-to-end instead of falling back to `chat('ping')`
- Add `withHealthTimeout(ms)` fluent setter to `SmartAgentBuilder`
- Document `healthTimeoutMs` in INTEGRATION.md with K8s probe alignment and operational verification notes

Closes #71

## Test plan

- [x] Unit tests for default and custom `healthTimeoutMs` values
- [x] Unit test for incoming caller `AbortSignal` propagation
- [x] Unit tests for all 4 decorators: forwards `healthCheck` when inner implements it, omits when not
- [x] Regression: existing `HealthChecker` tests pass (17/17)
- [x] Build and lint clean
- [ ] Manual: verify `/v1/health` with SAP AI Core provider using `healthTimeoutMs: 15000` (cold-start OAuth scenario)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>