### PR TITLE
feat: embedder token usage, embedding models discovery, custom RAG stores

### DIFF
--- a/docs/examples/plugins/05-custom-embedder.ts
+++ b/docs/examples/plugins/05-custom-embedder.ts
@@ -20,6 +20,7 @@ import type {
   EmbedderFactory,
   EmbedderFactoryConfig,
   IEmbedder,
+  IEmbedResult,
 } from '@mcp-abap-adt/llm-agent';
 
 /**
@@ -37,7 +38,7 @@ class CohereEmbedder implements IEmbedder {
     this.baseUrl = cfg.url ?? 'https://api.cohere.com';
   }
 
-  async embed(text: string): Promise<number[]> {
+  async embed(text: string): Promise<IEmbedResult> {
     const response = await fetch(`${this.baseUrl}/v1/embed`, {
       method: 'POST',
       headers: {
@@ -57,7 +58,7 @@ class CohereEmbedder implements IEmbedder {
     }
 
     const data = (await response.json()) as { embeddings: number[][] };
-    return data.embeddings[0];
+    return { vector: data.embeddings[0] };
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,6 +145,7 @@ export type {
   EmbedderFactoryConfig,
   IEmbedder,
   IEmbedderBatch,
+  IEmbedResult,
   IPrecomputedVectorRag,
   IRag,
 } from './smart-agent/interfaces/rag.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,6 +123,7 @@ export type {
   McpConnectionResult,
 } from './smart-agent/interfaces/mcp-connection-strategy.js';
 export type {
+  IModelFilter,
   IModelInfo,
   IModelProvider,
 } from './smart-agent/interfaces/model-provider.js';

--- a/src/llm-providers/anthropic.ts
+++ b/src/llm-providers/anthropic.ts
@@ -84,6 +84,10 @@ export class AnthropicProvider extends BaseLLMProvider<AnthropicConfig> {
     );
   }
 
+  async getEmbeddingModels(): Promise<IModelInfo[]> {
+    return [];
+  }
+
   /**
    * Format messages for Anthropic API
    */

--- a/src/llm-providers/base.ts
+++ b/src/llm-providers/base.ts
@@ -23,6 +23,11 @@ export interface LLMProvider {
    * Get available models
    */
   getModels?(): Promise<string[] | IModelInfo[]>;
+
+  /**
+   * Get embedding models. Best-effort; may return empty array.
+   */
+  getEmbeddingModels?(): Promise<string[] | IModelInfo[]>;
 }
 
 export abstract class BaseLLMProvider<

--- a/src/llm-providers/deepseek.ts
+++ b/src/llm-providers/deepseek.ts
@@ -126,6 +126,10 @@ export class DeepSeekProvider extends BaseLLMProvider<DeepSeekConfig> {
     );
   }
 
+  async getEmbeddingModels(): Promise<IModelInfo[]> {
+    return [];
+  }
+
   /**
    * Format messages with strict protocol enforcement.
    * Drops orphaned tool messages and ensures correct content types.

--- a/src/llm-providers/openai.ts
+++ b/src/llm-providers/openai.ts
@@ -142,6 +142,13 @@ export class OpenAIProvider extends BaseLLMProvider<OpenAIConfig> {
     );
   }
 
+  async getEmbeddingModels(): Promise<IModelInfo[]> {
+    const response = await this.client.get('/models');
+    return (response.data.data as Array<{ id: string; owned_by?: string }>)
+      .filter((m) => /embed/i.test(m.id))
+      .map((m) => ({ id: m.id, owned_by: m.owned_by }));
+  }
+
   /**
    * Format messages for OpenAI API with strict protocol enforcement.
    */

--- a/src/llm-providers/sap-core-ai.ts
+++ b/src/llm-providers/sap-core-ai.ts
@@ -360,7 +360,11 @@ export class SapCoreAIProvider extends BaseLLMProvider<SapCoreAIConfig> {
     }
   }
 
-  async getModels(): Promise<IModelInfo[]> {
+  /**
+   * Fetch all models from SAP AI Core, caching the result for MODELS_CACHE_TTL_MS.
+   * Returns ALL models regardless of capability — callers filter as needed.
+   */
+  private async _fetchAllModels(): Promise<IModelInfo[]> {
     if (this.modelsCache && Date.now() < this.modelsCacheExpiry) {
       return this.modelsCache;
     }
@@ -387,7 +391,7 @@ export class SapCoreAIProvider extends BaseLLMProvider<SapCoreAIConfig> {
       const models: IModelInfo[] = [];
       for (const r of result.resources as AiModel[]) {
         const latest = r.versions?.find((v) => v.isLatest) ?? r.versions?.[0];
-        if (!latest?.capabilities?.includes('text-generation')) continue;
+        if (!latest) continue;
         models.push({
           id: r.model,
           displayName: r.displayName,
@@ -408,6 +412,15 @@ export class SapCoreAIProvider extends BaseLLMProvider<SapCoreAIConfig> {
       // Fallback to configured model if AI API is not available
       return [{ id: this.model }];
     }
+  }
+
+  async getModels(): Promise<IModelInfo[]> {
+    return this._fetchAllModels();
+  }
+
+  async getEmbeddingModels(): Promise<IModelInfo[]> {
+    const all = await this._fetchAllModels();
+    return all.filter((m) => m.capabilities?.includes('embeddings'));
   }
 
   /**

--- a/src/smart-agent/__tests__/smart-agent-custom-rag.test.ts
+++ b/src/smart-agent/__tests__/smart-agent-custom-rag.test.ts
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { SmartAgent } from '../agent.js';
+import { makeDefaultDeps, makeRag } from '../testing/index.js';
+
+// ---------------------------------------------------------------------------
+// SmartAgent.addRagStore / removeRagStore
+// ---------------------------------------------------------------------------
+
+function makeAgent() {
+  const { deps } = makeDefaultDeps();
+  const config = { maxIterations: 5 };
+  const agent = new SmartAgent(deps, config);
+  return { agent, deps };
+}
+
+describe('SmartAgent.addRagStore()', () => {
+  it('adds a custom store to ragStores', () => {
+    const { agent, deps } = makeAgent();
+    const store = makeRag([]);
+    agent.addRagStore('kb', store);
+    assert.equal((deps.ragStores as Record<string, unknown>).kb, store);
+  });
+
+  it('overwrites an existing custom store with the same name', () => {
+    const { agent, deps } = makeAgent();
+    const store1 = makeRag([]);
+    const store2 = makeRag([]);
+    agent.addRagStore('kb', store1);
+    agent.addRagStore('kb', store2);
+    assert.equal((deps.ragStores as Record<string, unknown>).kb, store2);
+  });
+
+  it('throws when trying to overwrite built-in "tools" store', () => {
+    const { agent } = makeAgent();
+    assert.throws(
+      () => agent.addRagStore('tools', makeRag([])),
+      (err: Error) => {
+        assert.ok(err instanceof Error);
+        assert.match(err.message, /tools/);
+        return true;
+      },
+    );
+  });
+
+  it('throws when trying to overwrite built-in "history" store', () => {
+    const { agent } = makeAgent();
+    assert.throws(
+      () => agent.addRagStore('history', makeRag([])),
+      (err: Error) => {
+        assert.ok(err instanceof Error);
+        assert.match(err.message, /history/);
+        return true;
+      },
+    );
+  });
+});
+
+describe('SmartAgent.removeRagStore()', () => {
+  it('removes a custom store from ragStores', () => {
+    const { agent, deps } = makeAgent();
+    agent.addRagStore('kb', makeRag([]));
+    assert.ok('kb' in deps.ragStores);
+
+    agent.removeRagStore('kb');
+    assert.ok(!('kb' in deps.ragStores));
+  });
+
+  it('is a no-op when removing a non-existent custom store', () => {
+    const { agent, deps } = makeAgent();
+    assert.doesNotThrow(() => agent.removeRagStore('nonexistent'));
+    assert.ok(!('nonexistent' in deps.ragStores));
+  });
+
+  it('throws when trying to remove built-in "tools" store', () => {
+    const { agent } = makeAgent();
+    assert.throws(
+      () => agent.removeRagStore('tools'),
+      (err: Error) => {
+        assert.ok(err instanceof Error);
+        assert.match(err.message, /tools/);
+        return true;
+      },
+    );
+  });
+
+  it('throws when trying to remove built-in "history" store', () => {
+    const { agent } = makeAgent();
+    assert.throws(
+      () => agent.removeRagStore('history'),
+      (err: Error) => {
+        assert.ok(err instanceof Error);
+        assert.match(err.message, /history/);
+        return true;
+      },
+    );
+  });
+});

--- a/src/smart-agent/adapters/__tests__/llm-adapter-embedding-models.test.ts
+++ b/src/smart-agent/adapters/__tests__/llm-adapter-embedding-models.test.ts
@@ -1,0 +1,165 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { IModelInfo } from '../../interfaces/model-provider.js';
+import { LlmError } from '../../interfaces/types.js';
+import { LlmAdapter, type LlmAdapterProviderInfo } from '../llm-adapter.js';
+
+// ---------------------------------------------------------------------------
+// Minimal bridge mock — LlmAdapter only uses agent for chat/streamChat
+// ---------------------------------------------------------------------------
+
+// biome-ignore lint/suspicious/noExplicitAny: test double
+const dummyBridge = {} as any;
+
+// ---------------------------------------------------------------------------
+// Helper to build LlmAdapterProviderInfo
+// ---------------------------------------------------------------------------
+
+function makeProvider(opts: {
+  model?: string;
+  models?: string[] | IModelInfo[];
+  embeddingModels?: string[] | IModelInfo[];
+  throwOnModels?: boolean;
+  throwOnEmbeddingModels?: boolean;
+}): LlmAdapterProviderInfo {
+  return {
+    model: opts.model ?? 'gpt-4',
+    getModels:
+      opts.models !== undefined || opts.throwOnModels
+        ? async () => {
+            if (opts.throwOnModels) throw new Error('models fetch failed');
+            // biome-ignore lint/style/noNonNullAssertion: checked by condition above
+            return opts.models!;
+          }
+        : undefined,
+    getEmbeddingModels:
+      opts.embeddingModels !== undefined || opts.throwOnEmbeddingModels
+        ? async () => {
+            if (opts.throwOnEmbeddingModels)
+              throw new Error('embedding models fetch failed');
+            // biome-ignore lint/style/noNonNullAssertion: checked by condition above
+            return opts.embeddingModels!;
+          }
+        : undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// getEmbeddingModels()
+// ---------------------------------------------------------------------------
+
+describe('LlmAdapter.getEmbeddingModels()', () => {
+  it('returns empty array when provider has no getEmbeddingModels', async () => {
+    const adapter = new LlmAdapter(dummyBridge, {
+      model: 'gpt-4',
+    });
+    const result = await adapter.getEmbeddingModels();
+    assert.ok(result.ok);
+    assert.deepEqual(result.value, []);
+  });
+
+  it('returns normalized IModelInfo[] when provider returns strings', async () => {
+    const provider = makeProvider({
+      embeddingModels: ['text-embedding-3-small', 'text-embedding-3-large'],
+    });
+    const adapter = new LlmAdapter(dummyBridge, provider);
+    const result = await adapter.getEmbeddingModels();
+    assert.ok(result.ok);
+    assert.deepEqual(result.value, [
+      { id: 'text-embedding-3-small' },
+      { id: 'text-embedding-3-large' },
+    ]);
+  });
+
+  it('returns IModelInfo[] as-is when provider returns objects', async () => {
+    const models: IModelInfo[] = [
+      { id: 'text-embedding-3-small', displayName: 'Small Embedding' },
+    ];
+    const provider = makeProvider({ embeddingModels: models });
+    const adapter = new LlmAdapter(dummyBridge, provider);
+    const result = await adapter.getEmbeddingModels();
+    assert.ok(result.ok);
+    assert.deepEqual(result.value, models);
+  });
+
+  it('wraps errors as LlmError with MODEL_LIST_FAILED', async () => {
+    const provider = makeProvider({ throwOnEmbeddingModels: true });
+    const adapter = new LlmAdapter(dummyBridge, provider);
+    const result = await adapter.getEmbeddingModels();
+    assert.ok(!result.ok);
+    assert.ok(result.error instanceof LlmError);
+    assert.equal(result.error.code, 'MODEL_LIST_FAILED');
+  });
+
+  it('passes LlmError through unchanged', async () => {
+    const original = new LlmError('quota exceeded', 'QUOTA');
+    const provider: LlmAdapterProviderInfo = {
+      model: 'gpt-4',
+      getEmbeddingModels: async () => {
+        throw original;
+      },
+    };
+    const adapter = new LlmAdapter(dummyBridge, provider);
+    const result = await adapter.getEmbeddingModels();
+    assert.ok(!result.ok);
+    assert.equal(result.error, original);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getModels() with excludeEmbedding
+// ---------------------------------------------------------------------------
+
+describe('LlmAdapter.getModels()', () => {
+  it('returns single model entry when provider has no getModels', async () => {
+    const adapter = new LlmAdapter(dummyBridge, { model: 'gpt-4' });
+    const result = await adapter.getModels();
+    assert.ok(result.ok);
+    assert.deepEqual(result.value, [{ id: 'gpt-4' }]);
+  });
+
+  it('returns all models without excludeEmbedding flag', async () => {
+    const provider = makeProvider({
+      models: ['gpt-4', 'text-embedding-3-small'],
+      embeddingModels: ['text-embedding-3-small'],
+    });
+    const adapter = new LlmAdapter(dummyBridge, provider);
+    const result = await adapter.getModels();
+    assert.ok(result.ok);
+    assert.equal(result.value.length, 2);
+  });
+
+  it('with excludeEmbedding: true — filters out embedding models', async () => {
+    const provider = makeProvider({
+      models: ['gpt-4', 'text-embedding-3-small', 'text-embedding-3-large'],
+      embeddingModels: ['text-embedding-3-small', 'text-embedding-3-large'],
+    });
+    const adapter = new LlmAdapter(dummyBridge, provider);
+    const result = await adapter.getModels({ excludeEmbedding: true });
+    assert.ok(result.ok);
+    assert.equal(result.value.length, 1);
+    assert.equal(result.value[0].id, 'gpt-4');
+  });
+
+  it('excludeEmbedding works with IModelInfo objects', async () => {
+    const allModels: IModelInfo[] = [{ id: 'gpt-4' }, { id: 'ada-002' }];
+    const embeddingModels: IModelInfo[] = [{ id: 'ada-002' }];
+    const provider = makeProvider({
+      models: allModels,
+      embeddingModels,
+    });
+    const adapter = new LlmAdapter(dummyBridge, provider);
+    const result = await adapter.getModels({ excludeEmbedding: true });
+    assert.ok(result.ok);
+    assert.deepEqual(result.value, [{ id: 'gpt-4' }]);
+  });
+
+  it('wraps errors as LlmError with MODEL_LIST_FAILED', async () => {
+    const provider = makeProvider({ throwOnModels: true });
+    const adapter = new LlmAdapter(dummyBridge, provider);
+    const result = await adapter.getModels();
+    assert.ok(!result.ok);
+    assert.ok(result.error instanceof LlmError);
+    assert.equal(result.error.code, 'MODEL_LIST_FAILED');
+  });
+});

--- a/src/smart-agent/adapters/llm-adapter.ts
+++ b/src/smart-agent/adapters/llm-adapter.ts
@@ -9,6 +9,7 @@ import type {
 } from '../../types.js';
 import type { ILlm } from '../interfaces/llm.js';
 import type {
+  IModelFilter,
   IModelInfo,
   IModelProvider,
 } from '../interfaces/model-provider.js';
@@ -260,6 +261,7 @@ function parseStreamChunk(
 export interface LlmAdapterProviderInfo {
   model: string;
   getModels?(): Promise<string[] | IModelInfo[]>;
+  getEmbeddingModels?(): Promise<string[] | IModelInfo[]>;
 }
 
 function normalizeModelEntry(entry: string | IModelInfo): IModelInfo {
@@ -281,7 +283,7 @@ export class LlmAdapter implements ILlm, IModelProvider {
   }
 
   async getModels(
-    options?: CallOptions,
+    options?: CallOptions & IModelFilter,
   ): Promise<Result<IModelInfo[], LlmError>> {
     if (!this.provider?.getModels) {
       return {
@@ -291,6 +293,41 @@ export class LlmAdapter implements ILlm, IModelProvider {
     }
     try {
       const modelsPromise = this.provider.getModels();
+      const raw = options?.signal
+        ? await withAbort(
+            modelsPromise,
+            options.signal,
+            () => new LlmError('Aborted', 'ABORTED'),
+          )
+        : await modelsPromise;
+      let models = raw.map(normalizeModelEntry);
+
+      if (options?.excludeEmbedding && this.provider.getEmbeddingModels) {
+        const embeddingModels = await this.provider.getEmbeddingModels();
+        const embeddingIds = new Set(
+          embeddingModels.map((m) => (typeof m === 'string' ? m : m.id)),
+        );
+        models = models.filter((m) => !embeddingIds.has(m.id));
+      }
+
+      return { ok: true, value: models };
+    } catch (err) {
+      if (err instanceof LlmError) return { ok: false, error: err };
+      return {
+        ok: false,
+        error: new LlmError(String(err), 'MODEL_LIST_FAILED'),
+      };
+    }
+  }
+
+  async getEmbeddingModels(
+    options?: CallOptions,
+  ): Promise<Result<IModelInfo[], LlmError>> {
+    if (!this.provider?.getEmbeddingModels) {
+      return { ok: true, value: [] };
+    }
+    try {
+      const modelsPromise = this.provider.getEmbeddingModels();
       const raw = options?.signal
         ? await withAbort(
             modelsPromise,

--- a/src/smart-agent/agent.ts
+++ b/src/smart-agent/agent.ts
@@ -300,6 +300,34 @@ export class SmartAgent {
     }
   }
 
+  /**
+   * Add a custom RAG store at runtime. Takes effect on the next request.
+   * Built-in store names ('tools', 'history') cannot be overwritten.
+   */
+  addRagStore(name: string, store: IRag): void {
+    if (name === 'tools' || name === 'history') {
+      throw new Error(
+        `Cannot overwrite built-in RAG store "${name}" via addRagStore()`,
+      );
+    }
+    this.deps.ragStores[name] = store;
+    this.deps.pipeline?.rebuildStages?.();
+  }
+
+  /**
+   * Remove a custom RAG store at runtime. Takes effect on the next request.
+   * Built-in store names ('tools', 'history') cannot be removed.
+   */
+  removeRagStore(name: string): void {
+    if (name === 'tools' || name === 'history') {
+      throw new Error(
+        `Cannot remove built-in RAG store "${name}" via removeRagStore()`,
+      );
+    }
+    delete this.deps.ragStores[name];
+    this.deps.pipeline?.rebuildStages?.();
+  }
+
   /** Returns the model identifiers of the currently active LLM instances. */
   getActiveConfig(): {
     mainModel?: string;

--- a/src/smart-agent/builder.ts
+++ b/src/smart-agent/builder.ts
@@ -971,6 +971,7 @@ export class SmartAgentBuilder {
       mcpClients,
       toolsRag,
       historyRag,
+      ragStores,
       embedder: this._embedder,
       reranker: this._reranker,
       queryExpander: this._queryExpander,

--- a/src/smart-agent/builder.ts
+++ b/src/smart-agent/builder.ts
@@ -698,12 +698,12 @@ export class SmartAgentBuilder {
                 );
                 const batchStart = Date.now();
                 try {
-                  const vectors = await storeEmbedder.embedBatch(texts);
+                  const embedResults = await storeEmbedder.embedBatch(texts);
                   const batchDuration = Date.now() - batchStart;
                   for (let i = 0; i < tools.length; i++) {
                     const result = await toolsRag.upsertPrecomputed(
                       texts[i],
-                      vectors[i],
+                      embedResults[i].vector,
                       { id: `tool:${tools[i].name}` },
                     );
                     if (!result.ok) {
@@ -714,6 +714,18 @@ export class SmartAgentBuilder {
                       });
                     }
                   }
+                  const realUsage = embedResults.reduce<{
+                    promptTokens: number;
+                    totalTokens: number;
+                  } | null>((acc, r) => {
+                    if (!r.usage) return acc;
+                    return {
+                      promptTokens:
+                        (acc?.promptTokens ?? 0) + r.usage.promptTokens,
+                      totalTokens:
+                        (acc?.totalTokens ?? 0) + r.usage.totalTokens,
+                    };
+                  }, null);
                   const totalEstTokens = texts.reduce(
                     (sum, t) => sum + Math.ceil(t.length / 4),
                     0,
@@ -721,11 +733,11 @@ export class SmartAgentBuilder {
                   requestLogger.logLlmCall({
                     component: 'embedding',
                     model: 'embedder',
-                    promptTokens: totalEstTokens,
+                    promptTokens: realUsage?.promptTokens ?? totalEstTokens,
                     completionTokens: 0,
-                    totalTokens: totalEstTokens,
+                    totalTokens: realUsage?.totalTokens ?? totalEstTokens,
                     durationMs: batchDuration,
-                    estimated: true,
+                    estimated: realUsage === null,
                     scope: 'initialization',
                     detail: 'tools',
                   });

--- a/src/smart-agent/interfaces/model-provider.ts
+++ b/src/smart-agent/interfaces/model-provider.ts
@@ -15,10 +15,22 @@ export interface IModelInfo {
   deprecated?: boolean;
 }
 
+export interface IModelFilter {
+  /** When true, exclude embedding models from the result. */
+  excludeEmbedding?: boolean;
+}
+
 export interface IModelProvider {
   /** Currently configured (default) model name. */
   getModel(): string;
 
   /** Fetch available models from the provider. Called on demand. */
-  getModels(options?: CallOptions): Promise<Result<IModelInfo[], LlmError>>;
+  getModels(
+    options?: CallOptions & IModelFilter,
+  ): Promise<Result<IModelInfo[], LlmError>>;
+
+  /** Fetch embedding models from the provider. Best-effort; may return empty array. */
+  getEmbeddingModels?(
+    options?: CallOptions,
+  ): Promise<Result<IModelInfo[], LlmError>>;
 }

--- a/src/smart-agent/interfaces/pipeline.ts
+++ b/src/smart-agent/interfaces/pipeline.ts
@@ -95,6 +95,8 @@ export interface PipelineDeps {
   toolsRag?: IRag;
   /** RAG store used for history retrieval. */
   historyRag?: IRag;
+  /** Full record of RAG stores (tools, history, and any custom stores). */
+  ragStores?: Record<string, IRag>;
 }
 
 // ---------------------------------------------------------------------------
@@ -146,4 +148,10 @@ export interface IPipeline {
     options: CallOptions | undefined,
     yieldChunk: (chunk: Result<LlmStreamChunk, OrchestratorError>) => void,
   ): Promise<PipelineResult>;
+
+  /**
+   * Rebuild internal stage definitions.
+   * Called when RAG stores are added/removed at runtime.
+   */
+  rebuildStages?(): void;
 }

--- a/src/smart-agent/interfaces/query-embedding.ts
+++ b/src/smart-agent/interfaces/query-embedding.ts
@@ -1,3 +1,5 @@
+import type { IEmbedResult } from './rag.js';
+
 /**
  * A query embedding that lazily computes and caches its vector.
  *
@@ -9,4 +11,6 @@ export interface IQueryEmbedding {
   readonly text: string;
   /** Returns the embedding vector, computing it on first call. */
   toVector(): Promise<number[]>;
+  /** Returns token usage from the embedding call, if available. */
+  getUsage?(): Promise<IEmbedResult['usage']>;
 }

--- a/src/smart-agent/interfaces/rag.ts
+++ b/src/smart-agent/interfaces/rag.ts
@@ -7,8 +7,13 @@ import type {
   Result,
 } from './types.js';
 
+export interface IEmbedResult {
+  vector: number[];
+  usage?: { promptTokens: number; totalTokens: number };
+}
+
 export interface IEmbedder {
-  embed(text: string, options?: CallOptions): Promise<number[]>;
+  embed(text: string, options?: CallOptions): Promise<IEmbedResult>;
 }
 
 /** Config subset passed to EmbedderFactory so it can configure the embedder. */
@@ -55,7 +60,7 @@ export interface IRag {
 }
 
 export interface IEmbedderBatch extends IEmbedder {
-  embedBatch(texts: string[], options?: CallOptions): Promise<number[][]>;
+  embedBatch(texts: string[], options?: CallOptions): Promise<IEmbedResult[]>;
 }
 
 export function isBatchEmbedder(e: IEmbedder): e is IEmbedderBatch {

--- a/src/smart-agent/pipeline/__tests__/default-pipeline-custom-rag.test.ts
+++ b/src/smart-agent/pipeline/__tests__/default-pipeline-custom-rag.test.ts
@@ -1,0 +1,142 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { PipelineDeps } from '../../interfaces/pipeline.js';
+import type { IRag } from '../../interfaces/rag.js';
+import { makeDefaultDeps, makeRag } from '../../testing/index.js';
+import { DefaultPipeline } from '../default-pipeline.js';
+
+// ---------------------------------------------------------------------------
+// Types for private stage access
+// ---------------------------------------------------------------------------
+
+type StageChild = { id: string };
+type Stage = { id: string; type: string; stages?: StageChild[] };
+type PipelineWithStages = { stages: Stage[] };
+
+// ---------------------------------------------------------------------------
+// Helper to build minimal PipelineDeps from makeDefaultDeps
+// ---------------------------------------------------------------------------
+
+function buildDeps(overrides?: Partial<PipelineDeps>): PipelineDeps {
+  const { deps: base } = makeDefaultDeps();
+  return {
+    mainLlm: base.mainLlm,
+    mcpClients: base.mcpClients ?? [],
+    ...overrides,
+  };
+}
+
+function getStages(pipeline: DefaultPipeline): Stage[] {
+  return (pipeline as unknown as PipelineWithStages).stages;
+}
+
+// ---------------------------------------------------------------------------
+// DefaultPipeline — custom RAG stores
+// ---------------------------------------------------------------------------
+
+describe('DefaultPipeline.rebuildStages()', () => {
+  it('is callable after initialize and does not throw', () => {
+    const pipeline = new DefaultPipeline();
+    pipeline.initialize(buildDeps());
+    assert.doesNotThrow(() => pipeline.rebuildStages?.());
+  });
+
+  it('rebuildStages() is a no-op when called multiple times', () => {
+    const pipeline = new DefaultPipeline();
+    pipeline.initialize(buildDeps());
+    assert.doesNotThrow(() => {
+      pipeline.rebuildStages?.();
+      pipeline.rebuildStages?.();
+    });
+  });
+});
+
+describe('DefaultPipeline — custom ragStores', () => {
+  it('initializes without throwing when ragStores contains a custom store', () => {
+    const kbStore: IRag = makeRag([]);
+    const pipeline = new DefaultPipeline();
+    assert.doesNotThrow(() =>
+      pipeline.initialize(buildDeps({ ragStores: { kb: kbStore } })),
+    );
+  });
+
+  it('internal stages include rag-kb when ragStores has "kb"', () => {
+    const kbStore: IRag = makeRag([]);
+    const pipeline = new DefaultPipeline();
+    pipeline.initialize(buildDeps({ ragStores: { kb: kbStore } }));
+
+    const stages = getStages(pipeline);
+
+    // Find the rag-retrieval parallel stage
+    const ragRetrieval = stages.find((s) => s.id === 'rag-retrieval');
+    assert.ok(ragRetrieval, 'rag-retrieval stage should be present');
+    assert.ok(ragRetrieval.stages, 'rag-retrieval should have child stages');
+    const childIds = ragRetrieval.stages?.map((s) => s.id) ?? [];
+    assert.ok(
+      childIds.includes('rag-kb'),
+      `rag-kb expected in ${childIds.join(', ')}`,
+    );
+  });
+
+  it('built-in tools/history are not duplicated when present in ragStores', () => {
+    const toolsRag: IRag = makeRag([]);
+    const historyRag: IRag = makeRag([]);
+    const pipeline = new DefaultPipeline();
+
+    pipeline.initialize(
+      buildDeps({
+        toolsRag,
+        historyRag,
+        // Passing tools and history again via ragStores should not create duplicates
+        ragStores: { tools: toolsRag, history: historyRag },
+      }),
+    );
+
+    const stages = getStages(pipeline);
+    const ragRetrieval = stages.find((s) => s.id === 'rag-retrieval');
+    assert.ok(ragRetrieval, 'rag-retrieval stage should be present');
+    const childIds = ragRetrieval.stages?.map((s) => s.id) ?? [];
+
+    // Should have exactly rag-tools and rag-history, not duplicated
+    const toolsCount = childIds.filter((id) => id === 'rag-tools').length;
+    const historyCount = childIds.filter((id) => id === 'rag-history').length;
+    assert.equal(toolsCount, 1, 'rag-tools should appear exactly once');
+    assert.equal(historyCount, 1, 'rag-history should appear exactly once');
+  });
+
+  it('no rag-retrieval stage when no stores are provided', () => {
+    const pipeline = new DefaultPipeline();
+    pipeline.initialize(buildDeps({ ragStores: {} }));
+
+    const stages = getStages(pipeline);
+    const ragRetrieval = stages.find((s) => s.id === 'rag-retrieval');
+    assert.equal(
+      ragRetrieval,
+      undefined,
+      'rag-retrieval should be absent with no stores',
+    );
+  });
+
+  it('rebuildStages() reflects updated ragStores', () => {
+    const pipeline = new DefaultPipeline();
+    const deps = buildDeps({ ragStores: {} });
+    pipeline.initialize(deps);
+
+    // Initially no rag-retrieval
+    const stagesBefore = getStages(pipeline);
+    assert.equal(
+      stagesBefore.find((s) => s.id === 'rag-retrieval'),
+      undefined,
+    );
+
+    // Add a store to the deps object in-place (simulating addRagStore)
+    (deps.ragStores as Record<string, IRag>).kb = makeRag([]);
+    pipeline.rebuildStages?.();
+
+    const stagesAfter = getStages(pipeline);
+    const ragRetrieval = stagesAfter.find((s) => s.id === 'rag-retrieval');
+    assert.ok(ragRetrieval, 'rag-retrieval should now be present');
+    const childIds = ragRetrieval.stages?.map((s) => s.id) ?? [];
+    assert.ok(childIds.includes('rag-kb'));
+  });
+});

--- a/src/smart-agent/pipeline/context.ts
+++ b/src/smart-agent/pipeline/context.ts
@@ -136,6 +136,8 @@ export interface PipelineContext {
 
   /** Whether RAG retrieval should run (set by classify or condition logic). */
   shouldRetrieve: boolean;
+  /** Whether embedding usage has been logged for this request (prevents double-logging). */
+  embeddingUsageLogged?: boolean;
   /** Whether input text is ASCII-only (affects translation decision). */
   isAscii: boolean;
   /** Whether SAP/ABAP context was detected. */

--- a/src/smart-agent/pipeline/default-pipeline.ts
+++ b/src/smart-agent/pipeline/default-pipeline.ts
@@ -5,11 +5,13 @@
  * configured. It runs a fixed stage sequence:
  *
  * ```text
- * classify → summarize → parallel(rag-query tools, rag-query history) →
+ * classify → summarize → parallel(rag-query tools, rag-query history, rag-query <custom>…) →
  * rerank → skill-select → tool-select → assemble → tool-loop → history-upsert
  * ```
  *
- * Only two RAG stores are supported: `tools` and `history`.
+ * Built-in RAG stores (`tools`, `history`) are wired from `toolsRag`/`historyRag` deps.
+ * Additional custom stores can be passed via `ragStores` and are queried in parallel
+ * with built-ins. Stores can be added/removed at runtime via `rebuildStages()`.
  */
 
 import type { Message } from '../../types.js';
@@ -143,6 +145,10 @@ export class DefaultPipeline implements IPipeline {
     };
   }
 
+  rebuildStages(): void {
+    this.stages = this._buildStages();
+  }
+
   // -------------------------------------------------------------------------
   // Internals
   // -------------------------------------------------------------------------
@@ -166,6 +172,18 @@ export class DefaultPipeline implements IPipeline {
         type: 'rag-query',
         config: { store: 'history', scope: 'session' },
       });
+    }
+
+    // Custom stores — appended after built-in, same parallel block
+    if (this.deps.ragStores) {
+      for (const name of Object.keys(this.deps.ragStores)) {
+        if (name === 'tools' || name === 'history') continue;
+        ragChildren.push({
+          id: `rag-${name}`,
+          type: 'rag-query',
+          config: { store: name },
+        });
+      }
     }
 
     const stages: StageDefinition[] = [
@@ -209,8 +227,10 @@ export class DefaultPipeline implements IPipeline {
         ? input
         : (input.filter((m) => m.role === 'user').slice(-1)[0]?.content ?? '');
 
-    // Build ragStores record from DI deps
-    const ragStores: SmartAgentRagStores = {};
+    // Build ragStores record — custom stores first, built-ins override by name
+    const ragStores: SmartAgentRagStores = {
+      ...(this.deps.ragStores ?? {}),
+    };
     if (this.deps.toolsRag) ragStores.tools = this.deps.toolsRag;
     if (this.deps.historyRag) ragStores.history = this.deps.historyRag;
 

--- a/src/smart-agent/pipeline/handlers/rag-query.ts
+++ b/src/smart-agent/pipeline/handlers/rag-query.ts
@@ -77,6 +77,23 @@ export class RagQueryHandler implements IStageHandler {
       durationMs: Date.now() - ragStart,
     });
 
+    // Log embedding usage once (first rag-query stage that uses the embedding)
+    if (!ctx.embeddingUsageLogged && ctx.queryEmbedding?.getUsage) {
+      const usage = await ctx.queryEmbedding.getUsage();
+      if (usage) {
+        ctx.requestLogger.logLlmCall({
+          component: 'embedding',
+          model: ctx.embedder?.constructor?.name ?? 'embedder',
+          promptTokens: usage.promptTokens,
+          completionTokens: 0,
+          totalTokens: usage.totalTokens,
+          durationMs: Date.now() - ragStart,
+          scope: 'request',
+        });
+        ctx.embeddingUsageLogged = true;
+      }
+    }
+
     ctx.metrics.ragQueryCount.add(1, {
       store: storeName,
       hit: String(result.ok && result.value.length > 0),

--- a/src/smart-agent/pipeline/handlers/rag-query.ts
+++ b/src/smart-agent/pipeline/handlers/rag-query.ts
@@ -83,11 +83,11 @@ export class RagQueryHandler implements IStageHandler {
       if (usage) {
         ctx.requestLogger.logLlmCall({
           component: 'embedding',
-          model: ctx.embedder?.constructor?.name ?? 'embedder',
+          model: 'embedder',
           promptTokens: usage.promptTokens,
           completionTokens: 0,
           totalTokens: usage.totalTokens,
-          durationMs: Date.now() - ragStart,
+          durationMs: 0, // embed completed before store.query(); not separately measurable here
           scope: 'request',
         });
         ctx.embeddingUsageLogged = true;

--- a/src/smart-agent/providers.ts
+++ b/src/smart-agent/providers.ts
@@ -78,6 +78,7 @@ export function makeLlm(cfg: LlmProviderConfig, temperature: number): ILlm {
       llm = new LlmAdapter(agent, {
         model: provider.model,
         getModels: () => provider.getModels(),
+        getEmbeddingModels: () => provider.getEmbeddingModels(),
       });
       break;
     }
@@ -96,6 +97,7 @@ export function makeLlm(cfg: LlmProviderConfig, temperature: number): ILlm {
       llm = new LlmAdapter(agent, {
         model: provider.model,
         getModels: () => provider.getModels(),
+        getEmbeddingModels: () => provider.getEmbeddingModels(),
       });
       break;
     }
@@ -114,6 +116,7 @@ export function makeLlm(cfg: LlmProviderConfig, temperature: number): ILlm {
       llm = new LlmAdapter(agent, {
         model: provider.model,
         getModels: () => provider.getModels(),
+        getEmbeddingModels: () => provider.getEmbeddingModels(),
       });
       break;
     }
@@ -143,6 +146,7 @@ export function makeLlm(cfg: LlmProviderConfig, temperature: number): ILlm {
       llm = new LlmAdapter(agent, {
         model: provider.model,
         getModels: () => provider.getModels(),
+        getEmbeddingModels: () => provider.getEmbeddingModels(),
       });
       break;
     }

--- a/src/smart-agent/rag/__tests__/qdrant-rag.test.ts
+++ b/src/smart-agent/rag/__tests__/qdrant-rag.test.ts
@@ -10,11 +10,16 @@ import { QueryEmbedding } from '../query-embedding.js';
 // ---------------------------------------------------------------------------
 function makeEmbedder(dim = 3): IEmbedder {
   return {
-    async embed(text: string): Promise<number[]> {
+    async embed(text: string) {
       // Deterministic hash-based embedding
       let hash = 0;
       for (const ch of text) hash = (hash * 31 + ch.charCodeAt(0)) | 0;
-      return Array.from({ length: dim }, (_, i) => ((hash >> i) & 0xff) / 255);
+      return {
+        vector: Array.from(
+          { length: dim },
+          (_, i) => ((hash >> i) & 0xff) / 255,
+        ),
+      };
     },
   };
 }

--- a/src/smart-agent/rag/__tests__/query-embedding.test.ts
+++ b/src/smart-agent/rag/__tests__/query-embedding.test.ts
@@ -1,0 +1,146 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { IEmbedder, IEmbedResult } from '../../interfaces/rag.js';
+import {
+  FallbackQueryEmbedding,
+  QueryEmbedding,
+  TextOnlyEmbedding,
+} from '../query-embedding.js';
+
+// ---------------------------------------------------------------------------
+// Stub embedder factory
+// ---------------------------------------------------------------------------
+
+function makeStubEmbedder(
+  usage?: IEmbedResult['usage'],
+): IEmbedder & { callCount: number } {
+  let callCount = 0;
+  return {
+    get callCount() {
+      return callCount;
+    },
+    async embed(_text: string) {
+      callCount++;
+      return { vector: [1, 2, 3], usage };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// QueryEmbedding
+// ---------------------------------------------------------------------------
+
+describe('QueryEmbedding', () => {
+  it('toVector() returns the vector from embed result', async () => {
+    const embedder = makeStubEmbedder();
+    const qe = new QueryEmbedding('hello', embedder);
+    const vector = await qe.toVector();
+    assert.deepEqual(vector, [1, 2, 3]);
+  });
+
+  it('getUsage() returns usage when embedder provides it', async () => {
+    const usage = { promptTokens: 10, totalTokens: 10 };
+    const embedder = makeStubEmbedder(usage);
+    const qe = new QueryEmbedding('hello', embedder);
+    const result = await qe.getUsage();
+    assert.deepEqual(result, usage);
+  });
+
+  it('getUsage() returns undefined when embedder provides no usage', async () => {
+    const embedder = makeStubEmbedder(undefined);
+    const qe = new QueryEmbedding('hello', embedder);
+    const result = await qe.getUsage();
+    assert.equal(result, undefined);
+  });
+
+  it('embed is called only once even if both toVector() and getUsage() are called', async () => {
+    const embedder = makeStubEmbedder({ promptTokens: 5, totalTokens: 5 });
+    const qe = new QueryEmbedding('hello', embedder);
+
+    // Call both — should share one underlying embed() call
+    await qe.toVector();
+    await qe.getUsage();
+    await qe.toVector();
+
+    assert.equal(embedder.callCount, 1);
+  });
+
+  it('memoization works for concurrent calls', async () => {
+    const embedder = makeStubEmbedder();
+    const qe = new QueryEmbedding('hello', embedder);
+
+    // Fire multiple concurrent calls
+    await Promise.all([qe.toVector(), qe.toVector(), qe.getUsage()]);
+
+    assert.equal(embedder.callCount, 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TextOnlyEmbedding
+// ---------------------------------------------------------------------------
+
+describe('TextOnlyEmbedding', () => {
+  it('exposes text property', () => {
+    const te = new TextOnlyEmbedding('query text');
+    assert.equal(te.text, 'query text');
+  });
+
+  it('toVector() rejects with RagError', async () => {
+    const te = new TextOnlyEmbedding('query');
+    await assert.rejects(
+      () => te.toVector(),
+      (err: Error) => {
+        assert.ok(err instanceof Error);
+        assert.match(err.message, /embedder/i);
+        return true;
+      },
+    );
+  });
+
+  it('has no getUsage method', () => {
+    const te = new TextOnlyEmbedding('query');
+    assert.equal(typeof (te as { getUsage?: unknown }).getUsage, 'undefined');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FallbackQueryEmbedding
+// ---------------------------------------------------------------------------
+
+describe('FallbackQueryEmbedding', () => {
+  it('toVector() returns inner result when inner succeeds', async () => {
+    const inner = new QueryEmbedding('hello', makeStubEmbedder());
+    const fallback = makeStubEmbedder();
+    const fqe = new FallbackQueryEmbedding(inner, fallback);
+    const vector = await fqe.toVector();
+    assert.deepEqual(vector, [1, 2, 3]);
+    assert.equal(fallback.callCount, 0);
+  });
+
+  it('toVector() falls back to fallback embedder when inner fails', async () => {
+    const inner = new TextOnlyEmbedding('hello'); // always rejects on toVector
+    const fallbackEmbedder = makeStubEmbedder();
+    const fqe = new FallbackQueryEmbedding(inner, fallbackEmbedder);
+    const vector = await fqe.toVector();
+    assert.deepEqual(vector, [1, 2, 3]);
+    assert.equal(fallbackEmbedder.callCount, 1);
+  });
+
+  it('text property reflects inner text', () => {
+    const inner = new TextOnlyEmbedding('my query');
+    const fqe = new FallbackQueryEmbedding(inner, makeStubEmbedder());
+    assert.equal(fqe.text, 'my query');
+  });
+
+  it('fallback result is memoized', async () => {
+    const inner = new TextOnlyEmbedding('hello');
+    const fallbackEmbedder = makeStubEmbedder();
+    const fqe = new FallbackQueryEmbedding(inner, fallbackEmbedder);
+
+    await fqe.toVector();
+    await fqe.toVector();
+
+    assert.equal(fallbackEmbedder.callCount, 1);
+  });
+});

--- a/src/smart-agent/rag/__tests__/rag-evaluation.test.ts
+++ b/src/smart-agent/rag/__tests__/rag-evaluation.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import type { IEmbedder } from '../../interfaces/rag.js';
+import type { IEmbedder, IEmbedResult } from '../../interfaces/rag.js';
 import type { CallOptions, RagResult } from '../../interfaces/types.js';
 import { InMemoryRag } from '../in-memory-rag.js';
 import { QueryEmbedding, TextOnlyEmbedding } from '../query-embedding.js';
@@ -181,7 +181,7 @@ class TfEmbedder implements IEmbedder {
     this.vocabulary = [...allTokens].sort();
   }
 
-  async embed(_text: string, _options?: CallOptions): Promise<number[]> {
+  async embed(_text: string, _options?: CallOptions): Promise<IEmbedResult> {
     const tokens = this.tokenize(_text);
     const freq = new Map<string, number>();
     for (const t of tokens) freq.set(t, (freq.get(t) ?? 0) + 1);
@@ -194,7 +194,7 @@ class TfEmbedder implements IEmbedder {
       for (let i = 0; i < vec.length; i++) vec[i] /= norm;
     }
 
-    return vec;
+    return { vector: vec };
   }
 
   private tokenize(text: string): string[] {

--- a/src/smart-agent/rag/ollama-rag.ts
+++ b/src/smart-agent/rag/ollama-rag.ts
@@ -1,4 +1,4 @@
-import type { IEmbedderBatch } from '../interfaces/rag.js';
+import type { IEmbedderBatch, IEmbedResult } from '../interfaces/rag.js';
 import { type CallOptions, RagError } from '../interfaces/types.js';
 import { VectorRag, type VectorRagConfig } from './vector-rag.js';
 
@@ -22,7 +22,7 @@ export class OllamaEmbedder implements IEmbedderBatch {
     this.timeoutMs = config.timeoutMs ?? 30_000;
   }
 
-  async embed(text: string, options?: CallOptions): Promise<number[]> {
+  async embed(text: string, options?: CallOptions): Promise<IEmbedResult> {
     const url = `${this.ollamaUrl}/api/embeddings`;
 
     let lastError: Error | undefined;
@@ -51,7 +51,7 @@ export class OllamaEmbedder implements IEmbedderBatch {
         }
 
         const json = (await res.json()) as { embedding: number[] };
-        return json.embedding;
+        return { vector: json.embedding };
       } catch (err: unknown) {
         lastError = err instanceof Error ? err : new Error(String(err));
         if (err instanceof Error && err.name === 'AbortError') throw err;
@@ -71,7 +71,7 @@ export class OllamaEmbedder implements IEmbedderBatch {
   async embedBatch(
     texts: string[],
     options?: CallOptions,
-  ): Promise<number[][]> {
+  ): Promise<IEmbedResult[]> {
     if (texts.length === 0) return [];
 
     const url = `${this.ollamaUrl}/api/embed`;
@@ -101,7 +101,7 @@ export class OllamaEmbedder implements IEmbedderBatch {
         }
 
         const json = (await res.json()) as { embeddings: number[][] };
-        return json.embeddings;
+        return json.embeddings.map((vector) => ({ vector }));
       } catch (err: unknown) {
         lastError = err instanceof Error ? err : new Error(String(err));
         if (err instanceof Error && err.name === 'AbortError') throw err;

--- a/src/smart-agent/rag/openai-embedder.ts
+++ b/src/smart-agent/rag/openai-embedder.ts
@@ -1,4 +1,4 @@
-import type { IEmbedderBatch } from '../interfaces/rag.js';
+import type { IEmbedderBatch, IEmbedResult } from '../interfaces/rag.js';
 import { type CallOptions, RagError } from '../interfaces/types.js';
 
 export interface OpenAiEmbedderConfig {
@@ -32,7 +32,7 @@ export class OpenAiEmbedder implements IEmbedderBatch {
     }
   }
 
-  async embed(text: string, options?: CallOptions): Promise<number[]> {
+  async embed(text: string, options?: CallOptions): Promise<IEmbedResult> {
     const url = `${this.baseURL}/embeddings`;
     let lastError: Error | undefined;
     const maxRetries = 3;
@@ -64,8 +64,16 @@ export class OpenAiEmbedder implements IEmbedderBatch {
 
         const json = (await res.json()) as {
           data: Array<{ embedding: number[] }>;
+          usage?: { prompt_tokens: number; total_tokens: number };
         };
-        return json.data[0].embedding;
+        const vector = json.data[0].embedding;
+        const usage = json.usage
+          ? {
+              promptTokens: json.usage.prompt_tokens,
+              totalTokens: json.usage.total_tokens,
+            }
+          : undefined;
+        return { vector, usage };
       } catch (err: unknown) {
         lastError = err instanceof Error ? err : new Error(String(err));
         if (err instanceof Error && err.name === 'AbortError') throw err;
@@ -83,11 +91,11 @@ export class OpenAiEmbedder implements IEmbedderBatch {
   async embedBatch(
     texts: string[],
     options?: CallOptions,
-  ): Promise<number[][]> {
+  ): Promise<IEmbedResult[]> {
     if (texts.length === 0) return [];
 
     const chunkSize = 100;
-    const results: number[][] = new Array(texts.length);
+    const results: IEmbedResult[] = new Array(texts.length);
 
     for (let start = 0; start < texts.length; start += chunkSize) {
       const chunk = texts.slice(start, start + chunkSize);
@@ -122,10 +130,21 @@ export class OpenAiEmbedder implements IEmbedderBatch {
 
           const json = (await res.json()) as {
             data: Array<{ embedding: number[]; index: number }>;
+            usage?: { prompt_tokens: number; total_tokens: number };
           };
           const sorted = json.data.sort((a, b) => a.index - b.index);
+          const chunkLen = sorted.length;
+          const usagePerItem = json.usage
+            ? {
+                promptTokens: Math.round(json.usage.prompt_tokens / chunkLen),
+                totalTokens: Math.round(json.usage.total_tokens / chunkLen),
+              }
+            : undefined;
           for (let i = 0; i < sorted.length; i++) {
-            results[start + i] = sorted[i].embedding;
+            results[start + i] = {
+              vector: sorted[i].embedding,
+              usage: usagePerItem,
+            };
           }
           lastError = undefined;
           break;

--- a/src/smart-agent/rag/qdrant-rag.ts
+++ b/src/smart-agent/rag/qdrant-rag.ts
@@ -161,7 +161,7 @@ export class QdrantRag implements IPrecomputedVectorRag {
       return { ok: false, error: new RagError('Aborted', 'ABORTED') };
     }
     try {
-      const vector = await this.embedder.embed(text, options);
+      const { vector } = await this.embedder.embed(text, options);
       return this.upsertKnownVector(text, vector, metadata, options);
     } catch (err) {
       if (err instanceof RagError) return { ok: false, error: err };

--- a/src/smart-agent/rag/query-embedding.ts
+++ b/src/smart-agent/rag/query-embedding.ts
@@ -1,5 +1,5 @@
 import type { IQueryEmbedding } from '../interfaces/query-embedding.js';
-import type { IEmbedder } from '../interfaces/rag.js';
+import type { IEmbedder, IEmbedResult } from '../interfaces/rag.js';
 import type { CallOptions } from '../interfaces/types.js';
 import { RagError } from '../interfaces/types.js';
 
@@ -11,7 +11,7 @@ import { RagError } from '../interfaces/types.js';
  */
 export class QueryEmbedding implements IQueryEmbedding {
   readonly text: string;
-  private _vector: Promise<number[]> | null = null;
+  private _result: Promise<IEmbedResult> | null = null;
 
   constructor(
     text: string,
@@ -21,9 +21,17 @@ export class QueryEmbedding implements IQueryEmbedding {
     this.text = text;
   }
 
+  private _getResult(): Promise<IEmbedResult> {
+    this._result ??= this.embedder.embed(this.text, this.options);
+    return this._result;
+  }
+
   toVector(): Promise<number[]> {
-    this._vector ??= this.embedder.embed(this.text, this.options);
-    return this._vector;
+    return this._getResult().then((r) => r.vector);
+  }
+
+  getUsage(): Promise<IEmbedResult['usage']> {
+    return this._getResult().then((r) => r.usage);
   }
 }
 
@@ -66,7 +74,7 @@ export class FallbackQueryEmbedding implements IQueryEmbedding {
   toVector(): Promise<number[]> {
     this._vector ??= this.inner
       .toVector()
-      .catch(() => this.fallback.embed(this.text));
+      .catch(() => this.fallback.embed(this.text).then((r) => r.vector));
     return this._vector;
   }
 }

--- a/src/smart-agent/rag/sap-ai-core-embedder.ts
+++ b/src/smart-agent/rag/sap-ai-core-embedder.ts
@@ -5,7 +5,7 @@
  * Authentication: reads AICORE_SERVICE_KEY env var automatically (same as LLM provider).
  */
 
-import type { IEmbedderBatch } from '../interfaces/rag.js';
+import type { IEmbedderBatch, IEmbedResult } from '../interfaces/rag.js';
 import type { CallOptions } from '../interfaces/types.js';
 
 export interface SapAiCoreEmbedderConfig {
@@ -24,7 +24,7 @@ export class SapAiCoreEmbedder implements IEmbedderBatch {
     this.resourceGroup = config.resourceGroup;
   }
 
-  async embed(text: string, _options?: CallOptions): Promise<number[]> {
+  async embed(text: string, _options?: CallOptions): Promise<IEmbedResult> {
     const { OrchestrationEmbeddingClient } = await import(
       '@sap-ai-sdk/orchestration'
     );
@@ -53,16 +53,16 @@ export class SapAiCoreEmbedder implements IEmbedderBatch {
         buffer.byteOffset,
         buffer.length / 4,
       );
-      return Array.from(float32);
+      return { vector: Array.from(float32) };
     }
 
-    return embedding;
+    return { vector: embedding };
   }
 
   async embedBatch(
     texts: string[],
     _options?: CallOptions,
-  ): Promise<number[][]> {
+  ): Promise<IEmbedResult[]> {
     if (texts.length === 0) return [];
 
     const { OrchestrationEmbeddingClient } = await import(
@@ -92,9 +92,9 @@ export class SapAiCoreEmbedder implements IEmbedderBatch {
           buffer.byteOffset,
           buffer.length / 4,
         );
-        return Array.from(float32);
+        return { vector: Array.from(float32) };
       }
-      return e.embedding;
+      return { vector: e.embedding };
     });
   }
 }

--- a/src/smart-agent/rag/vector-rag.ts
+++ b/src/smart-agent/rag/vector-rag.ts
@@ -167,7 +167,7 @@ export class VectorRag implements IPrecomputedVectorRag {
     }
 
     try {
-      const vector = await this.embedder.embed(text, options);
+      const { vector } = await this.embedder.embed(text, options);
       return this.upsertKnownVector(text, vector, metadata);
     } catch (err) {
       if (err instanceof RagError) return { ok: false, error: err };

--- a/src/smart-agent/resilience/circuit-breaker-embedder.ts
+++ b/src/smart-agent/resilience/circuit-breaker-embedder.ts
@@ -5,7 +5,7 @@
  * underlying embedding service.
  */
 
-import type { IEmbedder } from '../interfaces/rag.js';
+import type { IEmbedder, IEmbedResult } from '../interfaces/rag.js';
 import { isBatchEmbedder } from '../interfaces/rag.js';
 import type { CallOptions } from '../interfaces/types.js';
 import { RagError } from '../interfaces/types.js';
@@ -17,7 +17,7 @@ export class CircuitBreakerEmbedder implements IEmbedder {
     readonly breaker: CircuitBreaker,
   ) {}
 
-  async embed(text: string, options?: CallOptions): Promise<number[]> {
+  async embed(text: string, options?: CallOptions): Promise<IEmbedResult> {
     if (!this.breaker.isCallPermitted) {
       throw new RagError('Embedder circuit breaker is open', 'CIRCUIT_OPEN');
     }
@@ -34,7 +34,7 @@ export class CircuitBreakerEmbedder implements IEmbedder {
   async embedBatch(
     texts: string[],
     options?: CallOptions,
-  ): Promise<number[][]> {
+  ): Promise<IEmbedResult[]> {
     if (!this.breaker.isCallPermitted) {
       throw new RagError('Embedder circuit breaker is open', 'CIRCUIT_OPEN');
     }

--- a/src/smart-agent/smart-server.ts
+++ b/src/smart-agent/smart-server.ts
@@ -622,11 +622,41 @@ export class SmartServer {
       req.method === 'GET' &&
       (urlPath === '/v1/models' || urlPath === '/models')
     ) {
+      const queryString = rawUrl.includes('?') ? rawUrl.split('?')[1] : '';
+      const queryParams = new URLSearchParams(queryString);
+      const excludeEmbedding = queryParams.get('exclude_embedding') === 'true';
       let data: Array<Record<string, unknown>> = [
         { id: 'smart-agent', object: 'model', owned_by: 'smart-agent' },
       ];
       if (modelProvider) {
-        const result = await modelProvider.getModels();
+        const result = await modelProvider.getModels({ excludeEmbedding });
+        if (result.ok) {
+          data = result.value.map((m) => ({
+            id: m.id,
+            object: 'model',
+            owned_by: m.owned_by ?? 'unknown',
+            ...(m.displayName ? { display_name: m.displayName } : {}),
+            ...(m.provider ? { provider: m.provider } : {}),
+            ...(m.capabilities ? { capabilities: m.capabilities } : {}),
+            ...(m.contextLength ? { context_length: m.contextLength } : {}),
+            ...(m.streamingSupported !== undefined
+              ? { streaming_supported: m.streamingSupported }
+              : {}),
+            ...(m.deprecated !== undefined ? { deprecated: m.deprecated } : {}),
+          }));
+        }
+      }
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ object: 'list', data }));
+      return;
+    }
+    if (
+      req.method === 'GET' &&
+      (urlPath === '/v1/embedding-models' || urlPath === '/embedding-models')
+    ) {
+      let data: Array<Record<string, unknown>> = [];
+      if (modelProvider?.getEmbeddingModels) {
+        const result = await modelProvider.getEmbeddingModels();
         if (result.ok) {
           data = result.value.map((m) => ({
             id: m.id,


### PR DESCRIPTION
## Summary

- **#87 — Track embedder token usage:** `IEmbedder.embed()` now returns `IEmbedResult { vector, usage? }` instead of `number[]`. OpenAI embedder parses `usage` from API response. `RagQueryHandler` logs embedding token usage via `requestLogger.logLlmCall()` with `component: 'embedding'`, making embedding costs visible in `getSummary().byModel`.

- **#83 — Embedding models discovery:** Added `getEmbeddingModels()` to `IModelProvider` / `LLMProvider`. SAP filters by `capabilities.includes('embeddings')` (reliable), OpenAI by `/embed/i` pattern (best-effort), Anthropic/DeepSeek return `[]`. `getModels()` now returns all models by default (SAP removed `text-generation` filter). New REST endpoint `GET /v1/embedding-models` + `?exclude_embedding=true` query param on `/v1/models`.

- **Custom RAG in DefaultPipeline:** `SmartAgent.addRagStore(name, store)` / `removeRagStore(name)` for runtime custom RAG store management between requests. Custom stores are queried in parallel with `tools`/`history` in the same pipeline stage. Built-in store names are protected.

### Breaking changes

- `IEmbedder.embed()` return type changed from `Promise<number[]>` to `Promise<IEmbedResult>` — all embedder implementations and call sites updated
- SAP `getModels()` now returns all models (previously filtered to `text-generation` only)

## Test plan

- [x] 37 unit tests added (QueryEmbedding, LlmAdapter, DefaultPipeline, SmartAgent)
- [x] `npm run build` passes (clean build)
- [x] `npm run lint:check` passes (228 files, 0 issues)
- [ ] Manual verification of `/v1/embedding-models` endpoint with SAP/OpenAI providers
- [ ] Manual verification of `addRagStore()` with a real RAG backend

Closes #87, closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)