### PR TITLE
fix: provider token usage and model discovery (#98)

### DIFF
--- a/src/llm-providers/__tests__/anthropic.test.ts
+++ b/src/llm-providers/__tests__/anthropic.test.ts
@@ -253,3 +253,30 @@ describe('AnthropicProvider — streamChat', () => {
     assert.equal(typeof provider.streamChat, 'function');
   });
 });
+
+// ---------------------------------------------------------------------------
+// chat() — usage extraction
+// ---------------------------------------------------------------------------
+
+describe('AnthropicProvider — chat() usage', () => {
+  it('returns usage from response', async () => {
+    const provider = new AnthropicProvider({ apiKey: 'sk-test' });
+    // @ts-expect-error — stub axios for test
+    provider.client.post = async () => ({
+      data: {
+        content: [{ type: 'text', text: 'ok' }],
+        stop_reason: 'end_turn',
+        usage: {
+          input_tokens: 15,
+          output_tokens: 25,
+        },
+      },
+    });
+    const result = await provider.chat([{ role: 'user', content: 'hi' }]);
+    assert.deepEqual(result.usage, {
+      prompt_tokens: 15,
+      completion_tokens: 25,
+      total_tokens: 40,
+    });
+  });
+});

--- a/src/llm-providers/__tests__/deepseek.test.ts
+++ b/src/llm-providers/__tests__/deepseek.test.ts
@@ -204,3 +204,32 @@ describe('chat() options forwarding', () => {
     assert.equal(capturedBody.max_tokens, 100);
   });
 });
+
+// ---------------------------------------------------------------------------
+// streamChat() — inherits stream_options from OpenAI
+// ---------------------------------------------------------------------------
+
+describe('DeepSeekProvider — streamChat() inherits usage', () => {
+  it('sends stream_options with include_usage: true', async () => {
+    const provider = new DeepSeekProvider({ apiKey: 'sk-test' });
+    let capturedBody: Record<string, unknown> = {};
+    // @ts-expect-error — stub axios for test
+    provider.client.post = async (
+      _url: string,
+      body: Record<string, unknown>,
+    ) => {
+      capturedBody = body;
+      return {
+        data: (async function* () {
+          yield Buffer.from('data: [DONE]\n\n');
+        })(),
+      };
+    };
+    for await (const _chunk of provider.streamChat([
+      { role: 'user', content: 'hi' },
+    ])) {
+      // drain
+    }
+    assert.deepEqual(capturedBody.stream_options, { include_usage: true });
+  });
+});

--- a/src/llm-providers/__tests__/openai.test.ts
+++ b/src/llm-providers/__tests__/openai.test.ts
@@ -353,3 +353,103 @@ describe('OpenAIProvider — chat() options forwarding', () => {
     assert.equal('stop' in capturedBody, false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// chat() — usage extraction
+// ---------------------------------------------------------------------------
+
+describe('OpenAIProvider — chat() usage', () => {
+  it('returns usage from response', async () => {
+    const provider = new OpenAIProvider({ apiKey: 'sk-test' });
+    // @ts-expect-error — stub axios for test
+    provider.client.post = async () => ({
+      data: {
+        choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }],
+        usage: {
+          prompt_tokens: 10,
+          completion_tokens: 20,
+          total_tokens: 30,
+        },
+      },
+    });
+    const result = await provider.chat([{ role: 'user', content: 'hi' }]);
+    assert.deepEqual(result.usage, {
+      prompt_tokens: 10,
+      completion_tokens: 20,
+      total_tokens: 30,
+    });
+  });
+
+  it('returns undefined usage when not present', async () => {
+    const provider = new OpenAIProvider({ apiKey: 'sk-test' });
+    // @ts-expect-error — stub axios for test
+    provider.client.post = async () => ({
+      data: {
+        choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }],
+      },
+    });
+    const result = await provider.chat([{ role: 'user', content: 'hi' }]);
+    assert.equal(result.usage, undefined);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// streamChat() — stream_options and usage chunk
+// ---------------------------------------------------------------------------
+
+describe('OpenAIProvider — streamChat() usage', () => {
+  it('sends stream_options with include_usage: true', async () => {
+    const provider = new OpenAIProvider({ apiKey: 'sk-test' });
+    let capturedBody: Record<string, unknown> = {};
+    // @ts-expect-error — stub axios for test
+    provider.client.post = async (
+      _url: string,
+      body: Record<string, unknown>,
+    ) => {
+      capturedBody = body;
+      return {
+        data: (async function* () {
+          yield Buffer.from('data: [DONE]\n\n');
+        })(),
+      };
+    };
+    for await (const _chunk of provider.streamChat([
+      { role: 'user', content: 'hi' },
+    ])) {
+      // drain
+    }
+    assert.deepEqual(capturedBody.stream_options, { include_usage: true });
+  });
+
+  it('yields usage-only chunk at end of stream', async () => {
+    const provider = new OpenAIProvider({ apiKey: 'sk-test' });
+    // @ts-expect-error — stub axios for test
+    provider.client.post = async () => ({
+      data: (async function* () {
+        yield Buffer.from(
+          'data: {"choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}\n\n',
+        );
+        yield Buffer.from(
+          'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n',
+        );
+        yield Buffer.from(
+          'data: {"choices":[],"usage":{"prompt_tokens":5,"completion_tokens":1,"total_tokens":6}}\n\n',
+        );
+        yield Buffer.from('data: [DONE]\n\n');
+      })(),
+    });
+    const chunks: import('../../types.js').LLMResponse[] = [];
+    for await (const chunk of provider.streamChat([
+      { role: 'user', content: 'hi' },
+    ])) {
+      chunks.push(chunk);
+    }
+    const usageChunk = chunks.find((c) => c.usage !== undefined);
+    assert.ok(usageChunk, 'expected a chunk with usage');
+    assert.deepEqual(usageChunk.usage, {
+      prompt_tokens: 5,
+      completion_tokens: 1,
+      total_tokens: 6,
+    });
+  });
+});

--- a/src/llm-providers/__tests__/types-usage.test.ts
+++ b/src/llm-providers/__tests__/types-usage.test.ts
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { LLMResponse } from '../../types.js';
+
+describe('LLMResponse — usage field', () => {
+  it('accepts response with usage', () => {
+    const resp: LLMResponse = {
+      content: 'Hello',
+      finishReason: 'stop',
+      usage: {
+        prompt_tokens: 10,
+        completion_tokens: 20,
+        total_tokens: 30,
+      },
+    };
+    assert.equal(resp.usage?.prompt_tokens, 10);
+    assert.equal(resp.usage?.completion_tokens, 20);
+    assert.equal(resp.usage?.total_tokens, 30);
+  });
+
+  it('accepts response without usage', () => {
+    const resp: LLMResponse = { content: 'Hello' };
+    assert.equal(resp.usage, undefined);
+  });
+});

--- a/src/llm-providers/anthropic.ts
+++ b/src/llm-providers/anthropic.ts
@@ -76,10 +76,21 @@ export class AnthropicProvider extends BaseLLMProvider<AnthropicConfig> {
         if (block.type === 'text') textContent += block.text;
       }
 
+      const rawUsage = response.data.usage;
+      const usage = rawUsage
+        ? {
+            prompt_tokens: rawUsage.input_tokens ?? 0,
+            completion_tokens: rawUsage.output_tokens ?? 0,
+            total_tokens:
+              (rawUsage.input_tokens ?? 0) + (rawUsage.output_tokens ?? 0),
+          }
+        : undefined;
+
       return {
         content: textContent,
         finishReason: response.data.stop_reason,
         raw: response.data,
+        usage,
       };
     } catch (error: unknown) {
       const message = axios.isAxiosError(error)
@@ -170,11 +181,30 @@ export class AnthropicProvider extends BaseLLMProvider<AnthropicConfig> {
               parsed.delta?.type === 'text_delta'
             ) {
               yield { content: parsed.delta.text || '', raw: parsed };
+            } else if (eventType === 'message_start' && parsed.message?.usage) {
+              const u = parsed.message.usage;
+              yield {
+                content: '',
+                raw: parsed,
+                usage: {
+                  prompt_tokens: u.input_tokens ?? 0,
+                  completion_tokens: u.output_tokens ?? 0,
+                  total_tokens: (u.input_tokens ?? 0) + (u.output_tokens ?? 0),
+                },
+              };
             } else if (eventType === 'message_delta') {
+              const u = parsed.usage;
               yield {
                 content: '',
                 finishReason: parsed.delta?.stop_reason,
                 raw: parsed,
+                usage: u
+                  ? {
+                      prompt_tokens: 0,
+                      completion_tokens: u.output_tokens ?? 0,
+                      total_tokens: u.output_tokens ?? 0,
+                    }
+                  : undefined,
               };
             } else if (eventType === 'error') {
               const error = parsed.error as { message?: string } | undefined;

--- a/src/llm-providers/deepseek.ts
+++ b/src/llm-providers/deepseek.ts
@@ -1,16 +1,10 @@
 /**
- * DeepSeek LLM Provider
+ * DeepSeek LLM Provider — extends OpenAI (DeepSeek uses OpenAI-compatible API).
  */
 
-import axios, { type AxiosInstance } from 'axios';
 import type { IModelInfo } from '../smart-agent/interfaces/model-provider.js';
-import type {
-  LLMCallOptions,
-  LLMProviderConfig,
-  LLMResponse,
-  Message,
-} from '../types.js';
-import { BaseLLMProvider } from './base.js';
+import type { LLMProviderConfig, Message } from '../types.js';
+import { type OpenAIConfig, OpenAIProvider } from './openai.js';
 
 export interface DeepSeekConfig extends LLMProviderConfig {
   model?: string;
@@ -18,147 +12,37 @@ export interface DeepSeekConfig extends LLMProviderConfig {
   maxTokens?: number;
 }
 
-export class DeepSeekProvider extends BaseLLMProvider<DeepSeekConfig> {
-  readonly client: AxiosInstance;
-  readonly model: string;
+export class DeepSeekProvider extends OpenAIProvider {
+  protected override readonly providerName: string = 'DeepSeek';
 
   constructor(config: DeepSeekConfig) {
-    super(config);
-    this.validateConfig();
-    this.model = config.model || 'deepseek-chat';
-    this.client = axios.create({
+    super({
+      ...config,
       baseURL: config.baseURL || 'https://api.deepseek.com/v1',
-      headers: {
-        Authorization: `Bearer ${config.apiKey}`,
-        'Content-Type': 'application/json',
-      },
-    });
+      model: config.model || 'deepseek-chat',
+    } as OpenAIConfig);
   }
 
-  async chat(
-    messages: Message[],
-    tools?: unknown[],
-    options?: LLMCallOptions,
-  ): Promise<LLMResponse> {
-    try {
-      const model = options?.model ?? this.model;
-      const temperature =
-        options?.temperature ?? this.config.temperature ?? 0.7;
-      const maxTokens = options?.maxTokens ?? this.config.maxTokens ?? 4096;
-
-      const response = await this.client.post('/chat/completions', {
-        model,
-        messages: this.formatMessages(messages),
-        tools: tools && tools.length > 0 ? tools : undefined,
-        tool_choice: tools && tools.length > 0 ? 'auto' : undefined,
-        temperature,
-        max_tokens: maxTokens,
-        ...(options?.topP !== undefined ? { top_p: options.topP } : {}),
-        ...(options?.stop ? { stop: options.stop } : {}),
-      });
-      const choice = response.data.choices[0];
-      return {
-        content: choice.message.content || '',
-        finishReason: choice.finish_reason,
-        raw: response.data,
-      };
-    } catch (error: unknown) {
-      const message = axios.isAxiosError(error)
-        ? (error.response?.data as { error?: { message?: string } })?.error
-            ?.message || error.message
-        : error instanceof Error
-          ? error.message
-          : String(error);
-      throw new Error(`DeepSeek API error: ${message}`);
-    }
+  /**
+   * DeepSeek always uses max_tokens (no gpt-5/o1/o3 distinction).
+   */
+  protected override getTokenLimitParam(
+    _model: string,
+    maxTokens: number,
+  ): Record<string, number> {
+    return { max_tokens: maxTokens };
   }
 
-  async *streamChat(
-    messages: Message[],
-    tools?: unknown[],
-    options?: LLMCallOptions,
-  ): AsyncIterable<LLMResponse> {
-    try {
-      const model = options?.model ?? this.model;
-      const temperature =
-        options?.temperature ?? this.config.temperature ?? 0.7;
-      const maxTokens = options?.maxTokens ?? this.config.maxTokens ?? 4096;
-
-      const response = await this.client.post(
-        '/chat/completions',
-        {
-          model,
-          messages: this.formatMessages(messages),
-          tools: tools && tools.length > 0 ? tools : undefined,
-          tool_choice: tools && tools.length > 0 ? 'auto' : undefined,
-          temperature,
-          max_tokens: maxTokens,
-          ...(options?.topP !== undefined ? { top_p: options.topP } : {}),
-          ...(options?.stop ? { stop: options.stop } : {}),
-          stream: true,
-          stream_options: { include_usage: true },
-        },
-        { responseType: 'stream' },
-      );
-
-      const stream = response.data;
-      let buffer = '';
-      for await (const chunk of stream) {
-        buffer += chunk.toString();
-        const lines = buffer.split('\n');
-        buffer = lines.pop() || '';
-        for (const line of lines) {
-          const trimmed = line.trim();
-          if (!trimmed?.startsWith('data: ')) continue;
-          const data = trimmed.slice(6);
-          if (data === '[DONE]') break;
-          try {
-            const parsed = JSON.parse(data);
-            const choice = parsed.choices?.[0];
-            if (choice?.delta) {
-              yield {
-                content: choice.delta.content || '',
-                finishReason: choice.finish_reason,
-                raw: parsed,
-              };
-            }
-            // Usage chunk (stream_options: include_usage)
-            if (parsed.usage && !choice) {
-              yield {
-                content: '',
-                raw: parsed,
-              };
-            }
-          } catch (_e) {}
-        }
-      }
-    } catch (error: unknown) {
-      const message = axios.isAxiosError(error)
-        ? (error.response?.data as { error?: { message?: string } })?.error
-            ?.message || error.message
-        : error instanceof Error
-          ? error.message
-          : String(error);
-      throw new Error(`DeepSeek Streaming error: ${message}`);
-    }
-  }
-
-  async getModels(): Promise<IModelInfo[]> {
-    const response = await this.client.get('/models');
-    return (response.data.data as Array<{ id: string; owned_by?: string }>).map(
-      (m) => ({ id: m.id, owned_by: m.owned_by }),
-    );
-  }
-
-  async getEmbeddingModels(): Promise<IModelInfo[]> {
+  override async getEmbeddingModels(): Promise<IModelInfo[]> {
     return [];
   }
 
   /**
-   * Format messages with strict protocol enforcement.
-   * Drops orphaned tool messages and ensures correct content types.
+   * Stricter formatMessages — tracks known tool_call_ids and drops orphans.
    */
-  private formatMessages(messages: Message[]): Array<Record<string, unknown>> {
+  protected override formatMessages(
+    messages: Message[],
+  ): Array<Record<string, unknown>> {
     const formatted: Array<Record<string, unknown>> = [];
     const knownToolCallIds = new Set<string>();
 
@@ -174,12 +58,11 @@ export class DeepSeekProvider extends BaseLLMProvider<DeepSeekConfig> {
         msg.tool_calls.length > 0
       ) {
         entry.tool_calls = msg.tool_calls;
-        entry.content = msg.content || null; // Protocol requirement
+        entry.content = msg.content || null;
         for (const tc of msg.tool_calls) if (tc.id) knownToolCallIds.add(tc.id);
       }
 
       if (msg.role === 'tool') {
-        // Drop tool messages that don't have a matching call ID in history
         if (!msg.tool_call_id || !knownToolCallIds.has(msg.tool_call_id))
           continue;
         entry.tool_call_id = msg.tool_call_id;

--- a/src/llm-providers/openai.ts
+++ b/src/llm-providers/openai.ts
@@ -75,10 +75,19 @@ export class OpenAIProvider extends BaseLLMProvider<OpenAIConfig> {
 
       const choice = response.data.choices[0];
 
+      const usage = response.data.usage
+        ? {
+            prompt_tokens: response.data.usage.prompt_tokens,
+            completion_tokens: response.data.usage.completion_tokens,
+            total_tokens: response.data.usage.total_tokens,
+          }
+        : undefined;
+
       return {
         content: choice.message.content || '',
         finishReason: choice.finish_reason,
         raw: response.data,
+        usage,
       };
     } catch (error: unknown) {
       const message = axios.isAxiosError(error)
@@ -114,6 +123,7 @@ export class OpenAIProvider extends BaseLLMProvider<OpenAIConfig> {
           ...(options?.topP !== undefined ? { top_p: options.topP } : {}),
           ...(options?.stop ? { stop: options.stop } : {}),
           stream: true,
+          stream_options: { include_usage: true },
         },
         { responseType: 'stream' },
       );
@@ -135,12 +145,24 @@ export class OpenAIProvider extends BaseLLMProvider<OpenAIConfig> {
 
           try {
             const parsed = JSON.parse(data);
-            const choice = parsed.choices[0];
-            if (choice.delta) {
+            const choice = parsed.choices?.[0];
+            if (choice?.delta) {
               yield {
                 content: choice.delta.content || '',
                 finishReason: choice.finish_reason,
                 raw: parsed,
+              };
+            }
+            // Usage-only chunk (stream_options: include_usage)
+            if (parsed.usage && !choice?.delta) {
+              yield {
+                content: '',
+                raw: parsed,
+                usage: {
+                  prompt_tokens: parsed.usage.prompt_tokens,
+                  completion_tokens: parsed.usage.completion_tokens,
+                  total_tokens: parsed.usage.total_tokens,
+                },
               };
             }
           } catch (_e) {

--- a/src/llm-providers/openai.ts
+++ b/src/llm-providers/openai.ts
@@ -200,7 +200,7 @@ export class OpenAIProvider extends BaseLLMProvider<OpenAIConfig> {
    * Newer models (o1, o3, gpt-5+) require max_completion_tokens;
    * legacy models use max_tokens.
    */
-  private getTokenLimitParam(
+  protected getTokenLimitParam(
     model: string,
     maxTokens: number,
   ): Record<string, number> {
@@ -214,7 +214,9 @@ export class OpenAIProvider extends BaseLLMProvider<OpenAIConfig> {
   /**
    * Format messages for OpenAI API with strict protocol enforcement.
    */
-  private formatMessages(messages: Message[]): Array<Record<string, unknown>> {
+  protected formatMessages(
+    messages: Message[],
+  ): Array<Record<string, unknown>> {
     const formatted: Array<Record<string, unknown>> = [];
 
     for (const msg of messages) {

--- a/src/llm-providers/openai.ts
+++ b/src/llm-providers/openai.ts
@@ -23,6 +23,7 @@ export interface OpenAIConfig extends LLMProviderConfig {
 export class OpenAIProvider extends BaseLLMProvider<OpenAIConfig> {
   readonly client: AxiosInstance;
   readonly model: string;
+  protected readonly providerName: string = 'OpenAI';
 
   constructor(config: OpenAIConfig) {
     super(config);
@@ -96,7 +97,7 @@ export class OpenAIProvider extends BaseLLMProvider<OpenAIConfig> {
         : error instanceof Error
           ? error.message
           : String(error);
-      throw new Error(`OpenAI API error: ${message}`);
+      throw new Error(`${this.providerName} API error: ${message}`);
     }
   }
 
@@ -177,7 +178,7 @@ export class OpenAIProvider extends BaseLLMProvider<OpenAIConfig> {
         : error instanceof Error
           ? error.message
           : String(error);
-      throw new Error(`OpenAI Streaming error: ${message}`);
+      throw new Error(`${this.providerName} Streaming error: ${message}`);
     }
   }
 

--- a/src/llm-providers/sap-core-ai.ts
+++ b/src/llm-providers/sap-core-ai.ts
@@ -327,9 +327,9 @@ export class SapCoreAIProvider extends BaseLLMProvider<SapCoreAIConfig> {
           ...(tokenUsage
             ? {
                 usage: {
-                  promptTokens: tokenUsage.prompt_tokens || 0,
-                  completionTokens: tokenUsage.completion_tokens || 0,
-                  totalTokens: tokenUsage.total_tokens || 0,
+                  prompt_tokens: tokenUsage.prompt_tokens || 0,
+                  completion_tokens: tokenUsage.completion_tokens || 0,
+                  total_tokens: tokenUsage.total_tokens || 0,
                 },
               }
             : {}),

--- a/src/smart-agent/adapters/non-streaming-llm.ts
+++ b/src/smart-agent/adapters/non-streaming-llm.ts
@@ -19,10 +19,14 @@ import type {
 
 export class NonStreamingLlm implements ILlm {
   healthCheck?: ILlm['healthCheck'];
+  getModels?: ILlm['getModels'];
 
   constructor(private readonly inner: ILlm) {
     if (inner.healthCheck) {
       this.healthCheck = inner.healthCheck.bind(inner);
+    }
+    if (inner.getModels) {
+      this.getModels = inner.getModels.bind(inner);
     }
   }
 

--- a/src/smart-agent/interfaces/llm.ts
+++ b/src/smart-agent/interfaces/llm.ts
@@ -1,4 +1,5 @@
 import type { Message } from '../../types.js';
+import type { IModelInfo } from './model-provider.js';
 import type {
   CallOptions,
   LlmError,
@@ -31,4 +32,10 @@ export interface ILlm {
    * Returns `true` when the configured model is available, `false` otherwise.
    */
   healthCheck?(options?: CallOptions): Promise<Result<boolean, LlmError>>;
+
+  /**
+   * Discover available models from the provider.
+   * Optional — not all contexts require model listing.
+   */
+  getModels?(options?: CallOptions): Promise<Result<IModelInfo[], LlmError>>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,11 @@ export interface LLMResponse {
   content: string;
   raw?: unknown;
   finishReason?: string;
+  usage?: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+  };
 }
 
 export interface LLMProviderConfig {


### PR DESCRIPTION
## Summary

- **OpenAI streaming fix**: added `stream_options: { include_usage: true }` so API returns usage chunk — root cause of #98
- **All providers return `usage`** in both `chat()` and `streamChat()` responses via new `LLMResponse.usage` field
- **DeepSeek extends OpenAI**: eliminates ~90% code duplication (−149 lines), inherits streaming usage fix
- **Anthropic streaming**: yields usage from `message_start` and `message_delta` SSE events
- **`ILlm.getModels()`**: optional method for model discovery without separate `IModelProvider` reference

Closes #98

## Test plan

- [x] 72 provider tests pass (OpenAI, DeepSeek, Anthropic, types)
- [x] 20 adapter tests pass
- [x] Build clean (`npm run build`)
- [x] Lint clean (`npm run lint:check`)
- [ ] Verify UI shows token usage for OpenAI provider in cloud-llm-hub
- [ ] Verify streaming and non-streaming paths both report usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)