### PR TITLE
feat(#74): forward per-request temperature, max_tokens, top_p, stop to pipeline

### DIFF
--- a/src/smart-agent/api-adapters/anthropic-adapter.ts
+++ b/src/smart-agent/api-adapters/anthropic-adapter.ts
@@ -161,6 +161,8 @@ export class AnthropicApiAdapter implements ILlmApiAdapter {
     if (body.max_tokens !== undefined)
       options.maxTokens = body.max_tokens as number;
     if (body.top_p !== undefined) options.topP = body.top_p as number;
+    if (Array.isArray(body.stop_sequences))
+      options.stop = body.stop_sequences as string[];
     if (Array.isArray(body.tools)) options.externalTools = body.tools;
     // Do NOT pass body.model to options — it would override the pipeline LLM model.
     // The request model name is stored in context.protocol for response formatting only.

--- a/src/smart-agent/smart-server.ts
+++ b/src/smart-agent/smart-server.ts
@@ -841,6 +841,10 @@ export class SmartServer {
         tool_calls?: unknown;
       }>;
       model?: string;
+      temperature?: number;
+      max_tokens?: number;
+      top_p?: number;
+      stop?: string | string[];
       tools?: unknown[];
       stream?: boolean;
       stream_options?: { include_usage?: boolean };
@@ -925,6 +929,14 @@ export class SmartServer {
       trace: { traceId },
       sessionLogger,
       model: body.model,
+      ...(body.temperature !== undefined
+        ? { temperature: body.temperature }
+        : {}),
+      ...(body.max_tokens !== undefined ? { maxTokens: body.max_tokens } : {}),
+      ...(body.top_p !== undefined ? { topP: body.top_p } : {}),
+      ...(body.stop !== undefined
+        ? { stop: Array.isArray(body.stop) ? body.stop : [body.stop] }
+        : {}),
     };
 
     const responseModel =


### PR DESCRIPTION
## Summary

- Extract `temperature`, `max_tokens`, `top_p`, `stop` from `/v1/chat/completions` request body
- Forward them via `CallOptions` to the LLM pipeline
- These are standard OpenAI API fields that were accepted but silently ignored

Maps `max_tokens` → `maxTokens`, `top_p` → `topP`, normalizes `stop` (string → array).

Partially addresses #74 (protocol-compliant fields only; `classifier_model`, `helper_model`, `_meta` deferred).

## Test plan

- [x] Build clean
- [x] Lint clean
- [ ] Manual: `curl -X POST .../v1/chat/completions -d '{"messages":[...],"temperature":0.1}'` — verify lower temperature affects response

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>