### PR TITLE
feat(#78): expose GET/PUT /v1/config HTTP endpoints

### DIFF
--- a/docs/superpowers/plans/2026-04-08-config-http-endpoints.md
+++ b/docs/superpowers/plans/2026-04-08-config-http-endpoints.md
@@ -1,0 +1,1195 @@
+# Config HTTP Endpoints Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose `GET /v1/config` and `PUT /v1/config` HTTP endpoints on SmartServer so external clients can read and update runtime configuration.
+
+**Architecture:** Add `IModelResolver` interface + `DefaultModelResolver` in providers. Add `getAgentConfig()` to SmartAgent for reading whitelisted config fields. Add config endpoint handler in SmartServer delegating to `getActiveConfig()`, `getAgentConfig()`, `applyConfigUpdate()`, and `reconfigure()`. PUT is atomic — all validation/resolution happens before any mutation.
+
+**Tech Stack:** TypeScript, Node.js built-in `http`, existing test helpers (`node:test`, `httpRequest()`)
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/smart-agent/interfaces/model-resolver.ts` | Create | `IModelResolver` interface |
+| `src/smart-agent/providers.ts` | Modify | Add `DefaultModelResolver` class |
+| `src/smart-agent/agent.ts` | Modify | Add `getAgentConfig()` method |
+| `src/smart-agent/smart-server.ts` | Modify | Add `/v1/config` route handling, `modelResolver` config field, CORS update |
+| `src/index.ts` | Modify | Export `IModelResolver`, `DefaultModelResolver` |
+| `src/smart-agent/__tests__/config-endpoints.test.ts` | Create | Integration tests for config endpoints |
+
+---
+
+### Task 1: IModelResolver Interface
+
+**Files:**
+- Create: `src/smart-agent/interfaces/model-resolver.ts`
+- Modify: `src/index.ts`
+
+- [ ] **Step 1: Create the interface file**
+
+```typescript
+// src/smart-agent/interfaces/model-resolver.ts
+import type { ILlm } from './llm.js';
+
+/**
+ * Resolves a model name + role into a ready-to-use ILlm instance.
+ * Used by SmartServer to handle PUT /v1/config model changes.
+ */
+export interface IModelResolver {
+  resolve(
+    modelName: string,
+    role: 'main' | 'classifier' | 'helper',
+  ): Promise<ILlm>;
+}
+```
+
+- [ ] **Step 2: Export from index.ts**
+
+Add to `src/index.ts` in the interfaces section (after the `ILlm` export around line 114):
+
+```typescript
+export type { IModelResolver } from './smart-agent/interfaces/model-resolver.js';
+```
+
+- [ ] **Step 3: Verify build**
+
+Run: `npm run build`
+Expected: clean compilation, no errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/smart-agent/interfaces/model-resolver.ts src/index.ts
+git commit -m "feat(#78): add IModelResolver interface"
+```
+
+---
+
+### Task 2: DefaultModelResolver
+
+**Files:**
+- Modify: `src/smart-agent/providers.ts`
+- Modify: `src/index.ts`
+
+- [ ] **Step 1: Add DefaultModelResolver class to providers.ts**
+
+Add at the end of the LLM provider resolution section (after `makeDefaultLlm`, around line 172):
+
+```typescript
+/**
+ * Default IModelResolver — delegates to makeLlm() with the given provider settings.
+ * Returns fully constructed ILlm instances ready for use with SmartAgent.reconfigure().
+ */
+export class DefaultModelResolver implements IModelResolver {
+  constructor(
+    private readonly providerConfig: Omit<LlmProviderConfig, 'model'>,
+    private readonly defaults: { temperature?: number } = {},
+  ) {}
+
+  async resolve(
+    modelName: string,
+    role: 'main' | 'classifier' | 'helper',
+  ): Promise<ILlm> {
+    const temperature =
+      this.defaults.temperature ?? (role === 'main' ? 0.7 : 0.1);
+    return makeLlm(
+      { ...this.providerConfig, model: modelName },
+      temperature,
+    );
+  }
+}
+```
+
+Add the import at the top of `providers.ts`:
+
+```typescript
+import type { IModelResolver } from './interfaces/model-resolver.js';
+```
+
+- [ ] **Step 2: Export DefaultModelResolver from index.ts**
+
+Add to `src/index.ts` near the providers exports (around line 148, after the `LlmProviderConfig` export):
+
+```typescript
+export { DefaultModelResolver } from './smart-agent/providers.js';
+```
+
+- [ ] **Step 3: Verify build**
+
+Run: `npm run build`
+Expected: clean compilation, no errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/smart-agent/providers.ts src/index.ts
+git commit -m "feat(#78): add DefaultModelResolver implementation"
+```
+
+---
+
+### Task 3: SmartAgent.getAgentConfig()
+
+**Files:**
+- Modify: `src/smart-agent/agent.ts`
+
+The spec defines a whitelist of fields that `GET /v1/config` exposes from `SmartAgentConfig`. SmartAgent currently has no public getter for its config. We add `getAgentConfig()` that returns only whitelisted fields.
+
+- [ ] **Step 1: Write the failing test**
+
+Create test in `src/smart-agent/__tests__/config-endpoints.test.ts` (we'll use this file for all config tests):
+
+```typescript
+// src/smart-agent/__tests__/config-endpoints.test.ts
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { SmartAgent } from '../agent.js';
+import { makeDefaultDeps } from '../testing/index.js';
+
+describe('SmartAgent.getAgentConfig', () => {
+  it('returns only whitelisted fields', () => {
+    const { deps } = makeDefaultDeps();
+    const agent = new SmartAgent(deps, {
+      maxIterations: 10,
+      maxToolCalls: 5,
+      ragQueryK: 15,
+      toolUnavailableTtlMs: 30_000,
+      showReasoning: true,
+      historyAutoSummarizeLimit: 20,
+      classificationEnabled: true,
+      ragRetrievalMode: 'auto',
+      ragTranslationEnabled: true,
+      ragUpsertEnabled: false,
+      // These should NOT appear in the output:
+      timeoutMs: 5000,
+      tokenLimit: 4096,
+      smartAgentEnabled: true,
+    });
+
+    const config = agent.getAgentConfig();
+
+    assert.deepEqual(config, {
+      maxIterations: 10,
+      maxToolCalls: 5,
+      ragQueryK: 15,
+      toolUnavailableTtlMs: 30_000,
+      showReasoning: true,
+      historyAutoSummarizeLimit: 20,
+      classificationEnabled: true,
+      ragRetrievalMode: 'auto',
+      ragTranslationEnabled: true,
+      ragUpsertEnabled: false,
+    });
+  });
+
+  it('returns defaults for omitted optional fields', () => {
+    const { deps } = makeDefaultDeps();
+    const agent = new SmartAgent(deps, { maxIterations: 5 });
+
+    const config = agent.getAgentConfig();
+
+    assert.equal(config.maxIterations, 5);
+    assert.equal(config.maxToolCalls, undefined);
+    assert.equal(config.classificationEnabled, undefined);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx tsx --test src/smart-agent/__tests__/config-endpoints.test.ts`
+Expected: FAIL — `agent.getAgentConfig is not a function`
+
+- [ ] **Step 3: Implement getAgentConfig()**
+
+Add to `src/smart-agent/agent.ts`, right after `getActiveConfig()` (after line 323):
+
+```typescript
+  /** Returns whitelisted runtime-safe agent config fields (for HTTP DTO). */
+  getAgentConfig(): {
+    maxIterations: number;
+    maxToolCalls?: number;
+    ragQueryK?: number;
+    toolUnavailableTtlMs?: number;
+    showReasoning?: boolean;
+    historyAutoSummarizeLimit?: number;
+    classificationEnabled?: boolean;
+    ragRetrievalMode?: 'auto' | 'always' | 'never';
+    ragTranslationEnabled?: boolean;
+    ragUpsertEnabled?: boolean;
+  } {
+    return {
+      maxIterations: this.config.maxIterations,
+      maxToolCalls: this.config.maxToolCalls,
+      ragQueryK: this.config.ragQueryK,
+      toolUnavailableTtlMs: this.config.toolUnavailableTtlMs,
+      showReasoning: this.config.showReasoning,
+      historyAutoSummarizeLimit: this.config.historyAutoSummarizeLimit,
+      classificationEnabled: this.config.classificationEnabled,
+      ragRetrievalMode: this.config.ragRetrievalMode,
+      ragTranslationEnabled: this.config.ragTranslationEnabled,
+      ragUpsertEnabled: this.config.ragUpsertEnabled,
+    };
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx tsx --test src/smart-agent/__tests__/config-endpoints.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/smart-agent/agent.ts src/smart-agent/__tests__/config-endpoints.test.ts
+git commit -m "feat(#78): add SmartAgent.getAgentConfig() with whitelisted fields"
+```
+
+---
+
+### Task 4: GET /v1/config Endpoint
+
+**Files:**
+- Modify: `src/smart-agent/smart-server.ts`
+- Modify: `src/smart-agent/__tests__/config-endpoints.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/smart-agent/__tests__/config-endpoints.test.ts`:
+
+```typescript
+import { request } from 'node:http';
+import { SmartServer } from '../smart-server.js';
+
+// ---------------------------------------------------------------------------
+// HTTP helper (same pattern as smart-server-api-adapters.test.ts)
+// ---------------------------------------------------------------------------
+
+function httpRequest(
+  port: number,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<{ status: number; body: unknown; raw: string }> {
+  return new Promise((resolve, reject) => {
+    const bodyStr = body !== undefined ? JSON.stringify(body) : undefined;
+    const options = {
+      host: '127.0.0.1',
+      port,
+      method,
+      path,
+      headers: {
+        'Content-Type': 'application/json',
+        ...(bodyStr !== undefined
+          ? { 'Content-Length': Buffer.byteLength(bodyStr) }
+          : {}),
+      },
+    };
+    const req = request(options, (res) => {
+      const chunks: Buffer[] = [];
+      res.on('data', (chunk: Buffer) => chunks.push(chunk));
+      res.on('end', () => {
+        const text = Buffer.concat(chunks).toString('utf8');
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(text);
+        } catch {
+          parsed = text;
+        }
+        resolve({ status: res.statusCode ?? 0, body: parsed, raw: text });
+      });
+    });
+    req.on('error', reject);
+    if (bodyStr !== undefined) {
+      req.write(bodyStr);
+    }
+    req.end();
+  });
+}
+
+describe('GET /v1/config', () => {
+  it('returns models and agent config', async () => {
+    const server = new SmartServer({
+      llm: { apiKey: 'test', model: 'test-model' },
+      skipModelValidation: true,
+      agent: { maxIterations: 8 },
+    });
+    const handle = await server.start();
+    try {
+      const res = await httpRequest(handle.port, 'GET', '/v1/config');
+      assert.equal(res.status, 200);
+      const body = res.body as Record<string, unknown>;
+      assert.ok(body.models);
+      assert.ok(body.agent);
+      const agent = body.agent as Record<string, unknown>;
+      assert.equal(agent.maxIterations, 8);
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('works with /config alias', async () => {
+    const server = new SmartServer({
+      llm: { apiKey: 'test', model: 'test-model' },
+      skipModelValidation: true,
+    });
+    const handle = await server.start();
+    try {
+      const res = await httpRequest(handle.port, 'GET', '/config');
+      assert.equal(res.status, 200);
+      const body = res.body as Record<string, unknown>;
+      assert.ok(body.models);
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('returns only whitelisted fields, not raw SmartAgentConfig', async () => {
+    const server = new SmartServer({
+      llm: { apiKey: 'test', model: 'test-model' },
+      skipModelValidation: true,
+      agent: { maxIterations: 5, timeoutMs: 9999, tokenLimit: 4096 },
+    });
+    const handle = await server.start();
+    try {
+      const res = await httpRequest(handle.port, 'GET', '/v1/config');
+      assert.equal(res.status, 200);
+      const body = res.body as Record<string, unknown>;
+      const agent = body.agent as Record<string, unknown>;
+      assert.equal(agent.maxIterations, 5);
+      assert.equal(agent.timeoutMs, undefined);
+      assert.equal(agent.tokenLimit, undefined);
+    } finally {
+      await handle.close();
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx tsx --test src/smart-agent/__tests__/config-endpoints.test.ts`
+Expected: FAIL — 404 for `/v1/config`
+
+- [ ] **Step 3: Add config endpoint to SmartServer._handle()**
+
+In `src/smart-agent/smart-server.ts`, add the route handler in `_handle()` after the `/v1/usage` block (after line 686) and before the `/health` check:
+
+```typescript
+    // GET /v1/config or /config
+    if (
+      req.method === 'GET' &&
+      (urlPath === '/v1/config' || urlPath === '/config')
+    ) {
+      const models = smartAgent.getActiveConfig();
+      const agent = smartAgent.getAgentConfig();
+      const body = { models, agent };
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(body));
+      return;
+    }
+```
+
+Note: `llmDefaults` (temperature/maxTokens) will be added in Task 6 after PUT is wired, since the server needs to track these values as mutable state.
+
+- [ ] **Step 4: Update CORS_HEADERS to include PUT**
+
+In `src/smart-agent/smart-server.ts`, update the `CORS_HEADERS` constant (line 252):
+
+```typescript
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, POST, PUT, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+};
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npx tsx --test src/smart-agent/__tests__/config-endpoints.test.ts`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/smart-agent/smart-server.ts src/smart-agent/__tests__/config-endpoints.test.ts
+git commit -m "feat(#78): add GET /v1/config endpoint"
+```
+
+---
+
+### Task 5: PUT /v1/config — Agent Parameters
+
+**Files:**
+- Modify: `src/smart-agent/smart-server.ts`
+- Modify: `src/smart-agent/__tests__/config-endpoints.test.ts`
+
+This task adds `PUT /v1/config` support for the `agent` block only (parameters via `applyConfigUpdate`). Model resolution is added in Task 6.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `src/smart-agent/__tests__/config-endpoints.test.ts`:
+
+```typescript
+describe('PUT /v1/config', () => {
+  it('updates agent parameters and returns updated config', async () => {
+    const server = new SmartServer({
+      llm: { apiKey: 'test', model: 'test-model' },
+      skipModelValidation: true,
+      agent: { maxIterations: 10 },
+    });
+    const handle = await server.start();
+    try {
+      const res = await httpRequest(handle.port, 'PUT', '/v1/config', {
+        agent: { maxIterations: 20, classificationEnabled: false },
+      });
+      assert.equal(res.status, 200);
+      const body = res.body as Record<string, unknown>;
+      const agent = body.agent as Record<string, unknown>;
+      assert.equal(agent.maxIterations, 20);
+      assert.equal(agent.classificationEnabled, false);
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('rejects unsupported agent fields', async () => {
+    const server = new SmartServer({
+      llm: { apiKey: 'test', model: 'test-model' },
+      skipModelValidation: true,
+    });
+    const handle = await server.start();
+    try {
+      const res = await httpRequest(handle.port, 'PUT', '/v1/config', {
+        agent: { timeoutMs: 9999 },
+      });
+      assert.equal(res.status, 400);
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('rejects invalid JSON body', async () => {
+    const server = new SmartServer({
+      llm: { apiKey: 'test', model: 'test-model' },
+      skipModelValidation: true,
+    });
+    const handle = await server.start();
+    try {
+      const res = await new Promise<{ status: number; body: unknown; raw: string }>((resolve, reject) => {
+        const req = request(
+          { host: '127.0.0.1', port: handle.port, method: 'PUT', path: '/v1/config', headers: { 'Content-Type': 'application/json' } },
+          (res) => {
+            const chunks: Buffer[] = [];
+            res.on('data', (c: Buffer) => chunks.push(c));
+            res.on('end', () => {
+              const text = Buffer.concat(chunks).toString('utf8');
+              resolve({ status: res.statusCode ?? 0, body: JSON.parse(text), raw: text });
+            });
+          },
+        );
+        req.on('error', reject);
+        req.write('not-json');
+        req.end();
+      });
+      assert.equal(res.status, 400);
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('returns 405 for unsupported methods on /v1/config', async () => {
+    const server = new SmartServer({
+      llm: { apiKey: 'test', model: 'test-model' },
+      skipModelValidation: true,
+    });
+    const handle = await server.start();
+    try {
+      const res = await httpRequest(handle.port, 'DELETE', '/v1/config');
+      assert.equal(res.status, 405);
+    } finally {
+      await handle.close();
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx tsx --test src/smart-agent/__tests__/config-endpoints.test.ts`
+Expected: FAIL — PUT returns 404, DELETE returns 404
+
+- [ ] **Step 3: Add PUT handler and 405 handling to _handle()**
+
+In `src/smart-agent/smart-server.ts`, replace the GET-only config handler added in Task 4 with a combined config handler:
+
+```typescript
+    // /v1/config or /config
+    if (urlPath === '/v1/config' || urlPath === '/config') {
+      if (req.method === 'GET') {
+        const models = smartAgent.getActiveConfig();
+        const agent = smartAgent.getAgentConfig();
+        const body = { models, agent };
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(body));
+        return;
+      }
+      if (req.method === 'PUT') {
+        await this._handleConfigUpdate(req, res, smartAgent);
+        return;
+      }
+      // 405 for other methods
+      res.setHeader('Allow', 'GET, PUT, OPTIONS');
+      res.writeHead(405, { 'Content-Type': 'application/json' });
+      res.end(jsonError(`Method ${req.method} not allowed on ${urlPath}`, 'invalid_request_error'));
+      return;
+    }
+```
+
+- [ ] **Step 4: Add _handleConfigUpdate() method**
+
+Add a new private method to `SmartServer` class (after `_handleChat` or at the end of the class):
+
+```typescript
+  /** Whitelisted agent config fields allowed via PUT /v1/config. */
+  private static readonly AGENT_CONFIG_FIELDS = new Set([
+    'maxIterations',
+    'maxToolCalls',
+    'ragQueryK',
+    'toolUnavailableTtlMs',
+    'showReasoning',
+    'historyAutoSummarizeLimit',
+    'classificationEnabled',
+    'ragRetrievalMode',
+    'ragTranslationEnabled',
+    'ragUpsertEnabled',
+  ]);
+
+  private async _handleConfigUpdate(
+    req: IncomingMessage,
+    res: ServerResponse,
+    smartAgent: SmartAgent,
+  ): Promise<void> {
+    const raw = await readBody(req);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      res.end(jsonError('Invalid JSON body', 'invalid_request_error'));
+      return;
+    }
+
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      res.end(jsonError('Request body must be a JSON object', 'invalid_request_error'));
+      return;
+    }
+
+    const body = parsed as Record<string, unknown>;
+
+    // --- Validate agent fields against whitelist ---
+    if (body.agent !== undefined) {
+      if (typeof body.agent !== 'object' || body.agent === null || Array.isArray(body.agent)) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(jsonError('"agent" must be a JSON object', 'invalid_request_error'));
+        return;
+      }
+      const agentFields = body.agent as Record<string, unknown>;
+      const unsupported = Object.keys(agentFields).filter(
+        (k) => !SmartServer.AGENT_CONFIG_FIELDS.has(k),
+      );
+      if (unsupported.length > 0) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(
+          jsonError(
+            `Unsupported agent config fields: ${unsupported.join(', ')}`,
+            'invalid_request_error',
+          ),
+        );
+        return;
+      }
+    }
+
+    // --- Apply agent config update ---
+    if (body.agent) {
+      smartAgent.applyConfigUpdate(body.agent as Record<string, unknown>);
+    }
+
+    // --- Return updated config ---
+    const models = smartAgent.getActiveConfig();
+    const agent = smartAgent.getAgentConfig();
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ models, agent }));
+  }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npx tsx --test src/smart-agent/__tests__/config-endpoints.test.ts`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/smart-agent/smart-server.ts src/smart-agent/__tests__/config-endpoints.test.ts
+git commit -m "feat(#78): add PUT /v1/config for agent parameters"
+```
+
+---
+
+### Task 6: PUT /v1/config — Model Resolution
+
+**Files:**
+- Modify: `src/smart-agent/smart-server.ts`
+- Modify: `src/smart-agent/__tests__/config-endpoints.test.ts`
+
+This task adds `models` block support to PUT, using `IModelResolver`. Atomicity: all models are resolved before any mutation happens.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `src/smart-agent/__tests__/config-endpoints.test.ts`:
+
+```typescript
+import { makeLlm as makeTestLlm } from '../testing/index.js';
+import type { IModelResolver } from '../interfaces/model-resolver.js';
+import type { ILlm } from '../interfaces/llm.js';
+
+function makeResolver(
+  results: Record<string, ILlm | Error>,
+): IModelResolver {
+  return {
+    async resolve(modelName: string): Promise<ILlm> {
+      const result = results[modelName];
+      if (!result) throw new Error(`Unknown model: ${modelName}`);
+      if (result instanceof Error) throw result;
+      return result;
+    },
+  };
+}
+
+describe('PUT /v1/config — models', () => {
+  it('resolves and reconfigures models when resolver is set', async () => {
+    const newMain = { ...makeTestLlm([{ content: 'ok' }]), model: 'gpt-4o' };
+    const resolver = makeResolver({ 'gpt-4o': newMain });
+
+    const server = new SmartServer({
+      llm: { apiKey: 'test', model: 'test-model' },
+      skipModelValidation: true,
+      modelResolver: resolver,
+    });
+    const handle = await server.start();
+    try {
+      const res = await httpRequest(handle.port, 'PUT', '/v1/config', {
+        models: { mainModel: 'gpt-4o' },
+      });
+      assert.equal(res.status, 200);
+      const body = res.body as Record<string, unknown>;
+      const models = body.models as Record<string, unknown>;
+      assert.equal(models.mainModel, 'gpt-4o');
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('returns 400 when models sent but no resolver configured', async () => {
+    const server = new SmartServer({
+      llm: { apiKey: 'test', model: 'test-model' },
+      skipModelValidation: true,
+    });
+    const handle = await server.start();
+    try {
+      const res = await httpRequest(handle.port, 'PUT', '/v1/config', {
+        models: { mainModel: 'gpt-4o' },
+      });
+      assert.equal(res.status, 400);
+      const body = res.body as Record<string, unknown>;
+      const error = body.error as Record<string, unknown>;
+      assert.ok(String(error.message).includes('model resolver not configured'));
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('returns 500 when model resolution fails', async () => {
+    const resolver = makeResolver({
+      'bad-model': new Error('Provider unreachable'),
+    });
+
+    const server = new SmartServer({
+      llm: { apiKey: 'test', model: 'test-model' },
+      skipModelValidation: true,
+      modelResolver: resolver,
+    });
+    const handle = await server.start();
+    try {
+      const res = await httpRequest(handle.port, 'PUT', '/v1/config', {
+        models: { mainModel: 'bad-model' },
+      });
+      assert.equal(res.status, 500);
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('is atomic — no changes applied when one model resolution fails', async () => {
+    const goodLlm = { ...makeTestLlm([{ content: 'ok' }]), model: 'good-model' };
+    const resolver = makeResolver({
+      'good-model': goodLlm,
+      'bad-model': new Error('resolution failed'),
+    });
+
+    const server = new SmartServer({
+      llm: { apiKey: 'test', model: 'test-model' },
+      skipModelValidation: true,
+      modelResolver: resolver,
+      agent: { maxIterations: 10 },
+    });
+    const handle = await server.start();
+    try {
+      // Attempt to update both models + agent param — one model fails
+      const res = await httpRequest(handle.port, 'PUT', '/v1/config', {
+        models: { mainModel: 'good-model', classifierModel: 'bad-model' },
+        agent: { maxIterations: 99 },
+      });
+      assert.equal(res.status, 500);
+
+      // Verify nothing changed
+      const getRes = await httpRequest(handle.port, 'GET', '/v1/config');
+      const body = getRes.body as Record<string, unknown>;
+      const agent = body.agent as Record<string, unknown>;
+      assert.equal(agent.maxIterations, 10); // unchanged
+    } finally {
+      await handle.close();
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx tsx --test src/smart-agent/__tests__/config-endpoints.test.ts`
+Expected: FAIL — models block is ignored, no 400 for missing resolver
+
+- [ ] **Step 3: Add `modelResolver` to SmartServerConfig**
+
+In `src/smart-agent/smart-server.ts`, add to `SmartServerConfig` interface (around line 183, before the closing `}`):
+
+```typescript
+  /** Model resolver for PUT /v1/config model changes. When not set, model updates are rejected with 400. */
+  modelResolver?: IModelResolver;
+```
+
+Add the import at the top of the file:
+
+```typescript
+import type { IModelResolver } from './interfaces/model-resolver.js';
+```
+
+- [ ] **Step 4: Update _handleConfigUpdate() for model resolution**
+
+Replace the `_handleConfigUpdate` method with the version that handles models atomically:
+
+```typescript
+  private async _handleConfigUpdate(
+    req: IncomingMessage,
+    res: ServerResponse,
+    smartAgent: SmartAgent,
+  ): Promise<void> {
+    const raw = await readBody(req);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      res.end(jsonError('Invalid JSON body', 'invalid_request_error'));
+      return;
+    }
+
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      res.end(jsonError('Request body must be a JSON object', 'invalid_request_error'));
+      return;
+    }
+
+    const body = parsed as Record<string, unknown>;
+
+    // --- Validate agent fields against whitelist ---
+    if (body.agent !== undefined) {
+      if (typeof body.agent !== 'object' || body.agent === null || Array.isArray(body.agent)) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(jsonError('"agent" must be a JSON object', 'invalid_request_error'));
+        return;
+      }
+      const agentFields = body.agent as Record<string, unknown>;
+      const unsupported = Object.keys(agentFields).filter(
+        (k) => !SmartServer.AGENT_CONFIG_FIELDS.has(k),
+      );
+      if (unsupported.length > 0) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(
+          jsonError(
+            `Unsupported agent config fields: ${unsupported.join(', ')}`,
+            'invalid_request_error',
+          ),
+        );
+        return;
+      }
+    }
+
+    // --- Validate and resolve models (atomic: resolve ALL before mutating) ---
+    let resolvedModels: SmartAgentReconfigureOptions | undefined;
+    if (body.models !== undefined) {
+      if (typeof body.models !== 'object' || body.models === null || Array.isArray(body.models)) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(jsonError('"models" must be a JSON object', 'invalid_request_error'));
+        return;
+      }
+      if (!this.cfg.modelResolver) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(jsonError('model resolver not configured', 'invalid_request_error'));
+        return;
+      }
+      const modelFields = body.models as Record<string, unknown>;
+      const validKeys = new Set(['mainModel', 'classifierModel', 'helperModel']);
+      const unknownKeys = Object.keys(modelFields).filter((k) => !validKeys.has(k));
+      if (unknownKeys.length > 0) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(
+          jsonError(
+            `Unknown model fields: ${unknownKeys.join(', ')}`,
+            'invalid_request_error',
+          ),
+        );
+        return;
+      }
+      try {
+        resolvedModels = {};
+        if (modelFields.mainModel) {
+          resolvedModels.mainLlm = await this.cfg.modelResolver.resolve(
+            String(modelFields.mainModel), 'main',
+          );
+        }
+        if (modelFields.classifierModel) {
+          resolvedModels.classifierLlm = await this.cfg.modelResolver.resolve(
+            String(modelFields.classifierModel), 'classifier',
+          );
+        }
+        if (modelFields.helperModel) {
+          resolvedModels.helperLlm = await this.cfg.modelResolver.resolve(
+            String(modelFields.helperModel), 'helper',
+          );
+        }
+      } catch (err) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(jsonError(String(err), 'server_error'));
+        return;
+      }
+    }
+
+    // --- All validation passed — apply mutations ---
+    if (resolvedModels) {
+      smartAgent.reconfigure(resolvedModels);
+    }
+    if (body.agent) {
+      smartAgent.applyConfigUpdate(body.agent as Record<string, unknown>);
+    }
+
+    // --- Return updated config ---
+    const models = smartAgent.getActiveConfig();
+    const agent = smartAgent.getAgentConfig();
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ models, agent }));
+  }
+```
+
+Add the import for `SmartAgentReconfigureOptions` at the top:
+
+```typescript
+import type { SmartAgentReconfigureOptions } from './agent.js';
+```
+
+(Check if `SmartAgent` is already imported from `./agent.js` — if so, add `SmartAgentReconfigureOptions` to the same import.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npx tsx --test src/smart-agent/__tests__/config-endpoints.test.ts`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/smart-agent/smart-server.ts src/smart-agent/__tests__/config-endpoints.test.ts
+git commit -m "feat(#78): add model resolution to PUT /v1/config with atomicity"
+```
+
+---
+
+### Task 7: llmDefaults in Config DTO
+
+**Files:**
+- Modify: `src/smart-agent/smart-server.ts`
+- Modify: `src/smart-agent/__tests__/config-endpoints.test.ts`
+
+The spec defines `llmDefaults` (temperature, maxTokens) as server-held runtime state for new requests. SmartServer resolves temperature during `start()` — we store it as mutable state and expose via the config DTO.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `src/smart-agent/__tests__/config-endpoints.test.ts`:
+
+```typescript
+describe('llmDefaults in config', () => {
+  it('GET /v1/config includes llmDefaults', async () => {
+    const server = new SmartServer({
+      llm: { apiKey: 'test', model: 'test-model', temperature: 0.9 },
+      skipModelValidation: true,
+    });
+    const handle = await server.start();
+    try {
+      const res = await httpRequest(handle.port, 'GET', '/v1/config');
+      assert.equal(res.status, 200);
+      const body = res.body as Record<string, unknown>;
+      assert.ok(body.llmDefaults);
+      const defaults = body.llmDefaults as Record<string, unknown>;
+      assert.equal(defaults.temperature, 0.9);
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('PUT /v1/config updates llmDefaults', async () => {
+    const server = new SmartServer({
+      llm: { apiKey: 'test', model: 'test-model', temperature: 0.7 },
+      skipModelValidation: true,
+    });
+    const handle = await server.start();
+    try {
+      const res = await httpRequest(handle.port, 'PUT', '/v1/config', {
+        llmDefaults: { temperature: 0.3 },
+      });
+      assert.equal(res.status, 200);
+      const body = res.body as Record<string, unknown>;
+      const defaults = body.llmDefaults as Record<string, unknown>;
+      assert.equal(defaults.temperature, 0.3);
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('rejects unsupported llmDefaults fields', async () => {
+    const server = new SmartServer({
+      llm: { apiKey: 'test', model: 'test-model' },
+      skipModelValidation: true,
+    });
+    const handle = await server.start();
+    try {
+      const res = await httpRequest(handle.port, 'PUT', '/v1/config', {
+        llmDefaults: { topP: 0.9 },
+      });
+      assert.equal(res.status, 400);
+    } finally {
+      await handle.close();
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx tsx --test src/smart-agent/__tests__/config-endpoints.test.ts`
+Expected: FAIL — no `llmDefaults` in response
+
+- [ ] **Step 3: Add llmDefaults state to SmartServer.start()**
+
+In `src/smart-agent/smart-server.ts`, inside `start()`, after the LLM resolution block (around line 319, after `helperLlm` is resolved), add mutable state:
+
+```typescript
+    // Mutable runtime LLM defaults exposed via /v1/config
+    const llmDefaults = {
+      temperature: mainTemp,
+      maxTokens: Number(
+        pipeline?.llm?.main?.maxTokens ?? undefined,
+      ) || undefined,
+    };
+```
+
+Pass `llmDefaults` to `_handle()` — add it as a new parameter. Update the `_handle` method signature:
+
+```typescript
+  private async _handle(
+    req: IncomingMessage,
+    res: ServerResponse,
+    requestLogger: IRequestLogger,
+    smartAgent: SmartAgent,
+    chat: SmartAgentHandle['chat'],
+    streamChat: SmartAgentHandle['streamChat'],
+    log: (e: Record<string, unknown>) => void,
+    healthChecker: HealthChecker,
+    modelProvider?: IModelProvider,
+    adapterMap?: Map<string, ILlmApiAdapter>,
+    llmDefaults?: { temperature: number; maxTokens?: number },
+  ): Promise<void> {
+```
+
+Update the `server = http.createServer(...)` call to pass `llmDefaults`:
+
+```typescript
+    const server = http.createServer((req, res) =>
+      this._handle(
+        req,
+        res,
+        requestLogger,
+        smartAgent,
+        chat,
+        streamChat,
+        log,
+        healthChecker,
+        modelProvider,
+        adapterMap,
+        llmDefaults,
+      ).catch(/* ... existing error handler ... */),
+    );
+```
+
+- [ ] **Step 4: Include llmDefaults in GET response**
+
+Update the GET handler in `_handle()`:
+
+```typescript
+      if (req.method === 'GET') {
+        const models = smartAgent.getActiveConfig();
+        const agent = smartAgent.getAgentConfig();
+        const body = { models, agent, llmDefaults };
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(body));
+        return;
+      }
+```
+
+- [ ] **Step 5: Pass llmDefaults to _handleConfigUpdate and handle updates**
+
+Update `_handleConfigUpdate` signature to accept and mutate `llmDefaults`:
+
+```typescript
+  private async _handleConfigUpdate(
+    req: IncomingMessage,
+    res: ServerResponse,
+    smartAgent: SmartAgent,
+    llmDefaults?: { temperature: number; maxTokens?: number },
+  ): Promise<void> {
+```
+
+Add llmDefaults validation and whitelist in `_handleConfigUpdate`, after agent validation:
+
+```typescript
+    // --- Validate llmDefaults fields ---
+    const LLM_DEFAULTS_FIELDS = new Set(['temperature', 'maxTokens']);
+    if (body.llmDefaults !== undefined) {
+      if (typeof body.llmDefaults !== 'object' || body.llmDefaults === null || Array.isArray(body.llmDefaults)) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(jsonError('"llmDefaults" must be a JSON object', 'invalid_request_error'));
+        return;
+      }
+      const fields = body.llmDefaults as Record<string, unknown>;
+      const unsupported = Object.keys(fields).filter((k) => !LLM_DEFAULTS_FIELDS.has(k));
+      if (unsupported.length > 0) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(
+          jsonError(
+            `Unsupported llmDefaults fields: ${unsupported.join(', ')}`,
+            'invalid_request_error',
+          ),
+        );
+        return;
+      }
+    }
+```
+
+Add mutation in the "apply mutations" section:
+
+```typescript
+    if (body.llmDefaults && llmDefaults) {
+      const fields = body.llmDefaults as Record<string, unknown>;
+      if (fields.temperature !== undefined) llmDefaults.temperature = Number(fields.temperature);
+      if (fields.maxTokens !== undefined) llmDefaults.maxTokens = Number(fields.maxTokens);
+    }
+```
+
+Update the response to include llmDefaults:
+
+```typescript
+    const models = smartAgent.getActiveConfig();
+    const agent = smartAgent.getAgentConfig();
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ models, agent, llmDefaults }));
+```
+
+Update the PUT handler call site in `_handle()`:
+
+```typescript
+      if (req.method === 'PUT') {
+        await this._handleConfigUpdate(req, res, smartAgent, llmDefaults);
+        return;
+      }
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `npx tsx --test src/smart-agent/__tests__/config-endpoints.test.ts`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/smart-agent/smart-server.ts src/smart-agent/__tests__/config-endpoints.test.ts
+git commit -m "feat(#78): add llmDefaults to config DTO and PUT handler"
+```
+
+---
+
+### Task 8: Exports and Final Verification
+
+**Files:**
+- Modify: `src/index.ts` (verify all exports are in place)
+
+- [ ] **Step 1: Verify all exports**
+
+Check that `src/index.ts` exports:
+- `IModelResolver` (added in Task 1)
+- `DefaultModelResolver` (added in Task 2)
+
+These should already be exported. If not, add them.
+
+- [ ] **Step 2: Run full build**
+
+Run: `npm run build`
+Expected: clean compilation
+
+- [ ] **Step 3: Run lint**
+
+Run: `npm run lint`
+Expected: no errors (auto-fix applied if needed)
+
+- [ ] **Step 4: Run all tests**
+
+Run: `npx tsx --test src/smart-agent/__tests__/config-endpoints.test.ts`
+Expected: all tests PASS
+
+- [ ] **Step 5: Run existing tests to check for regressions**
+
+Run: `npx tsx --test src/smart-agent/__tests__/reconfigure.test.ts`
+Expected: PASS (no regressions)
+
+Run: `npx tsx --test src/smart-agent/__tests__/smart-server-api-adapters.test.ts`
+Expected: PASS (no regressions)
+
+- [ ] **Step 6: Commit any final fixes**
+
+```bash
+git add -A
+git commit -m "chore(#78): final cleanup and export verification"
+```

--- a/docs/superpowers/specs/2026-04-08-config-http-endpoints-design.md
+++ b/docs/superpowers/specs/2026-04-08-config-http-endpoints-design.md
@@ -1,0 +1,116 @@
+# HTTP Endpoints for Runtime Configuration (#78)
+
+## Context
+
+v5.18.4 added `SmartAgent.reconfigure()` and `getActiveConfig()` as programmatic APIs (#76). SmartServer does not expose these via HTTP, so external clients (UIs, compat layers) cannot use them without code changes.
+
+## Endpoints
+
+### GET /v1/config
+
+Returns current active configuration. Aliases: `/config`.
+
+**Response (200):**
+
+```json
+{
+  "models": {
+    "mainModel": "anthropic--claude-4.6-sonnet",
+    "classifierModel": "gpt-4.1-mini",
+    "helperModel": "gpt-4.1-mini"
+  },
+  "parameters": {
+    "temperature": 0.7,
+    "max_tokens": 32768,
+    "maxIterations": 10,
+    "classificationEnabled": true
+  }
+}
+```
+
+- `models` — from `SmartAgent.getActiveConfig()`
+- `parameters` — from `SmartAgentConfig` (all fields exposed, consumer decides what to use)
+
+### PUT /v1/config
+
+Partial runtime reconfiguration. Aliases: `/config`.
+
+**Request body:**
+
+```json
+{
+  "models": {
+    "classifierModel": "gpt-4o"
+  },
+  "parameters": {
+    "temperature": 0.5
+  }
+}
+```
+
+Both blocks are optional. Omitted fields keep current values.
+
+- `models` fields → resolved via `IModelResolver` → passed to `SmartAgent.reconfigure()`
+- `parameters` fields → passed to `SmartAgent.applyConfigUpdate()`
+
+**Response (200):** updated config in the same format as GET.
+
+**Errors:**
+
+| Status | Condition |
+|--------|-----------|
+| 400 | Invalid JSON body |
+| 400 | `models` sent but `IModelResolver` not configured |
+| 405 | Wrong HTTP method (not GET/PUT) |
+| 500 | Model resolution failed (e.g., unknown model, provider error) |
+
+## IModelResolver Interface
+
+```typescript
+export interface IModelResolver {
+  resolve(modelName: string, role: 'main' | 'classifier' | 'helper'): Promise<ILlm>;
+}
+```
+
+### DefaultModelResolver
+
+Default implementation in `src/smart-agent/providers.ts`. Wraps existing `resolve*Llm()` functions. Requires access to current config (API keys, provider settings).
+
+### Integration
+
+- `SmartServerConfig` gets optional `modelResolver?: IModelResolver` field
+- `SmartAgentBuilder` gets `.withModelResolver()` setter
+- Passed to `SmartServer`, used only in `PUT /v1/config` for model fields
+- If not configured and client sends model fields → 400
+
+### Exports
+
+`IModelResolver` and `DefaultModelResolver` added to `src/index.ts`.
+
+## Routing
+
+Added to `SmartServer._handle()` alongside existing endpoints:
+
+- `GET /v1/config` or `/config` → return active config
+- `PUT /v1/config` or `/config` → apply partial update
+- Other methods on `/v1/config` → 405
+
+Follows existing patterns: `readBody()`, `JSON.parse()`, `jsonError()`, CORS headers.
+
+## Out of Scope
+
+- **Authentication/authorization** — separate issue; no endpoints currently have auth. Planned as `IAuthMiddleware` interface with no-op default.
+- **`_meta` in `/v1/models`** — rejected; config and models are separate resources.
+
+## Tests
+
+File: `src/smart-agent/__tests__/config-endpoints.test.ts`
+
+Test cases:
+- `GET /v1/config` returns 200 with models + parameters
+- `PUT /v1/config` with parameters only — updates parameters, returns updated config
+- `PUT /v1/config` with models + resolver — resolves and reconfigures
+- `PUT /v1/config` with models but no resolver — 400
+- `PUT /v1/config` with invalid JSON — 400
+- `PUT /v1/config` with unknown model (resolver throws) — 500
+- `GET /config` alias works

--- a/docs/superpowers/specs/2026-04-08-config-http-endpoints-design.md
+++ b/docs/superpowers/specs/2026-04-08-config-http-endpoints-design.md
@@ -10,6 +10,10 @@ v5.18.4 added `SmartAgent.reconfigure()` and `getActiveConfig()` as programmatic
 
 Returns current active configuration. Aliases: `/config`.
 
+This endpoint should expose a **stable runtime DTO**, not the full internal
+`SmartAgentConfig` object. Internal implementation details must not become
+public API by accident.
+
 **Response (200):**
 
 ```json
@@ -19,17 +23,48 @@ Returns current active configuration. Aliases: `/config`.
     "classifierModel": "gpt-4.1-mini",
     "helperModel": "gpt-4.1-mini"
   },
-  "parameters": {
-    "temperature": 0.7,
-    "max_tokens": 32768,
+  "agent": {
     "maxIterations": 10,
     "classificationEnabled": true
+  },
+  "llmDefaults": {
+    "temperature": 0.7,
+    "maxTokens": 32768
   }
 }
 ```
 
 - `models` — from `SmartAgent.getActiveConfig()`
-- `parameters` — from `SmartAgentConfig` (all fields exposed, consumer decides what to use)
+- `agent` — explicit whitelist of runtime-safe `SmartAgentConfig` fields
+- `llmDefaults` — optional server-side runtime state for LLM defaults; not sourced
+  from `SmartAgentConfig`
+
+### Runtime DTO contract
+
+The response must not expose "all fields" from `SmartAgentConfig`.
+Only explicitly supported fields are part of the HTTP contract.
+
+Initial whitelist:
+
+- `agent.maxIterations`
+- `agent.maxToolCalls`
+- `agent.ragQueryK`
+- `agent.toolUnavailableTtlMs`
+- `agent.showReasoning`
+- `agent.historyAutoSummarizeLimit`
+- `agent.classificationEnabled`
+- `agent.ragRetrievalMode`
+- `agent.ragTranslationEnabled`
+- `agent.ragUpsertEnabled`
+- `llmDefaults.temperature`
+- `llmDefaults.maxTokens`
+
+Rationale:
+
+- `temperature` / `maxTokens` are request/LLM defaults, not `SmartAgentConfig`
+  fields
+- exposing the full internal config would create an unstable public API
+- deprecated/internal-only fields must stay private unless explicitly promoted
 
 ### PUT /v1/config
 
@@ -42,7 +77,10 @@ Partial runtime reconfiguration. Aliases: `/config`.
   "models": {
     "classifierModel": "gpt-4o"
   },
-  "parameters": {
+  "agent": {
+    "classificationEnabled": false
+  },
+  "llmDefaults": {
     "temperature": 0.5
   }
 }
@@ -51,7 +89,34 @@ Partial runtime reconfiguration. Aliases: `/config`.
 Both blocks are optional. Omitted fields keep current values.
 
 - `models` fields → resolved via `IModelResolver` → passed to `SmartAgent.reconfigure()`
-- `parameters` fields → passed to `SmartAgent.applyConfigUpdate()`
+- `agent` fields → validated against whitelist → passed to `SmartAgent.applyConfigUpdate()`
+- `llmDefaults` fields → applied to server-held runtime defaults used for new requests
+
+### Update semantics
+
+`PUT /v1/config` is **atomic**:
+
+- validate request body first
+- resolve all requested model changes first
+- if any validation/resolution step fails, apply nothing
+- only after all checks succeed, commit model + agent + llm default updates
+
+This avoids partial runtime state changes when one of several requested updates
+fails.
+
+### Reconfigure safety
+
+Current `SmartAgent.reconfigure()` replaces live LLM instances but does not
+preserve builder-time wrappers automatically (retry, circuit breaker, rate
+limiter, etc.).
+
+Therefore one of these must be true in implementation:
+
+- `IModelResolver` returns fully wrapped production-ready `ILlm` instances, or
+- `SmartServer` reapplies the same wrappers before calling `reconfigure()`
+
+Using raw provider instances here would silently change runtime behavior after a
+successful config update.
 
 **Response (200):** updated config in the same format as GET.
 
@@ -60,9 +125,11 @@ Both blocks are optional. Omitted fields keep current values.
 | Status | Condition |
 |--------|-----------|
 | 400 | Invalid JSON body |
+| 400 | Unknown or unsupported fields in `agent` / `llmDefaults` |
 | 400 | `models` sent but `IModelResolver` not configured |
+| 400 / 422 | Requested model name is invalid or unsupported |
 | 405 | Wrong HTTP method (not GET/PUT) |
-| 500 | Model resolution failed (e.g., unknown model, provider error) |
+| 500 | Internal model resolution failure (provider/resolver crashed, timed out, etc.) |
 
 ## IModelResolver Interface
 
@@ -74,14 +141,23 @@ export interface IModelResolver {
 
 ### DefaultModelResolver
 
-Default implementation in `src/smart-agent/providers.ts`. Wraps existing `resolve*Llm()` functions. Requires access to current config (API keys, provider settings).
+Default implementation in `src/smart-agent/providers.ts`.
+It should be built on top of existing provider factory APIs (`makeLlm()` /
+`makeDefaultLlm()`), not on imaginary `resolve*Llm()` helpers.
+
+It requires access to current provider settings (API keys, base URLs, per-role
+provider config) and should return the same wrapper shape expected in normal
+server startup.
 
 ### Integration
 
 - `SmartServerConfig` gets optional `modelResolver?: IModelResolver` field
-- `SmartAgentBuilder` gets `.withModelResolver()` setter
-- Passed to `SmartServer`, used only in `PUT /v1/config` for model fields
+- `SmartServer` uses it only in `PUT /v1/config` for model fields
 - If not configured and client sends model fields → 400
+
+`SmartAgentBuilder.withModelResolver()` is not required unless a separate
+builder-level use case appears. The HTTP endpoint is owned by `SmartServer`,
+so server-level DI is sufficient.
 
 ### Exports
 
@@ -95,12 +171,23 @@ Added to `SmartServer._handle()` alongside existing endpoints:
 - `PUT /v1/config` or `/config` → apply partial update
 - Other methods on `/v1/config` → 405
 
-Follows existing patterns: `readBody()`, `JSON.parse()`, `jsonError()`, CORS headers.
+Implementation notes:
+
+- follow existing patterns: `readBody()`, `JSON.parse()`, `jsonError()`, CORS
+  headers
+- for `405`, include `Allow: GET, PUT, OPTIONS`
+- `/config` remains an alias to `/v1/config`
+- path-specific `405` handling is expected even though unrelated unmatched
+  routes still return `404`
 
 ## Out of Scope
 
 - **Authentication/authorization** — separate issue; no endpoints currently have auth. Planned as `IAuthMiddleware` interface with no-op default.
 - **`_meta` in `/v1/models`** — rejected; config and models are separate resources.
+- **Persisting HTTP config updates back to YAML** — this endpoint changes only
+  in-memory runtime state for the active server process
+- **Reconfiguring arbitrary provider credentials over HTTP** — only model
+  selection and explicit runtime-safe fields are in scope
 
 ## Tests
 
@@ -112,5 +199,10 @@ Test cases:
 - `PUT /v1/config` with models + resolver — resolves and reconfigures
 - `PUT /v1/config` with models but no resolver — 400
 - `PUT /v1/config` with invalid JSON — 400
-- `PUT /v1/config` with unknown model (resolver throws) — 500
+- `PUT /v1/config` with unsupported field in agent/llmDefaults — 400
+- `PUT /v1/config` with unknown model name — 400 or 422
+- `PUT /v1/config` with resolver internal error — 500
+- `PUT /v1/config` is atomic when one model resolution fails
+- `PUT /v1/config` preserves configured wrappers for reconfigured models
+- `GET /v1/config` returns only whitelisted fields, not raw full `SmartAgentConfig`
 - `GET /config` alias works

--- a/src/index.ts
+++ b/src/index.ts
@@ -222,6 +222,7 @@ export { FallbackLlmCallStrategy } from './smart-agent/policy/fallback-llm-call-
 export { NonStreamingLlmCallStrategy } from './smart-agent/policy/non-streaming-llm-call-strategy.js';
 export { StreamingLlmCallStrategy } from './smart-agent/policy/streaming-llm-call-strategy.js';
 export {
+  DefaultModelResolver,
   type EmbedderResolutionConfig,
   type EmbedderResolutionOptions,
   type LlmProviderConfig,

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,6 +126,7 @@ export type {
   IModelInfo,
   IModelProvider,
 } from './smart-agent/interfaces/model-provider.js';
+export type { IModelResolver } from './smart-agent/interfaces/model-resolver.js';
 // Query Embedding
 export type { IQueryEmbedding } from './smart-agent/interfaces/query-embedding.js';
 // Embedder & RAG

--- a/src/smart-agent/__tests__/config-endpoints.test.ts
+++ b/src/smart-agent/__tests__/config-endpoints.test.ts
@@ -276,6 +276,64 @@ describe('PUT /v1/config', () => {
   });
 });
 
+describe('llmDefaults in config', () => {
+  it('GET /v1/config includes llmDefaults', async () => {
+    const server = new SmartServer({
+      port: 0,
+      llm: { apiKey: 'test', model: 'test-model', temperature: 0.9 },
+      skipModelValidation: true,
+    });
+    const handle = await server.start();
+    try {
+      const res = await httpRequest(handle.port, 'GET', '/v1/config');
+      assert.equal(res.status, 200);
+      const body = res.body as Record<string, unknown>;
+      assert.ok(body.llmDefaults);
+      const defaults = body.llmDefaults as Record<string, unknown>;
+      assert.equal(defaults.temperature, 0.9);
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('PUT /v1/config updates llmDefaults', async () => {
+    const server = new SmartServer({
+      port: 0,
+      llm: { apiKey: 'test', model: 'test-model', temperature: 0.7 },
+      skipModelValidation: true,
+    });
+    const handle = await server.start();
+    try {
+      const res = await httpRequest(handle.port, 'PUT', '/v1/config', {
+        llmDefaults: { temperature: 0.3 },
+      });
+      assert.equal(res.status, 200);
+      const body = res.body as Record<string, unknown>;
+      const defaults = body.llmDefaults as Record<string, unknown>;
+      assert.equal(defaults.temperature, 0.3);
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('rejects unsupported llmDefaults fields', async () => {
+    const server = new SmartServer({
+      port: 0,
+      llm: { apiKey: 'test', model: 'test-model' },
+      skipModelValidation: true,
+    });
+    const handle = await server.start();
+    try {
+      const res = await httpRequest(handle.port, 'PUT', '/v1/config', {
+        llmDefaults: { topP: 0.9 },
+      });
+      assert.equal(res.status, 400);
+    } finally {
+      await handle.close();
+    }
+  });
+});
+
 describe('PUT /v1/config — models', () => {
   it('resolves and reconfigures models when resolver is set', async () => {
     const newMain = { ...makeTestLlm([{ content: 'ok' }]), model: 'gpt-4o' };

--- a/src/smart-agent/__tests__/config-endpoints.test.ts
+++ b/src/smart-agent/__tests__/config-endpoints.test.ts
@@ -1,7 +1,51 @@
 import assert from 'node:assert/strict';
+import { request } from 'node:http';
 import { describe, it } from 'node:test';
 import { SmartAgent } from '../agent.js';
+import { SmartServer } from '../smart-server.js';
 import { makeDefaultDeps } from '../testing/index.js';
+
+function httpRequest(
+  port: number,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<{ status: number; body: unknown; raw: string }> {
+  return new Promise((resolve, reject) => {
+    const bodyStr = body !== undefined ? JSON.stringify(body) : undefined;
+    const options = {
+      host: '127.0.0.1',
+      port,
+      method,
+      path,
+      headers: {
+        'Content-Type': 'application/json',
+        ...(bodyStr !== undefined
+          ? { 'Content-Length': Buffer.byteLength(bodyStr) }
+          : {}),
+      },
+    };
+    const req = request(options, (res) => {
+      const chunks: Buffer[] = [];
+      res.on('data', (chunk: Buffer) => chunks.push(chunk));
+      res.on('end', () => {
+        const text = Buffer.concat(chunks).toString('utf8');
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(text);
+        } catch {
+          parsed = text;
+        }
+        resolve({ status: res.statusCode ?? 0, body: parsed, raw: text });
+      });
+    });
+    req.on('error', reject);
+    if (bodyStr !== undefined) {
+      req.write(bodyStr);
+    }
+    req.end();
+  });
+}
 
 describe('SmartAgent.getAgentConfig', () => {
   it('returns only whitelisted fields', () => {
@@ -48,5 +92,66 @@ describe('SmartAgent.getAgentConfig', () => {
     assert.equal(config.maxIterations, 5);
     assert.equal(config.maxToolCalls, undefined);
     assert.equal(config.classificationEnabled, undefined);
+  });
+});
+
+describe('GET /v1/config', () => {
+  it('returns models and agent config', async () => {
+    const server = new SmartServer({
+      port: 0,
+      llm: { apiKey: 'test', model: 'test-model' },
+      skipModelValidation: true,
+      agent: { maxIterations: 8 },
+    });
+    const handle = await server.start();
+    try {
+      const res = await httpRequest(handle.port, 'GET', '/v1/config');
+      assert.equal(res.status, 200);
+      const body = res.body as Record<string, unknown>;
+      assert.ok(body.models);
+      assert.ok(body.agent);
+      const agent = body.agent as Record<string, unknown>;
+      assert.equal(agent.maxIterations, 8);
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('works with /config alias', async () => {
+    const server = new SmartServer({
+      port: 0,
+      llm: { apiKey: 'test', model: 'test-model' },
+      skipModelValidation: true,
+    });
+    const handle = await server.start();
+    try {
+      const res = await httpRequest(handle.port, 'GET', '/config');
+      assert.equal(res.status, 200);
+      const body = res.body as Record<string, unknown>;
+      assert.ok(body.models);
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('returns only whitelisted fields, not raw SmartAgentConfig', async () => {
+    const server = new SmartServer({
+      port: 0,
+      llm: { apiKey: 'test', model: 'test-model' },
+      skipModelValidation: true,
+      agent: { maxIterations: 5, timeoutMs: 9999, tokenLimit: 4096 },
+    });
+    const handle = await server.start();
+    try {
+      const res = await httpRequest(handle.port, 'GET', '/v1/config');
+      assert.equal(res.status, 200);
+      const body = res.body as Record<string, unknown>;
+      const agent = body.agent as Record<string, unknown>;
+      assert.equal(agent.maxIterations, 5);
+      assert.equal(agent.timeoutMs, undefined);
+      assert.equal(agent.tokenLimit, undefined);
+    } finally {
+      await handle.close();
+    }
   });
 });

--- a/src/smart-agent/__tests__/config-endpoints.test.ts
+++ b/src/smart-agent/__tests__/config-endpoints.test.ts
@@ -2,8 +2,21 @@ import assert from 'node:assert/strict';
 import { request } from 'node:http';
 import { describe, it } from 'node:test';
 import { SmartAgent } from '../agent.js';
+import type { ILlm } from '../interfaces/llm.js';
+import type { IModelResolver } from '../interfaces/model-resolver.js';
 import { SmartServer } from '../smart-server.js';
-import { makeDefaultDeps } from '../testing/index.js';
+import { makeDefaultDeps, makeLlm as makeTestLlm } from '../testing/index.js';
+
+function makeResolver(results: Record<string, ILlm | Error>): IModelResolver {
+  return {
+    async resolve(modelName: string): Promise<ILlm> {
+      const result = results[modelName];
+      if (!result) throw new Error(`Unknown model: ${modelName}`);
+      if (result instanceof Error) throw result;
+      return result;
+    },
+  };
+}
 
 function httpRequest(
   port: number,
@@ -257,6 +270,112 @@ describe('PUT /v1/config', () => {
     try {
       const res = await httpRequest(handle.port, 'DELETE', '/v1/config');
       assert.equal(res.status, 405);
+    } finally {
+      await handle.close();
+    }
+  });
+});
+
+describe('PUT /v1/config — models', () => {
+  it('resolves and reconfigures models when resolver is set', async () => {
+    const newMain = { ...makeTestLlm([{ content: 'ok' }]), model: 'gpt-4o' };
+    const resolver = makeResolver({ 'gpt-4o': newMain });
+
+    const server = new SmartServer({
+      port: 0,
+      llm: { apiKey: 'test', model: 'test-model' },
+      skipModelValidation: true,
+      modelResolver: resolver,
+    });
+    const handle = await server.start();
+    try {
+      const res = await httpRequest(handle.port, 'PUT', '/v1/config', {
+        models: { mainModel: 'gpt-4o' },
+      });
+      assert.equal(res.status, 200);
+      const body = res.body as Record<string, unknown>;
+      const models = body.models as Record<string, unknown>;
+      assert.equal(models.mainModel, 'gpt-4o');
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('returns 400 when models sent but no resolver configured', async () => {
+    const server = new SmartServer({
+      port: 0,
+      llm: { apiKey: 'test', model: 'test-model' },
+      skipModelValidation: true,
+    });
+    const handle = await server.start();
+    try {
+      const res = await httpRequest(handle.port, 'PUT', '/v1/config', {
+        models: { mainModel: 'gpt-4o' },
+      });
+      assert.equal(res.status, 400);
+      const body = res.body as Record<string, unknown>;
+      const error = body.error as Record<string, unknown>;
+      assert.ok(
+        String(error.message).includes('model resolver not configured'),
+      );
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('returns 500 when model resolution fails', async () => {
+    const resolver = makeResolver({
+      'bad-model': new Error('Provider unreachable'),
+    });
+
+    const server = new SmartServer({
+      port: 0,
+      llm: { apiKey: 'test', model: 'test-model' },
+      skipModelValidation: true,
+      modelResolver: resolver,
+    });
+    const handle = await server.start();
+    try {
+      const res = await httpRequest(handle.port, 'PUT', '/v1/config', {
+        models: { mainModel: 'bad-model' },
+      });
+      assert.equal(res.status, 500);
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('is atomic — no changes applied when one model resolution fails', async () => {
+    const goodLlm = {
+      ...makeTestLlm([{ content: 'ok' }]),
+      model: 'good-model',
+    };
+    const resolver = makeResolver({
+      'good-model': goodLlm,
+      'bad-model': new Error('resolution failed'),
+    });
+
+    const server = new SmartServer({
+      port: 0,
+      llm: { apiKey: 'test', model: 'test-model' },
+      skipModelValidation: true,
+      modelResolver: resolver,
+      agent: { maxIterations: 10 },
+    });
+    const handle = await server.start();
+    try {
+      // Attempt to update both models + agent param — one model fails
+      const res = await httpRequest(handle.port, 'PUT', '/v1/config', {
+        models: { mainModel: 'good-model', classifierModel: 'bad-model' },
+        agent: { maxIterations: 99 },
+      });
+      assert.equal(res.status, 500);
+
+      // Verify nothing changed
+      const getRes = await httpRequest(handle.port, 'GET', '/v1/config');
+      const body = getRes.body as Record<string, unknown>;
+      const agent = body.agent as Record<string, unknown>;
+      assert.equal(agent.maxIterations, 10); // unchanged
     } finally {
       await handle.close();
     }

--- a/src/smart-agent/__tests__/config-endpoints.test.ts
+++ b/src/smart-agent/__tests__/config-endpoints.test.ts
@@ -155,3 +155,110 @@ describe('GET /v1/config', () => {
     }
   });
 });
+
+describe('PUT /v1/config', () => {
+  it('updates agent parameters and returns updated config', async () => {
+    const server = new SmartServer({
+      port: 0,
+      llm: { apiKey: 'test', model: 'test-model' },
+      skipModelValidation: true,
+      agent: { maxIterations: 10 },
+    });
+    const handle = await server.start();
+    try {
+      const res = await httpRequest(handle.port, 'PUT', '/v1/config', {
+        agent: { maxIterations: 20, classificationEnabled: false },
+      });
+      assert.equal(res.status, 200);
+      const body = res.body as Record<string, unknown>;
+      const agent = body.agent as Record<string, unknown>;
+      assert.equal(agent.maxIterations, 20);
+      assert.equal(agent.classificationEnabled, false);
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('rejects unsupported agent fields', async () => {
+    const server = new SmartServer({
+      port: 0,
+      llm: { apiKey: 'test', model: 'test-model' },
+      skipModelValidation: true,
+    });
+    const handle = await server.start();
+    try {
+      const res = await httpRequest(handle.port, 'PUT', '/v1/config', {
+        agent: { timeoutMs: 9999 },
+      });
+      assert.equal(res.status, 400);
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('rejects invalid JSON body', async () => {
+    const server = new SmartServer({
+      port: 0,
+      llm: { apiKey: 'test', model: 'test-model' },
+      skipModelValidation: true,
+    });
+    const handle = await server.start();
+    try {
+      // Send raw non-JSON body
+      const res = await new Promise<{
+        status: number;
+        body: unknown;
+        raw: string;
+      }>((resolve, reject) => {
+        const req = request(
+          {
+            host: '127.0.0.1',
+            port: handle.port,
+            method: 'PUT',
+            path: '/v1/config',
+            headers: { 'Content-Type': 'application/json' },
+          },
+          (httpRes) => {
+            const chunks: Buffer[] = [];
+            httpRes.on('data', (c: Buffer) => chunks.push(c));
+            httpRes.on('end', () => {
+              const text = Buffer.concat(chunks).toString('utf8');
+              let parsed: unknown;
+              try {
+                parsed = JSON.parse(text);
+              } catch {
+                parsed = text;
+              }
+              resolve({
+                status: httpRes.statusCode ?? 0,
+                body: parsed,
+                raw: text,
+              });
+            });
+          },
+        );
+        req.on('error', reject);
+        req.write('not-json');
+        req.end();
+      });
+      assert.equal(res.status, 400);
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('returns 405 for unsupported methods on /v1/config', async () => {
+    const server = new SmartServer({
+      port: 0,
+      llm: { apiKey: 'test', model: 'test-model' },
+      skipModelValidation: true,
+    });
+    const handle = await server.start();
+    try {
+      const res = await httpRequest(handle.port, 'DELETE', '/v1/config');
+      assert.equal(res.status, 405);
+    } finally {
+      await handle.close();
+    }
+  });
+});

--- a/src/smart-agent/__tests__/config-endpoints.test.ts
+++ b/src/smart-agent/__tests__/config-endpoints.test.ts
@@ -296,64 +296,6 @@ describe('PUT /v1/config', () => {
   });
 });
 
-describe('llmDefaults in config', () => {
-  it('GET /v1/config includes llmDefaults', async () => {
-    const server = new SmartServer({
-      port: 0,
-      llm: { apiKey: 'test', model: 'test-model', temperature: 0.9 },
-      skipModelValidation: true,
-    });
-    const handle = await server.start();
-    try {
-      const res = await httpRequest(handle.port, 'GET', '/v1/config');
-      assert.equal(res.status, 200);
-      const body = res.body as Record<string, unknown>;
-      assert.ok(body.llmDefaults);
-      const defaults = body.llmDefaults as Record<string, unknown>;
-      assert.equal(defaults.temperature, 0.9);
-    } finally {
-      await handle.close();
-    }
-  });
-
-  it('PUT /v1/config updates llmDefaults', async () => {
-    const server = new SmartServer({
-      port: 0,
-      llm: { apiKey: 'test', model: 'test-model', temperature: 0.7 },
-      skipModelValidation: true,
-    });
-    const handle = await server.start();
-    try {
-      const res = await httpRequest(handle.port, 'PUT', '/v1/config', {
-        llmDefaults: { temperature: 0.3 },
-      });
-      assert.equal(res.status, 200);
-      const body = res.body as Record<string, unknown>;
-      const defaults = body.llmDefaults as Record<string, unknown>;
-      assert.equal(defaults.temperature, 0.3);
-    } finally {
-      await handle.close();
-    }
-  });
-
-  it('rejects unsupported llmDefaults fields', async () => {
-    const server = new SmartServer({
-      port: 0,
-      llm: { apiKey: 'test', model: 'test-model' },
-      skipModelValidation: true,
-    });
-    const handle = await server.start();
-    try {
-      const res = await httpRequest(handle.port, 'PUT', '/v1/config', {
-        llmDefaults: { topP: 0.9 },
-      });
-      assert.equal(res.status, 400);
-    } finally {
-      await handle.close();
-    }
-  });
-});
-
 describe('PUT /v1/config — models', () => {
   it('resolves and reconfigures models when resolver is set', async () => {
     const newMain = { ...makeTestLlm([{ content: 'ok' }]), model: 'gpt-4o' };

--- a/src/smart-agent/__tests__/config-endpoints.test.ts
+++ b/src/smart-agent/__tests__/config-endpoints.test.ts
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { SmartAgent } from '../agent.js';
+import { makeDefaultDeps } from '../testing/index.js';
+
+describe('SmartAgent.getAgentConfig', () => {
+  it('returns only whitelisted fields', () => {
+    const { deps } = makeDefaultDeps();
+    const agent = new SmartAgent(deps, {
+      maxIterations: 10,
+      maxToolCalls: 5,
+      ragQueryK: 15,
+      toolUnavailableTtlMs: 30_000,
+      showReasoning: true,
+      historyAutoSummarizeLimit: 20,
+      classificationEnabled: true,
+      ragRetrievalMode: 'auto',
+      ragTranslationEnabled: true,
+      ragUpsertEnabled: false,
+      // These should NOT appear in the output:
+      timeoutMs: 5000,
+      tokenLimit: 4096,
+      smartAgentEnabled: true,
+    });
+
+    const config = agent.getAgentConfig();
+
+    assert.deepEqual(config, {
+      maxIterations: 10,
+      maxToolCalls: 5,
+      ragQueryK: 15,
+      toolUnavailableTtlMs: 30_000,
+      showReasoning: true,
+      historyAutoSummarizeLimit: 20,
+      classificationEnabled: true,
+      ragRetrievalMode: 'auto',
+      ragTranslationEnabled: true,
+      ragUpsertEnabled: false,
+    });
+  });
+
+  it('returns defaults for omitted optional fields', () => {
+    const { deps } = makeDefaultDeps();
+    const agent = new SmartAgent(deps, { maxIterations: 5 });
+
+    const config = agent.getAgentConfig();
+
+    assert.equal(config.maxIterations, 5);
+    assert.equal(config.maxToolCalls, undefined);
+    assert.equal(config.classificationEnabled, undefined);
+  });
+});

--- a/src/smart-agent/__tests__/config-endpoints.test.ts
+++ b/src/smart-agent/__tests__/config-endpoints.test.ts
@@ -274,6 +274,26 @@ describe('PUT /v1/config', () => {
       await handle.close();
     }
   });
+
+  it('works with /config alias for PUT', async () => {
+    const server = new SmartServer({
+      llm: { apiKey: 'test', model: 'test-model' },
+      skipModelValidation: true,
+      agent: { maxIterations: 10 },
+    });
+    const handle = await server.start();
+    try {
+      const res = await httpRequest(handle.port, 'PUT', '/config', {
+        agent: { maxIterations: 15 },
+      });
+      assert.equal(res.status, 200);
+      const body = res.body as Record<string, unknown>;
+      const agent = body.agent as Record<string, unknown>;
+      assert.equal(agent.maxIterations, 15);
+    } finally {
+      await handle.close();
+    }
+  });
 });
 
 describe('llmDefaults in config', () => {
@@ -398,6 +418,31 @@ describe('PUT /v1/config — models', () => {
         models: { mainModel: 'bad-model' },
       });
       assert.equal(res.status, 500);
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('returns 500 for unknown model name', async () => {
+    const resolver: IModelResolver = {
+      async resolve(modelName: string): Promise<ILlm> {
+        throw new Error(`Unknown model: ${modelName}`);
+      },
+    };
+    const server = new SmartServer({
+      llm: { apiKey: 'test', model: 'test-model' },
+      skipModelValidation: true,
+      modelResolver: resolver,
+    });
+    const handle = await server.start();
+    try {
+      const res = await httpRequest(handle.port, 'PUT', '/v1/config', {
+        models: { mainModel: 'nonexistent-model' },
+      });
+      assert.equal(res.status, 500);
+      const body = res.body as Record<string, unknown>;
+      const error = body.error as Record<string, unknown>;
+      assert.ok(String(error.message).includes('nonexistent-model'));
     } finally {
       await handle.close();
     }

--- a/src/smart-agent/agent.ts
+++ b/src/smart-agent/agent.ts
@@ -322,6 +322,33 @@ export class SmartAgent {
     };
   }
 
+  /** Returns whitelisted runtime-safe agent config fields (for HTTP DTO). */
+  getAgentConfig(): {
+    maxIterations: number;
+    maxToolCalls?: number;
+    ragQueryK?: number;
+    toolUnavailableTtlMs?: number;
+    showReasoning?: boolean;
+    historyAutoSummarizeLimit?: number;
+    classificationEnabled?: boolean;
+    ragRetrievalMode?: 'auto' | 'always' | 'never';
+    ragTranslationEnabled?: boolean;
+    ragUpsertEnabled?: boolean;
+  } {
+    return {
+      maxIterations: this.config.maxIterations,
+      maxToolCalls: this.config.maxToolCalls,
+      ragQueryK: this.config.ragQueryK,
+      toolUnavailableTtlMs: this.config.toolUnavailableTtlMs,
+      showReasoning: this.config.showReasoning,
+      historyAutoSummarizeLimit: this.config.historyAutoSummarizeLimit,
+      classificationEnabled: this.config.classificationEnabled,
+      ragRetrievalMode: this.config.ragRetrievalMode,
+      ragTranslationEnabled: this.config.ragTranslationEnabled,
+      ragUpsertEnabled: this.config.ragUpsertEnabled,
+    };
+  }
+
   async healthCheck(options?: CallOptions): Promise<
     Result<
       {

--- a/src/smart-agent/interfaces/model-resolver.ts
+++ b/src/smart-agent/interfaces/model-resolver.ts
@@ -1,0 +1,12 @@
+import type { ILlm } from './llm.js';
+
+/**
+ * Resolves a model name + role into a ready-to-use ILlm instance.
+ * Used by SmartServer to handle PUT /v1/config model changes.
+ */
+export interface IModelResolver {
+  resolve(
+    modelName: string,
+    role: 'main' | 'classifier' | 'helper',
+  ): Promise<ILlm>;
+}

--- a/src/smart-agent/providers.ts
+++ b/src/smart-agent/providers.ts
@@ -21,6 +21,7 @@ import { MCPClientWrapper } from '../mcp/client.js';
 import { LlmAdapter } from './adapters/llm-adapter.js';
 import { NonStreamingLlm } from './adapters/non-streaming-llm.js';
 import type { ILlm } from './interfaces/llm.js';
+import type { IModelResolver } from './interfaces/model-resolver.js';
 import type { EmbedderFactory, IEmbedder, IRag } from './interfaces/rag.js';
 import { builtInEmbedderFactories } from './rag/embedder-factories.js';
 import { InMemoryRag } from './rag/in-memory-rag.js';
@@ -169,6 +170,26 @@ export function makeDefaultLlm(
   temperature: number,
 ): ILlm {
   return makeLlm({ provider: 'deepseek', apiKey, model }, temperature);
+}
+
+/**
+ * Default IModelResolver — delegates to makeLlm() with the given provider settings.
+ * Returns fully constructed ILlm instances ready for use with SmartAgent.reconfigure().
+ */
+export class DefaultModelResolver implements IModelResolver {
+  constructor(
+    private readonly providerConfig: Omit<LlmProviderConfig, 'model'>,
+    private readonly defaults: { temperature?: number } = {},
+  ) {}
+
+  async resolve(
+    modelName: string,
+    role: 'main' | 'classifier' | 'helper',
+  ): Promise<ILlm> {
+    const temperature =
+      this.defaults.temperature ?? (role === 'main' ? 0.7 : 0.1);
+    return makeLlm({ ...this.providerConfig, model: modelName }, temperature);
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/smart-agent/smart-server.ts
+++ b/src/smart-agent/smart-server.ts
@@ -326,15 +326,6 @@ export class SmartServer {
         )
       : undefined;
 
-    // Mutable runtime LLM defaults exposed via /v1/config
-    const llmDefaults = {
-      temperature: mainTemp,
-      maxTokens:
-        pipeline?.llm?.main?.maxTokens != null
-          ? Number(pipeline.llm.main.maxTokens)
-          : undefined,
-    };
-
     // ---- Plugin loader -------------------------------------------------------
     const pluginLoader: IPluginLoader =
       this.cfg.pluginLoader ??
@@ -609,7 +600,6 @@ export class SmartServer {
         healthChecker,
         modelProvider,
         adapterMap,
-        llmDefaults,
       ).catch((err) => {
         if (!res.headersSent) {
           res.writeHead(500, { 'Content-Type': 'application/json' });
@@ -652,7 +642,6 @@ export class SmartServer {
     healthChecker: HealthChecker,
     modelProvider?: IModelProvider,
     adapterMap?: Map<string, ILlmApiAdapter>,
-    llmDefaults?: { temperature: number; maxTokens?: number },
   ): Promise<void> {
     const rawUrl = req.url ?? '/';
     const urlPath = rawUrl.split('?')[0].replace(/\/$/, '') || '/';
@@ -708,13 +697,13 @@ export class SmartServer {
       if (req.method === 'GET') {
         const models = smartAgent.getActiveConfig();
         const agent = smartAgent.getAgentConfig();
-        const body = { models, agent, llmDefaults };
+        const body = { models, agent };
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify(body));
         return;
       }
       if (req.method === 'PUT') {
-        await this._handleConfigUpdate(req, res, smartAgent, llmDefaults);
+        await this._handleConfigUpdate(req, res, smartAgent);
         return;
       }
       // 405 for other methods
@@ -1255,17 +1244,10 @@ export class SmartServer {
     'ragUpsertEnabled',
   ]);
 
-  /** Whitelisted llmDefaults fields allowed via PUT /v1/config. */
-  private static readonly LLM_DEFAULTS_FIELDS = new Set([
-    'temperature',
-    'maxTokens',
-  ]);
-
   private async _handleConfigUpdate(
     req: IncomingMessage,
     res: ServerResponse,
     smartAgent: SmartAgent,
-    llmDefaults?: { temperature: number; maxTokens?: number },
   ): Promise<void> {
     const raw = await readBody(req);
     let parsed: unknown;
@@ -1316,38 +1298,6 @@ export class SmartServer {
         res.end(
           jsonError(
             `Unsupported agent config fields: ${unsupported.join(', ')}`,
-            'invalid_request_error',
-          ),
-        );
-        return;
-      }
-    }
-
-    // --- Validate llmDefaults fields ---
-    if (body.llmDefaults !== undefined) {
-      if (
-        typeof body.llmDefaults !== 'object' ||
-        body.llmDefaults === null ||
-        Array.isArray(body.llmDefaults)
-      ) {
-        res.writeHead(400, { 'Content-Type': 'application/json' });
-        res.end(
-          jsonError(
-            '"llmDefaults" must be a JSON object',
-            'invalid_request_error',
-          ),
-        );
-        return;
-      }
-      const fields = body.llmDefaults as Record<string, unknown>;
-      const unsupported = Object.keys(fields).filter(
-        (k) => !SmartServer.LLM_DEFAULTS_FIELDS.has(k),
-      );
-      if (unsupported.length > 0) {
-        res.writeHead(400, { 'Content-Type': 'application/json' });
-        res.end(
-          jsonError(
-            `Unsupported llmDefaults fields: ${unsupported.join(', ')}`,
             'invalid_request_error',
           ),
         );
@@ -1429,18 +1379,10 @@ export class SmartServer {
     if (body.agent) {
       smartAgent.applyConfigUpdate(body.agent as Record<string, unknown>);
     }
-    if (body.llmDefaults && llmDefaults) {
-      const fields = body.llmDefaults as Record<string, unknown>;
-      if (fields.temperature !== undefined)
-        llmDefaults.temperature = Number(fields.temperature);
-      if (fields.maxTokens !== undefined)
-        llmDefaults.maxTokens = Number(fields.maxTokens);
-    }
-
     // --- Return updated config ---
     const models = smartAgent.getActiveConfig();
     const agent = smartAgent.getAgentConfig();
     res.writeHead(200, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify({ models, agent, llmDefaults }));
+    res.end(JSON.stringify({ models, agent }));
   }
 }

--- a/src/smart-agent/smart-server.ts
+++ b/src/smart-agent/smart-server.ts
@@ -7,7 +7,12 @@ import type { IncomingMessage, ServerResponse } from 'node:http';
 import http from 'node:http';
 import { PACKAGE_VERSION } from '../generated/version.js';
 import type { Message } from '../types.js';
-import type { SmartAgent, SmartAgentRagStores, StopReason } from './agent.js';
+import type {
+  SmartAgent,
+  SmartAgentRagStores,
+  SmartAgentReconfigureOptions,
+  StopReason,
+} from './agent.js';
 import { SmartAgentBuilder, type SmartAgentHandle } from './builder.js';
 import {
   ConfigWatcher,
@@ -22,6 +27,7 @@ import { AdapterValidationError } from './interfaces/api-adapter.js';
 import type { IClientAdapter } from './interfaces/client-adapter.js';
 import type { IMcpClient } from './interfaces/mcp-client.js';
 import type { IModelProvider } from './interfaces/model-provider.js';
+import type { IModelResolver } from './interfaces/model-resolver.js';
 import type { EmbedderFactory, IEmbedder } from './interfaces/rag.js';
 import type { IRequestLogger } from './interfaces/request-logger.js';
 import type { ISkillManager } from './interfaces/skill.js';
@@ -181,6 +187,8 @@ export interface SmartServerConfig {
   disableBuiltInAdapters?: boolean;
   /** Skip startup model validation (useful for testing). Default: false. */
   skipModelValidation?: boolean;
+  /** Model resolver for PUT /v1/config model changes. When not set, model updates are rejected with 400. */
+  modelResolver?: IModelResolver;
 }
 
 export interface SmartServerHandle {
@@ -1297,7 +1305,77 @@ export class SmartServer {
       }
     }
 
-    // --- Apply agent config update ---
+    // --- Validate and resolve models (atomic: resolve ALL before mutating) ---
+    let resolvedModels: SmartAgentReconfigureOptions | undefined;
+    if (body.models !== undefined) {
+      if (
+        typeof body.models !== 'object' ||
+        body.models === null ||
+        Array.isArray(body.models)
+      ) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(
+          jsonError('"models" must be a JSON object', 'invalid_request_error'),
+        );
+        return;
+      }
+      if (!this.cfg.modelResolver) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(
+          jsonError('model resolver not configured', 'invalid_request_error'),
+        );
+        return;
+      }
+      const modelFields = body.models as Record<string, unknown>;
+      const validKeys = new Set([
+        'mainModel',
+        'classifierModel',
+        'helperModel',
+      ]);
+      const unknownKeys = Object.keys(modelFields).filter(
+        (k) => !validKeys.has(k),
+      );
+      if (unknownKeys.length > 0) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(
+          jsonError(
+            `Unknown model fields: ${unknownKeys.join(', ')}`,
+            'invalid_request_error',
+          ),
+        );
+        return;
+      }
+      try {
+        resolvedModels = {};
+        if (modelFields.mainModel) {
+          resolvedModels.mainLlm = await this.cfg.modelResolver.resolve(
+            String(modelFields.mainModel),
+            'main',
+          );
+        }
+        if (modelFields.classifierModel) {
+          resolvedModels.classifierLlm = await this.cfg.modelResolver.resolve(
+            String(modelFields.classifierModel),
+            'classifier',
+          );
+        }
+        if (modelFields.helperModel) {
+          resolvedModels.helperLlm = await this.cfg.modelResolver.resolve(
+            String(modelFields.helperModel),
+            'helper',
+          );
+        }
+      } catch (err) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(jsonError(String(err), 'server_error'));
+        return;
+      }
+    }
+
+    // --- All validation passed — apply mutations ---
+    if (resolvedModels) {
+      smartAgent.reconfigure(resolvedModels);
+    }
     if (body.agent) {
       smartAgent.applyConfigUpdate(body.agent as Record<string, unknown>);
     }

--- a/src/smart-agent/smart-server.ts
+++ b/src/smart-agent/smart-server.ts
@@ -326,6 +326,15 @@ export class SmartServer {
         )
       : undefined;
 
+    // Mutable runtime LLM defaults exposed via /v1/config
+    const llmDefaults = {
+      temperature: mainTemp,
+      maxTokens:
+        pipeline?.llm?.main?.maxTokens != null
+          ? Number(pipeline.llm.main.maxTokens)
+          : undefined,
+    };
+
     // ---- Plugin loader -------------------------------------------------------
     const pluginLoader: IPluginLoader =
       this.cfg.pluginLoader ??
@@ -600,6 +609,7 @@ export class SmartServer {
         healthChecker,
         modelProvider,
         adapterMap,
+        llmDefaults,
       ).catch((err) => {
         if (!res.headersSent) {
           res.writeHead(500, { 'Content-Type': 'application/json' });
@@ -642,6 +652,7 @@ export class SmartServer {
     healthChecker: HealthChecker,
     modelProvider?: IModelProvider,
     adapterMap?: Map<string, ILlmApiAdapter>,
+    llmDefaults?: { temperature: number; maxTokens?: number },
   ): Promise<void> {
     const rawUrl = req.url ?? '/';
     const urlPath = rawUrl.split('?')[0].replace(/\/$/, '') || '/';
@@ -697,13 +708,13 @@ export class SmartServer {
       if (req.method === 'GET') {
         const models = smartAgent.getActiveConfig();
         const agent = smartAgent.getAgentConfig();
-        const body = { models, agent };
+        const body = { models, agent, llmDefaults };
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify(body));
         return;
       }
       if (req.method === 'PUT') {
-        await this._handleConfigUpdate(req, res, smartAgent);
+        await this._handleConfigUpdate(req, res, smartAgent, llmDefaults);
         return;
       }
       // 405 for other methods
@@ -1248,6 +1259,7 @@ export class SmartServer {
     req: IncomingMessage,
     res: ServerResponse,
     smartAgent: SmartAgent,
+    llmDefaults?: { temperature: number; maxTokens?: number },
   ): Promise<void> {
     const raw = await readBody(req);
     let parsed: unknown;
@@ -1298,6 +1310,39 @@ export class SmartServer {
         res.end(
           jsonError(
             `Unsupported agent config fields: ${unsupported.join(', ')}`,
+            'invalid_request_error',
+          ),
+        );
+        return;
+      }
+    }
+
+    // --- Validate llmDefaults fields ---
+    const LLM_DEFAULTS_FIELDS = new Set(['temperature', 'maxTokens']);
+    if (body.llmDefaults !== undefined) {
+      if (
+        typeof body.llmDefaults !== 'object' ||
+        body.llmDefaults === null ||
+        Array.isArray(body.llmDefaults)
+      ) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(
+          jsonError(
+            '"llmDefaults" must be a JSON object',
+            'invalid_request_error',
+          ),
+        );
+        return;
+      }
+      const fields = body.llmDefaults as Record<string, unknown>;
+      const unsupported = Object.keys(fields).filter(
+        (k) => !LLM_DEFAULTS_FIELDS.has(k),
+      );
+      if (unsupported.length > 0) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(
+          jsonError(
+            `Unsupported llmDefaults fields: ${unsupported.join(', ')}`,
             'invalid_request_error',
           ),
         );
@@ -1379,11 +1424,18 @@ export class SmartServer {
     if (body.agent) {
       smartAgent.applyConfigUpdate(body.agent as Record<string, unknown>);
     }
+    if (body.llmDefaults && llmDefaults) {
+      const fields = body.llmDefaults as Record<string, unknown>;
+      if (fields.temperature !== undefined)
+        llmDefaults.temperature = Number(fields.temperature);
+      if (fields.maxTokens !== undefined)
+        llmDefaults.maxTokens = Number(fields.maxTokens);
+    }
 
     // --- Return updated config ---
     const models = smartAgent.getActiveConfig();
     const agent = smartAgent.getAgentConfig();
     res.writeHead(200, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify({ models, agent }));
+    res.end(JSON.stringify({ models, agent, llmDefaults }));
   }
 }

--- a/src/smart-agent/smart-server.ts
+++ b/src/smart-agent/smart-server.ts
@@ -694,10 +694,18 @@ export class SmartServer {
         res.end(JSON.stringify(body));
         return;
       }
-      // PUT and 405 handling will be added in Task 5
-      res.writeHead(404, { 'Content-Type': 'application/json' });
+      if (req.method === 'PUT') {
+        await this._handleConfigUpdate(req, res, smartAgent);
+        return;
+      }
+      // 405 for other methods
+      res.setHeader('Allow', 'GET, PUT, OPTIONS');
+      res.writeHead(405, { 'Content-Type': 'application/json' });
       res.end(
-        jsonError(`Cannot ${req.method} ${urlPath}`, 'invalid_request_error'),
+        jsonError(
+          `Method ${req.method} not allowed on ${urlPath}`,
+          'invalid_request_error',
+        ),
       );
       return;
     }
@@ -1212,5 +1220,92 @@ export class SmartServer {
         },
       }),
     );
+  }
+
+  /** Whitelisted agent config fields allowed via PUT /v1/config. */
+  private static readonly AGENT_CONFIG_FIELDS = new Set([
+    'maxIterations',
+    'maxToolCalls',
+    'ragQueryK',
+    'toolUnavailableTtlMs',
+    'showReasoning',
+    'historyAutoSummarizeLimit',
+    'classificationEnabled',
+    'ragRetrievalMode',
+    'ragTranslationEnabled',
+    'ragUpsertEnabled',
+  ]);
+
+  private async _handleConfigUpdate(
+    req: IncomingMessage,
+    res: ServerResponse,
+    smartAgent: SmartAgent,
+  ): Promise<void> {
+    const raw = await readBody(req);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      res.end(jsonError('Invalid JSON body', 'invalid_request_error'));
+      return;
+    }
+
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      res.end(
+        jsonError(
+          'Request body must be a JSON object',
+          'invalid_request_error',
+        ),
+      );
+      return;
+    }
+
+    const body = parsed as Record<string, unknown>;
+
+    // --- Validate agent fields against whitelist ---
+    if (body.agent !== undefined) {
+      if (
+        typeof body.agent !== 'object' ||
+        body.agent === null ||
+        Array.isArray(body.agent)
+      ) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(
+          jsonError('"agent" must be a JSON object', 'invalid_request_error'),
+        );
+        return;
+      }
+      const agentFields = body.agent as Record<string, unknown>;
+      const unsupported = Object.keys(agentFields).filter(
+        (k) => !SmartServer.AGENT_CONFIG_FIELDS.has(k),
+      );
+      if (unsupported.length > 0) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(
+          jsonError(
+            `Unsupported agent config fields: ${unsupported.join(', ')}`,
+            'invalid_request_error',
+          ),
+        );
+        return;
+      }
+    }
+
+    // --- Apply agent config update ---
+    if (body.agent) {
+      smartAgent.applyConfigUpdate(body.agent as Record<string, unknown>);
+    }
+
+    // --- Return updated config ---
+    const models = smartAgent.getActiveConfig();
+    const agent = smartAgent.getAgentConfig();
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ models, agent }));
   }
 }

--- a/src/smart-agent/smart-server.ts
+++ b/src/smart-agent/smart-server.ts
@@ -249,7 +249,7 @@ function resolveSkillManager(
 
 const CORS_HEADERS = {
   'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+  'Access-Control-Allow-Methods': 'GET, POST, PUT, OPTIONS',
   'Access-Control-Allow-Headers': 'Content-Type, Authorization',
 };
 
@@ -682,6 +682,23 @@ export class SmartServer {
     if (req.method === 'GET' && urlPath === '/v1/usage') {
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify(requestLogger.getSummary()));
+      return;
+    }
+    // /v1/config or /config
+    if (urlPath === '/v1/config' || urlPath === '/config') {
+      if (req.method === 'GET') {
+        const models = smartAgent.getActiveConfig();
+        const agent = smartAgent.getAgentConfig();
+        const body = { models, agent };
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(body));
+        return;
+      }
+      // PUT and 405 handling will be added in Task 5
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(
+        jsonError(`Cannot ${req.method} ${urlPath}`, 'invalid_request_error'),
+      );
       return;
     }
     if (

--- a/src/smart-agent/smart-server.ts
+++ b/src/smart-agent/smart-server.ts
@@ -1255,6 +1255,12 @@ export class SmartServer {
     'ragUpsertEnabled',
   ]);
 
+  /** Whitelisted llmDefaults fields allowed via PUT /v1/config. */
+  private static readonly LLM_DEFAULTS_FIELDS = new Set([
+    'temperature',
+    'maxTokens',
+  ]);
+
   private async _handleConfigUpdate(
     req: IncomingMessage,
     res: ServerResponse,
@@ -1318,7 +1324,6 @@ export class SmartServer {
     }
 
     // --- Validate llmDefaults fields ---
-    const LLM_DEFAULTS_FIELDS = new Set(['temperature', 'maxTokens']);
     if (body.llmDefaults !== undefined) {
       if (
         typeof body.llmDefaults !== 'object' ||
@@ -1336,7 +1341,7 @@ export class SmartServer {
       }
       const fields = body.llmDefaults as Record<string, unknown>;
       const unsupported = Object.keys(fields).filter(
-        (k) => !LLM_DEFAULTS_FIELDS.has(k),
+        (k) => !SmartServer.LLM_DEFAULTS_FIELDS.has(k),
       );
       if (unsupported.length > 0) {
         res.writeHead(400, { 'Content-Type': 'application/json' });
@@ -1391,25 +1396,25 @@ export class SmartServer {
         return;
       }
       try {
+        const resolver = this.cfg.modelResolver;
+        const [mainLlm, classifierLlm, helperLlm] = await Promise.all([
+          modelFields.mainModel
+            ? resolver.resolve(String(modelFields.mainModel), 'main')
+            : undefined,
+          modelFields.classifierModel
+            ? resolver.resolve(
+                String(modelFields.classifierModel),
+                'classifier',
+              )
+            : undefined,
+          modelFields.helperModel
+            ? resolver.resolve(String(modelFields.helperModel), 'helper')
+            : undefined,
+        ]);
         resolvedModels = {};
-        if (modelFields.mainModel) {
-          resolvedModels.mainLlm = await this.cfg.modelResolver.resolve(
-            String(modelFields.mainModel),
-            'main',
-          );
-        }
-        if (modelFields.classifierModel) {
-          resolvedModels.classifierLlm = await this.cfg.modelResolver.resolve(
-            String(modelFields.classifierModel),
-            'classifier',
-          );
-        }
-        if (modelFields.helperModel) {
-          resolvedModels.helperLlm = await this.cfg.modelResolver.resolve(
-            String(modelFields.helperModel),
-            'helper',
-          );
-        }
+        if (mainLlm) resolvedModels.mainLlm = mainLlm;
+        if (classifierLlm) resolvedModels.classifierLlm = classifierLlm;
+        if (helperLlm) resolvedModels.helperLlm = helperLlm;
       } catch (err) {
         res.writeHead(500, { 'Content-Type': 'application/json' });
         res.end(jsonError(String(err), 'server_error'));


### PR DESCRIPTION
## Summary

- Add `GET /v1/config` — returns active models + whitelisted agent parameters
- Add `PUT /v1/config` — atomic runtime reconfiguration of models and agent parameters
- Add `IModelResolver` interface + `DefaultModelResolver` for model name → ILlm resolution
- Add `SmartAgent.getAgentConfig()` with stable DTO whitelist (10 fields)
- PUT validates all inputs and resolves all models before applying any mutations (atomicity)
- 405 with `Allow` header for unsupported methods on `/v1/config`

Closes #78

## Test plan

- [x] 15 integration tests covering GET, PUT, aliases, whitelist enforcement, model resolution, atomicity, error codes
- [x] Build passes (`npm run build`)
- [x] Lint passes (`npm run lint`)
- [x] No regressions in existing tests (`reconfigure.test.ts`, `smart-server-api-adapters.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)