### PR TITLE
docs: update ARCHITECTURE.md — history layer and history-upsert stage

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -523,7 +523,7 @@ src/
     context/               # final LLM context assembly
     health/                # health check endpoint
     interfaces/            # all public interfaces (ILlm, IRag, IMcpClient, etc.)
-    llm/                   # LLM client wrappers
+    history/               # session history memory and summarization
     logger/                # structured logging (ConsoleLogger, SessionLogger)
     metrics/               # Prometheus / metrics collection
     otel/                  # OpenTelemetry integration
@@ -584,6 +584,7 @@ Key components:
 | `skill-select` | `SkillSelectHandler` | Select skills from RAG results, load content into `ctx.skillContent` |
 | `assemble` | `AssembleHandler` | Build final LLM context; appends skill content as `## Active Skills` section |
 | `tool-loop` | `ToolLoopHandler` | Streaming LLM + tool execution loop |
+| `history-upsert` | `HistoryUpsertHandler` | Summarize turn via IHistorySummarizer, upsert to history RAG, push to recency buffer (best-effort) |
 
 **Control flow** — orchestrate child stages:
 
@@ -601,7 +602,7 @@ classify → summarize → rag-upsert
   → rag-retrieval (parallel, when: shouldRetrieve):
       stages: [translate, expand]
       after: [rag-query×3 (parallel), rerank, tool-select, skill-select]
-  → assemble → tool-loop
+  → assemble → tool-loop → history-upsert
 ```
 
 ### YAML Example


### PR DESCRIPTION
## Summary
- Replace non-existent `llm/` directory with actual `history/` directory in repo structure
- Add `history-upsert` (`HistoryUpsertHandler`) to the built-in stage types table
- Update default pipeline diagram to include `history-upsert` as the final stage

## Context
Documentation audit found three stale items in `docs/ARCHITECTURE.md`:
1. `llm/` directory was listed but never existed — replaced with `history/` (session history memory + summarization)
2. `history-upsert` stage handler was missing from the stage types table
3. Default pipeline diagram didn't show the `history-upsert` step after `tool-loop`

## Test plan
- [x] Build passes
- [x] Lint passes
- [ ] Visual review of ARCHITECTURE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)