### PR TITLE
fix(#80): initialize classifierLlm from deps in SmartAgent constructor

### DIFF
--- a/src/smart-agent/agent.ts
+++ b/src/smart-agent/agent.ts
@@ -90,6 +90,7 @@ export interface SmartAgentDeps {
   mcpClients: IMcpClient[];
   ragStores: SmartAgentRagStores;
   classifier: ISubpromptClassifier;
+  classifierLlm?: ILlm;
   classifierConfig?: LlmClassifierConfig;
   assembler: IContextAssembler;
   reranker?: IReranker;
@@ -249,7 +250,7 @@ export class SmartAgent {
     this._mainLlm = deps.mainLlm;
     this._helperLlm = deps.helperLlm;
     this._classifier = deps.classifier;
-    this._classifierLlm = undefined;
+    this._classifierLlm = deps.classifierLlm;
   }
 
   private async _resolveActiveClients(opts?: CallOptions): Promise<void> {

--- a/src/smart-agent/builder.ts
+++ b/src/smart-agent/builder.ts
@@ -1036,6 +1036,7 @@ export class SmartAgentBuilder {
         mcpClients,
         ragStores,
         classifier,
+        classifierLlm,
         classifierConfig: classifierCfg,
         assembler,
         ...(log ? { logger: log } : {}),


### PR DESCRIPTION
## Summary
- **Bug**: `getActiveConfig()` always returned `classifierModel: undefined` because the constructor hardcoded `_classifierLlm = undefined`
- **Fix**: Added `classifierLlm?: ILlm` to `SmartAgentDeps`, pass it from the builder, and initialize from deps in the constructor
- All existing tests pass, no breaking changes (field is optional)

Closes #80

## Test plan
- [x] Existing `reconfigure.test.ts` tests pass (6/6)
- [x] Build passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)