### PR TITLE
feat!: RAG registry + corrections layer (closes #103)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,9 +32,6 @@ Thumbs.db
 .claude/skills/
 .agents/skills/
 
-# Superpowers plans/specs (generated, session-local)
-docs/superpowers/
-
 # Logs
 *.log
 *.log.bak*

--- a/docs/superpowers/plans/2026-04-22-rag-registry-and-corrections.md
+++ b/docs/superpowers/plans/2026-04-22-rag-registry-and-corrections.md
@@ -1,0 +1,2006 @@
+# RAG Registry and Corrections Layer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `IRagEditor` / `IRagRegistry` split, four edit strategies, four id strategies, two overlay IRags, corrections module, and MCP tool factory — letting consumers compose heterogeneous editable/immutable RAG collections without re-implementing the plumbing.
+
+**Architecture:** Split `IRag` (read) from `IRagEditor` (write); per-collection id resolution via `IIdStrategy`; layered reads via `OverlayRag` / `SessionScopedRag`; write-only edit strategies (`Direct`, `Immutable`, `Overlay`, `SessionScoped`); `SimpleRagRegistry` binds them; corrections stay pure-logic in a separate module; MCP tools consume the registry.
+
+**Tech Stack:** TypeScript (strict, ESM), Node ≥ 18, Biome, `node:test` via `tsx`, existing backends (`VectorRag`, `QdrantRag`, `InMemoryRag`).
+
+**Spec:** `docs/superpowers/specs/2026-04-22-rag-registry-corrections-design.md`
+
+**Branch:** `feat/rag-registry-and-corrections` (already created)
+
+---
+
+## File map
+
+**Create:**
+- `src/smart-agent/rag/corrections/errors.ts` — `ReadOnlyError`, `MissingIdError`, `CanonicalKeyCollisionError`
+- `src/smart-agent/rag/corrections/metadata.ts` — pure helpers
+- `src/smart-agent/rag/corrections/active-filtering-rag.ts` — `ActiveFilteringRag`
+- `src/smart-agent/rag/corrections/index.ts` — barrel
+- `src/smart-agent/rag/strategies/id/{caller-provided,session-scoped,global-unique,canonical-key,index}.ts`
+- `src/smart-agent/rag/strategies/edit/{direct,immutable,overlay,session-scoped,index}.ts`
+- `src/smart-agent/rag/overlays/{overlay-rag,session-scoped-rag,index}.ts`
+- `src/smart-agent/rag/registry/{simple-rag-registry,index}.ts`
+- `src/smart-agent/rag/mcp-tools/{rag-collection-tools,index}.ts`
+- `src/smart-agent/rag/__tests__/` — one `*.test.ts` per new module
+
+**Modify:**
+- `src/smart-agent/interfaces/rag.ts` — new interfaces; remove `IRag.upsert`, `IRag.clear`
+- `src/smart-agent/rag/in-memory-rag.ts` — split read/write; expose `IRagBackendWriter`; implement `getById`
+- `src/smart-agent/rag/vector-rag.ts` — same
+- `src/smart-agent/rag/qdrant-rag.ts` — same
+- `src/smart-agent/rag/tool-indexing-strategy.ts` — use `IRagEditor` via registry
+- `src/smart-agent/rag/preprocessor.ts` — use `IRagEditor` via registry
+- `src/smart-agent/rag/index.ts` — re-export new modules
+- `src/index.ts` — public API
+- `package.json` — major version bump to 9.0.0
+
+**Deferred / unused after migration:** `IRag.clear` (moves to editor), `IPrecomputedVectorRag.upsertPrecomputed` (moves to backend writer).
+
+---
+
+## Task 1: Add error types
+
+**Files:**
+- Create: `src/smart-agent/rag/corrections/errors.ts`
+- Test: `src/smart-agent/rag/__tests__/corrections-errors.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+// src/smart-agent/rag/__tests__/corrections-errors.test.ts
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  ReadOnlyError,
+  MissingIdError,
+  CanonicalKeyCollisionError,
+} from '../corrections/errors.js';
+import { RagError } from '../../interfaces/types.js';
+
+describe('corrections errors', () => {
+  it('ReadOnlyError extends RagError with code', () => {
+    const e = new ReadOnlyError('corp-facts');
+    assert.ok(e instanceof RagError);
+    assert.equal(e.code, 'RAG_READ_ONLY');
+    assert.match(e.message, /corp-facts/);
+  });
+
+  it('MissingIdError extends RagError with code', () => {
+    const e = new MissingIdError('CallerProvidedIdStrategy');
+    assert.ok(e instanceof RagError);
+    assert.equal(e.code, 'RAG_MISSING_ID');
+    assert.match(e.message, /CallerProvidedIdStrategy/);
+  });
+
+  it('CanonicalKeyCollisionError extends RagError with code', () => {
+    const e = new CanonicalKeyCollisionError('doc-42');
+    assert.ok(e instanceof RagError);
+    assert.equal(e.code, 'RAG_CANONICAL_KEY_COLLISION');
+    assert.match(e.message, /doc-42/);
+  });
+});
+```
+
+- [ ] **Step 2: Run test — expect failure**
+
+```
+node --import tsx/esm --test --test-reporter=spec src/smart-agent/rag/__tests__/corrections-errors.test.ts
+```
+Expected: Cannot find module `../corrections/errors.js`.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// src/smart-agent/rag/corrections/errors.ts
+import { RagError } from '../../interfaces/types.js';
+
+export class ReadOnlyError extends RagError {
+  constructor(collectionName: string) {
+    super(`Collection '${collectionName}' is read-only`, 'RAG_READ_ONLY');
+    this.name = 'ReadOnlyError';
+  }
+}
+
+export class MissingIdError extends RagError {
+  constructor(strategyName: string) {
+    super(`${strategyName} requires metadata.id`, 'RAG_MISSING_ID');
+    this.name = 'MissingIdError';
+  }
+}
+
+export class CanonicalKeyCollisionError extends RagError {
+  constructor(key: string) {
+    super(
+      `canonicalKey '${key}' already exists in base; reserved for future overlay-block semantics`,
+      'RAG_CANONICAL_KEY_COLLISION',
+    );
+    this.name = 'CanonicalKeyCollisionError';
+  }
+}
+```
+
+- [ ] **Step 4: Run test — expect pass**
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/smart-agent/rag/corrections/errors.ts src/smart-agent/rag/__tests__/corrections-errors.test.ts
+git commit -m "feat(rag): add corrections error types"
+```
+
+---
+
+## Task 2: Declare new interfaces (non-breaking, additive)
+
+Keep the old `IRag.upsert` / `IRag.clear` in place for now so the codebase stays buildable while we add the new parts. Removal happens in Task 13.
+
+**Files:**
+- Modify: `src/smart-agent/interfaces/rag.ts`
+
+- [ ] **Step 1: Add the following exports to the bottom of `rag.ts` (do not remove anything yet)**
+
+```ts
+// Added in 9.0 refactor — see docs/superpowers/specs/2026-04-22-rag-registry-corrections-design.md
+
+export interface IRagEditor {
+  upsert(
+    text: string,
+    metadata: RagMetadata,
+    options?: CallOptions,
+  ): Promise<Result<{ id: string }, RagError>>;
+  deleteById(
+    id: string,
+    options?: CallOptions,
+  ): Promise<Result<boolean, RagError>>;
+  clear?(): Promise<Result<void, RagError>>;
+}
+
+export interface IIdStrategy {
+  /** Always returns a valid id; throws MissingIdError when required input is missing. */
+  resolve(metadata: RagMetadata, text: string): string;
+}
+
+export interface IRagBackendWriter {
+  upsertRaw(
+    id: string,
+    text: string,
+    metadata: RagMetadata,
+    options?: CallOptions,
+  ): Promise<Result<void, RagError>>;
+  deleteByIdRaw(
+    id: string,
+    options?: CallOptions,
+  ): Promise<Result<boolean, RagError>>;
+  clearAll?(): Promise<Result<void, RagError>>;
+}
+
+export interface RagCollectionMeta {
+  readonly name: string;
+  readonly displayName: string;
+  readonly description?: string;
+  readonly editable: boolean;
+  readonly tags?: readonly string[];
+}
+
+export interface IRagRegistry {
+  register(
+    name: string,
+    rag: IRag,
+    editor?: IRagEditor,
+    meta?: Omit<RagCollectionMeta, 'name' | 'editable'>,
+  ): void;
+  unregister(name: string): boolean;
+  get(name: string): IRag | undefined;
+  getEditor(name: string): IRagEditor | undefined;
+  list(): readonly RagCollectionMeta[];
+}
+```
+
+Also add `getById` to the existing `IRag` as **optional** for now (required in Task 11 after backends implement it):
+
+```ts
+export interface IRag {
+  // existing members unchanged…
+  getById?(
+    id: string,
+    options?: CallOptions,
+  ): Promise<Result<RagResult | null, RagError>>;
+}
+```
+
+- [ ] **Step 2: Build the project**
+
+```
+npm run build
+```
+Expected: build passes.
+
+- [ ] **Step 3: Commit**
+
+```
+git add src/smart-agent/interfaces/rag.ts
+git commit -m "feat(rag): declare IRagEditor, IIdStrategy, IRagRegistry, IRagBackendWriter"
+```
+
+---
+
+## Task 3: Implement four id strategies
+
+**Files:**
+- Create: `src/smart-agent/rag/strategies/id/caller-provided.ts`
+- Create: `src/smart-agent/rag/strategies/id/global-unique.ts`
+- Create: `src/smart-agent/rag/strategies/id/session-scoped.ts`
+- Create: `src/smart-agent/rag/strategies/id/canonical-key.ts`
+- Create: `src/smart-agent/rag/strategies/id/index.ts`
+- Test: `src/smart-agent/rag/__tests__/id-strategies.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+// src/smart-agent/rag/__tests__/id-strategies.test.ts
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  CallerProvidedIdStrategy,
+  GlobalUniqueIdStrategy,
+  SessionScopedIdStrategy,
+  CanonicalKeyIdStrategy,
+} from '../strategies/id/index.js';
+import { MissingIdError } from '../corrections/errors.js';
+
+describe('CallerProvidedIdStrategy', () => {
+  it('returns metadata.id when present', () => {
+    const s = new CallerProvidedIdStrategy();
+    assert.equal(s.resolve({ id: 'abc' }, 'text'), 'abc');
+  });
+  it('throws MissingIdError when id absent', () => {
+    const s = new CallerProvidedIdStrategy();
+    assert.throws(() => s.resolve({}, 'text'), MissingIdError);
+  });
+});
+
+describe('GlobalUniqueIdStrategy', () => {
+  it('returns metadata.id when present', () => {
+    const s = new GlobalUniqueIdStrategy();
+    assert.equal(s.resolve({ id: 'abc' }, 'text'), 'abc');
+  });
+  it('generates uuid when id absent', () => {
+    const s = new GlobalUniqueIdStrategy();
+    const id = s.resolve({}, 'text');
+    assert.match(id, /^[0-9a-f-]{36}$/);
+  });
+});
+
+describe('SessionScopedIdStrategy', () => {
+  it('prefixes explicit id with session', () => {
+    const s = new SessionScopedIdStrategy('sess-1');
+    assert.equal(s.resolve({ id: 'x' }, 't'), 'sess-1:x');
+  });
+  it('falls back to canonicalKey', () => {
+    const s = new SessionScopedIdStrategy('sess-1');
+    assert.equal(s.resolve({ canonicalKey: 'doc' }, 't'), 'sess-1:doc');
+  });
+  it('generates session-scoped uuid when neither present', () => {
+    const s = new SessionScopedIdStrategy('sess-1');
+    const id = s.resolve({}, 't');
+    assert.match(id, /^sess-1:[0-9a-f-]{36}$/);
+  });
+});
+
+describe('CanonicalKeyIdStrategy', () => {
+  it('uses canonicalKey with default version', () => {
+    const s = new CanonicalKeyIdStrategy();
+    assert.equal(s.resolve({ canonicalKey: 'doc' }, 't'), 'doc:v1');
+  });
+  it('uses provided version from metadata', () => {
+    const s = new CanonicalKeyIdStrategy();
+    assert.equal(
+      s.resolve({ canonicalKey: 'doc', version: 3 }, 't'),
+      'doc:v3',
+    );
+  });
+  it('throws when canonicalKey missing', () => {
+    const s = new CanonicalKeyIdStrategy();
+    assert.throws(() => s.resolve({}, 't'), MissingIdError);
+  });
+});
+```
+
+- [ ] **Step 2: Run test — expect failure (modules missing)**
+
+- [ ] **Step 3: Implement strategies**
+
+```ts
+// src/smart-agent/rag/strategies/id/caller-provided.ts
+import type { IIdStrategy } from '../../../interfaces/rag.js';
+import type { RagMetadata } from '../../../interfaces/types.js';
+import { MissingIdError } from '../../corrections/errors.js';
+
+export class CallerProvidedIdStrategy implements IIdStrategy {
+  resolve(metadata: RagMetadata, _text: string): string {
+    if (typeof metadata.id !== 'string' || metadata.id.length === 0) {
+      throw new MissingIdError('CallerProvidedIdStrategy');
+    }
+    return metadata.id;
+  }
+}
+```
+
+```ts
+// src/smart-agent/rag/strategies/id/global-unique.ts
+import { randomUUID } from 'node:crypto';
+import type { IIdStrategy } from '../../../interfaces/rag.js';
+import type { RagMetadata } from '../../../interfaces/types.js';
+
+export class GlobalUniqueIdStrategy implements IIdStrategy {
+  resolve(metadata: RagMetadata, _text: string): string {
+    return typeof metadata.id === 'string' && metadata.id.length > 0
+      ? metadata.id
+      : randomUUID();
+  }
+}
+```
+
+```ts
+// src/smart-agent/rag/strategies/id/session-scoped.ts
+import { randomUUID } from 'node:crypto';
+import type { IIdStrategy } from '../../../interfaces/rag.js';
+import type { RagMetadata } from '../../../interfaces/types.js';
+
+export class SessionScopedIdStrategy implements IIdStrategy {
+  constructor(private readonly sessionId: string) {}
+
+  resolve(metadata: RagMetadata, _text: string): string {
+    const suffix =
+      (typeof metadata.id === 'string' && metadata.id) ||
+      (typeof metadata.canonicalKey === 'string' && metadata.canonicalKey) ||
+      randomUUID();
+    return `${this.sessionId}:${suffix}`;
+  }
+}
+```
+
+```ts
+// src/smart-agent/rag/strategies/id/canonical-key.ts
+import type { IIdStrategy } from '../../../interfaces/rag.js';
+import type { RagMetadata } from '../../../interfaces/types.js';
+import { MissingIdError } from '../../corrections/errors.js';
+
+export class CanonicalKeyIdStrategy implements IIdStrategy {
+  resolve(metadata: RagMetadata, _text: string): string {
+    const key = metadata.canonicalKey;
+    if (typeof key !== 'string' || key.length === 0) {
+      throw new MissingIdError('CanonicalKeyIdStrategy');
+    }
+    const version =
+      typeof metadata.version === 'number' && metadata.version > 0
+        ? metadata.version
+        : 1;
+    return `${key}:v${version}`;
+  }
+}
+```
+
+```ts
+// src/smart-agent/rag/strategies/id/index.ts
+export { CallerProvidedIdStrategy } from './caller-provided.js';
+export { GlobalUniqueIdStrategy } from './global-unique.js';
+export { SessionScopedIdStrategy } from './session-scoped.js';
+export { CanonicalKeyIdStrategy } from './canonical-key.js';
+```
+
+- [ ] **Step 4: Run test — expect pass**
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/smart-agent/rag/strategies/id src/smart-agent/rag/__tests__/id-strategies.test.ts
+git commit -m "feat(rag): add id strategies (caller-provided, global-unique, session-scoped, canonical-key)"
+```
+
+---
+
+## Task 4: Corrections pure-logic module
+
+**Files:**
+- Create: `src/smart-agent/rag/corrections/metadata.ts`
+- Test: `src/smart-agent/rag/__tests__/corrections-metadata.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+// src/smart-agent/rag/__tests__/corrections-metadata.test.ts
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  validateCorrectionMetadata,
+  deprecateMetadata,
+  buildCorrectionMetadata,
+  filterActive,
+} from '../corrections/metadata.js';
+
+describe('validateCorrectionMetadata', () => {
+  it('passes with canonicalKey', () => {
+    validateCorrectionMetadata({ canonicalKey: 'k' });
+  });
+  it('throws when canonicalKey missing', () => {
+    assert.throws(() =>
+      validateCorrectionMetadata({ canonicalKey: '' as string }),
+    );
+  });
+});
+
+describe('deprecateMetadata', () => {
+  it('adds deprecated tag with reason and timestamp', () => {
+    const out = deprecateMetadata({ canonicalKey: 'k' }, 'outdated', 1000);
+    assert.deepEqual(out.tags, ['deprecated']);
+    assert.equal(out.deprecatedReason, 'outdated');
+    assert.equal(out.deprecatedAt, 1000);
+  });
+  it('is idempotent', () => {
+    const once = deprecateMetadata({ canonicalKey: 'k' }, 'r', 1);
+    const twice = deprecateMetadata(once, 'r', 1);
+    assert.deepEqual(twice.tags, ['deprecated']);
+  });
+});
+
+describe('buildCorrectionMetadata', () => {
+  it('marks predecessor superseded and next as correction', () => {
+    const { predecessor, next } = buildCorrectionMetadata({
+      predecessor: { canonicalKey: 'k' },
+      predecessorId: 'k:v1',
+      newEntryId: 'k:v2',
+      reason: 'typo fix',
+    });
+    assert.ok(predecessor.tags?.includes('superseded'));
+    assert.equal(predecessor.supersededBy, 'k:v2');
+    assert.ok(next.tags?.includes('correction'));
+    assert.equal(next.canonicalKey, 'k');
+  });
+});
+
+describe('filterActive', () => {
+  const items = [
+    { meta: { canonicalKey: 'a' } },
+    { meta: { canonicalKey: 'b', tags: ['deprecated'] as const } },
+    { meta: { canonicalKey: 'c', tags: ['superseded'] as const } },
+    { meta: { canonicalKey: 'd', tags: ['verified'] as const } },
+  ];
+  it('hides deprecated and superseded by default', () => {
+    const out = filterActive(items, (i) => i.meta as any);
+    assert.deepEqual(
+      out.map((i) => i.meta.canonicalKey),
+      ['a', 'd'],
+    );
+  });
+  it('returns all when includeInactive is true', () => {
+    const out = filterActive(items, (i) => i.meta as any, {
+      includeInactive: true,
+    });
+    assert.equal(out.length, 4);
+  });
+});
+```
+
+- [ ] **Step 2: Run test — expect failure**
+
+- [ ] **Step 3: Implement**
+
+```ts
+// src/smart-agent/rag/corrections/metadata.ts
+import { RagError } from '../../interfaces/types.js';
+
+export type CorrectionTag =
+  | 'verified'
+  | 'deprecated'
+  | 'superseded'
+  | 'correction';
+
+export interface CorrectionMetadata {
+  canonicalKey: string;
+  tags?: CorrectionTag[];
+  sessionId?: string;
+  supersededBy?: string;
+  deprecatedAt?: number;
+  deprecatedReason?: string;
+}
+
+export function validateCorrectionMetadata(meta: CorrectionMetadata): void {
+  if (typeof meta.canonicalKey !== 'string' || meta.canonicalKey.length === 0) {
+    throw new RagError(
+      'CorrectionMetadata.canonicalKey must be a non-empty string',
+      'RAG_VALIDATION_ERROR',
+    );
+  }
+}
+
+function withTag(
+  meta: CorrectionMetadata,
+  tag: CorrectionTag,
+): CorrectionMetadata {
+  const existing = meta.tags ?? [];
+  return existing.includes(tag) ? meta : { ...meta, tags: [...existing, tag] };
+}
+
+export function deprecateMetadata(
+  current: CorrectionMetadata,
+  reason: string,
+  nowSeconds?: number,
+): CorrectionMetadata {
+  validateCorrectionMetadata(current);
+  const stamped: CorrectionMetadata = {
+    ...current,
+    deprecatedReason: reason,
+    deprecatedAt: nowSeconds ?? Math.floor(Date.now() / 1000),
+  };
+  return withTag(stamped, 'deprecated');
+}
+
+export function buildCorrectionMetadata(input: {
+  predecessor: CorrectionMetadata;
+  predecessorId: string;
+  newEntryId: string;
+  reason: string;
+}): { predecessor: CorrectionMetadata; next: CorrectionMetadata } {
+  validateCorrectionMetadata(input.predecessor);
+  const predecessor = withTag(
+    {
+      ...input.predecessor,
+      supersededBy: input.newEntryId,
+      deprecatedReason: input.reason,
+      deprecatedAt: Math.floor(Date.now() / 1000),
+    },
+    'superseded',
+  );
+  const next: CorrectionMetadata = withTag(
+    {
+      canonicalKey: input.predecessor.canonicalKey,
+      sessionId: input.predecessor.sessionId,
+    },
+    'correction',
+  );
+  return { predecessor, next };
+}
+
+export function filterActive<T>(
+  items: readonly T[],
+  getMeta: (item: T) => CorrectionMetadata | undefined,
+  options?: { includeInactive?: boolean },
+): T[] {
+  if (options?.includeInactive) return [...items];
+  return items.filter((item) => {
+    const tags = getMeta(item)?.tags ?? [];
+    return !tags.includes('deprecated') && !tags.includes('superseded');
+  });
+}
+```
+
+- [ ] **Step 4: Run test — expect pass**
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/smart-agent/rag/corrections/metadata.ts src/smart-agent/rag/__tests__/corrections-metadata.test.ts
+git commit -m "feat(rag): add pure-logic corrections metadata module"
+```
+
+---
+
+## Task 5: Add `IRagBackendWriter` + `getById` to `InMemoryRag`
+
+**Files:**
+- Modify: `src/smart-agent/rag/in-memory-rag.ts`
+- Test: `src/smart-agent/rag/__tests__/in-memory-rag.test.ts` (extend)
+
+- [ ] **Step 1: Read current `InMemoryRag` to locate its internal Map**
+
+Find the internal record storage. Keep the existing `upsert` and `clear` (they will be removed in Task 13) so prior tests keep passing.
+
+- [ ] **Step 2: Add failing test for `getById` and writer surface**
+
+Append to `in-memory-rag.test.ts`:
+
+```ts
+import { InMemoryRag } from '../in-memory-rag.js';
+
+describe('InMemoryRag.getById', () => {
+  it('returns stored record by id', async () => {
+    const rag = new InMemoryRag();
+    await rag.upsert('hello world', { id: 'r1' });
+    const got = await rag.getById!('r1');
+    assert.ok(got.ok);
+    assert.ok(got.value);
+    assert.equal(got.value!.text, 'hello world');
+  });
+  it('returns null for unknown id', async () => {
+    const rag = new InMemoryRag();
+    const got = await rag.getById!('missing');
+    assert.ok(got.ok);
+    assert.equal(got.value, null);
+  });
+});
+
+describe('InMemoryRag backend writer', () => {
+  it('exposes IRagBackendWriter via writer()', async () => {
+    const rag = new InMemoryRag();
+    const writer = rag.writer();
+    const up = await writer.upsertRaw('id-1', 'hi', { id: 'id-1' });
+    assert.ok(up.ok);
+    const del = await writer.deleteByIdRaw('id-1');
+    assert.ok(del.ok && del.value === true);
+    const delAgain = await writer.deleteByIdRaw('id-1');
+    assert.ok(delAgain.ok && delAgain.value === false);
+  });
+});
+```
+
+- [ ] **Step 3: Run — expect failure**
+
+- [ ] **Step 4: Implement**
+
+Add to `InMemoryRag`:
+
+```ts
+// Inside the class
+async getById(
+  id: string,
+  _options?: CallOptions,
+): Promise<Result<RagResult | null, RagError>> {
+  const record = this.records.get(id);  // adjust to match actual field name
+  if (!record) return { ok: true, value: null };
+  return {
+    ok: true,
+    value: { text: record.text, metadata: record.metadata, score: 1 },
+  };
+}
+
+writer(): IRagBackendWriter {
+  return {
+    upsertRaw: async (id, text, metadata) => {
+      await this.upsert(text, { ...metadata, id });
+      return { ok: true, value: undefined };
+    },
+    deleteByIdRaw: async (id) => {
+      const had = this.records.has(id);  // adjust
+      if (had) this.records.delete(id);
+      return { ok: true, value: had };
+    },
+    clearAll: async () => {
+      this.records.clear();
+      return { ok: true, value: undefined };
+    },
+  };
+}
+```
+
+Adjust the internal field name (`records`, `store`, etc.) to match the actual implementation. Also import `IRagBackendWriter`, `RagResult`, `Result`, `RagError`, `CallOptions` at the top if not already.
+
+- [ ] **Step 5: Run tests — expect pass**
+
+```
+node --import tsx/esm --test --test-reporter=spec src/smart-agent/rag/__tests__/in-memory-rag.test.ts
+```
+
+- [ ] **Step 6: Commit**
+
+```
+git add src/smart-agent/rag/in-memory-rag.ts src/smart-agent/rag/__tests__/in-memory-rag.test.ts
+git commit -m "feat(rag): add getById and writer() to InMemoryRag"
+```
+
+---
+
+## Task 6: Add `getById` + writer to `VectorRag`
+
+**Files:**
+- Modify: `src/smart-agent/rag/vector-rag.ts`
+- Test: extend existing vector-rag tests, or add `src/smart-agent/rag/__tests__/vector-rag-writer.test.ts`
+
+- [ ] **Step 1: Add failing test**
+
+```ts
+// src/smart-agent/rag/__tests__/vector-rag-writer.test.ts
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { VectorRag } from '../vector-rag.js';
+import type { IEmbedder } from '../../interfaces/rag.js';
+
+const fakeEmbedder: IEmbedder = {
+  embed: async (t) => ({ vector: Array.from(t).map((c) => c.charCodeAt(0) / 255) }),
+};
+
+describe('VectorRag.getById', () => {
+  it('retrieves by id after upsert', async () => {
+    const rag = new VectorRag(fakeEmbedder);
+    await rag.upsert('hello', { id: 'v1' });
+    const got = await rag.getById!('v1');
+    assert.ok(got.ok && got.value?.text === 'hello');
+  });
+});
+
+describe('VectorRag backend writer', () => {
+  it('upsertRaw and deleteByIdRaw work', async () => {
+    const rag = new VectorRag(fakeEmbedder);
+    const w = rag.writer();
+    await w.upsertRaw('v1', 'hi', { id: 'v1' });
+    const got = await rag.getById!('v1');
+    assert.ok(got.ok && got.value !== null);
+    const del = await w.deleteByIdRaw('v1');
+    assert.ok(del.ok && del.value);
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect failure**
+
+- [ ] **Step 3: Implement `getById` and `writer()` on `VectorRag`**
+
+Look up the internal record store in `vector-rag.ts`. Mirror the `InMemoryRag` pattern: add `getById(id)` that iterates/looks up by `metadata.id`, and `writer()` that returns `IRagBackendWriter` delegating to the existing `upsert` / an internal delete.
+
+If `VectorRag` currently lacks a delete-by-id primitive, implement it alongside (filter out the matching record from the underlying store).
+
+- [ ] **Step 4: Run — expect pass**
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/smart-agent/rag/vector-rag.ts src/smart-agent/rag/__tests__/vector-rag-writer.test.ts
+git commit -m "feat(rag): add getById and writer() to VectorRag"
+```
+
+---
+
+## Task 7: Add `getById` + writer to `QdrantRag`
+
+**Files:**
+- Modify: `src/smart-agent/rag/qdrant-rag.ts`
+
+- [ ] **Step 1: Read `qdrant-rag.ts` to identify the points API used**
+
+Qdrant supports `points/retrieve?ids=[...]` and `points/delete?points=[...]`. Use these for `getById` and `deleteByIdRaw`.
+
+- [ ] **Step 2: Skip live integration test** — existing `qdrant-rag.test.ts` likely runs against a real Qdrant and is not required for CI. Verify the file pattern and add new tests only if they stay offline (mock `fetch` or use dependency injection). If the test file already mocks `fetch`, extend it; otherwise add a lightweight mocked unit test under `__tests__/qdrant-rag-writer.test.ts` using the same mock pattern.
+
+- [ ] **Step 3: Implement**
+
+Add to `QdrantRag`:
+
+```ts
+async getById(id: string, _options?: CallOptions): Promise<Result<RagResult | null, RagError>> {
+  // POST {baseUrl}/collections/{collection}/points with ids=[id]
+  // Return null when the response array is empty; otherwise map the point to RagResult.
+}
+
+writer(): IRagBackendWriter {
+  return {
+    upsertRaw: async (id, text, metadata) => {
+      return this.upsert(text, { ...metadata, id });
+    },
+    deleteByIdRaw: async (id) => {
+      // POST {baseUrl}/collections/{collection}/points/delete with points=[id]
+      // Return ok: true, value: <whether the point existed>
+    },
+    clearAll: async () => {
+      // DELETE collection points via filter={} (or recreate collection); safest is a no-op + typed error if unsupported.
+      return { ok: false, error: new RagError('clearAll not supported on QdrantRag', 'RAG_UNSUPPORTED') };
+    },
+  };
+}
+```
+
+Fill in the exact HTTP calls using the existing `fetch`/axios pattern in this file. Reuse the error-wrapping utilities already present.
+
+- [ ] **Step 4: Run `npm run build`** — expect pass. Run any offline unit tests added.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/smart-agent/rag/qdrant-rag.ts src/smart-agent/rag/__tests__/qdrant-rag-writer.test.ts
+git commit -m "feat(rag): add getById and writer() to QdrantRag"
+```
+
+---
+
+## Task 8: Implement `DirectEditStrategy` and `ImmutableEditStrategy`
+
+**Files:**
+- Create: `src/smart-agent/rag/strategies/edit/direct.ts`
+- Create: `src/smart-agent/rag/strategies/edit/immutable.ts`
+- Create: `src/smart-agent/rag/strategies/edit/index.ts` (partial — add overlay later)
+- Test: `src/smart-agent/rag/__tests__/edit-strategies-basic.test.ts`
+
+- [ ] **Step 1: Failing test**
+
+```ts
+// src/smart-agent/rag/__tests__/edit-strategies-basic.test.ts
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { DirectEditStrategy, ImmutableEditStrategy } from '../strategies/edit/index.js';
+import { GlobalUniqueIdStrategy } from '../strategies/id/index.js';
+import { ReadOnlyError } from '../corrections/errors.js';
+import type { IRagBackendWriter } from '../../interfaces/rag.js';
+
+function fakeWriter(): IRagBackendWriter & { calls: Record<string, unknown[]> } {
+  const calls: Record<string, unknown[]> = { upsertRaw: [], deleteByIdRaw: [] };
+  return {
+    calls,
+    upsertRaw: async (id, text, meta) => {
+      calls.upsertRaw.push({ id, text, meta });
+      return { ok: true, value: undefined };
+    },
+    deleteByIdRaw: async (id) => {
+      calls.deleteByIdRaw.push({ id });
+      return { ok: true, value: true };
+    },
+  };
+}
+
+describe('DirectEditStrategy', () => {
+  it('resolves id via strategy and forwards upsert', async () => {
+    const w = fakeWriter();
+    const ed = new DirectEditStrategy(w, new GlobalUniqueIdStrategy());
+    const res = await ed.upsert('hello', { id: 'x' });
+    assert.ok(res.ok);
+    assert.equal(res.value.id, 'x');
+    assert.equal(w.calls.upsertRaw.length, 1);
+  });
+  it('forwards delete', async () => {
+    const w = fakeWriter();
+    const ed = new DirectEditStrategy(w, new GlobalUniqueIdStrategy());
+    const res = await ed.deleteById('x');
+    assert.ok(res.ok);
+  });
+});
+
+describe('ImmutableEditStrategy', () => {
+  it('returns ReadOnlyError for upsert', async () => {
+    const ed = new ImmutableEditStrategy('corp-facts');
+    const res = await ed.upsert('t', {});
+    assert.ok(!res.ok);
+    assert.ok(res.error instanceof ReadOnlyError);
+  });
+  it('returns ReadOnlyError for deleteById', async () => {
+    const ed = new ImmutableEditStrategy('corp-facts');
+    const res = await ed.deleteById('x');
+    assert.ok(!res.ok);
+    assert.ok(res.error instanceof ReadOnlyError);
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect failure**
+
+- [ ] **Step 3: Implement**
+
+```ts
+// src/smart-agent/rag/strategies/edit/direct.ts
+import type {
+  IIdStrategy,
+  IRagBackendWriter,
+  IRagEditor,
+} from '../../../interfaces/rag.js';
+import type {
+  CallOptions,
+  RagError,
+  RagMetadata,
+  Result,
+} from '../../../interfaces/types.js';
+import { MissingIdError } from '../../corrections/errors.js';
+
+export class DirectEditStrategy implements IRagEditor {
+  constructor(
+    private readonly writer: IRagBackendWriter,
+    private readonly idStrategy: IIdStrategy,
+  ) {}
+
+  async upsert(
+    text: string,
+    metadata: RagMetadata,
+    options?: CallOptions,
+  ): Promise<Result<{ id: string }, RagError>> {
+    let id: string;
+    try {
+      id = this.idStrategy.resolve(metadata, text);
+    } catch (e) {
+      if (e instanceof MissingIdError) return { ok: false, error: e };
+      throw e;
+    }
+    const res = await this.writer.upsertRaw(id, text, { ...metadata, id }, options);
+    return res.ok ? { ok: true, value: { id } } : res;
+  }
+
+  async deleteById(
+    id: string,
+    options?: CallOptions,
+  ): Promise<Result<boolean, RagError>> {
+    return this.writer.deleteByIdRaw(id, options);
+  }
+
+  async clear(): Promise<Result<void, RagError>> {
+    if (this.writer.clearAll) return this.writer.clearAll();
+    return { ok: true, value: undefined };
+  }
+}
+```
+
+```ts
+// src/smart-agent/rag/strategies/edit/immutable.ts
+import type { IRagEditor } from '../../../interfaces/rag.js';
+import type { RagError, Result } from '../../../interfaces/types.js';
+import { ReadOnlyError } from '../../corrections/errors.js';
+
+export class ImmutableEditStrategy implements IRagEditor {
+  constructor(private readonly collectionName = 'immutable') {}
+  async upsert(): Promise<Result<{ id: string }, RagError>> {
+    return { ok: false, error: new ReadOnlyError(this.collectionName) };
+  }
+  async deleteById(): Promise<Result<boolean, RagError>> {
+    return { ok: false, error: new ReadOnlyError(this.collectionName) };
+  }
+}
+```
+
+```ts
+// src/smart-agent/rag/strategies/edit/index.ts
+export { DirectEditStrategy } from './direct.js';
+export { ImmutableEditStrategy } from './immutable.js';
+// overlay and session-scoped added in later tasks
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/smart-agent/rag/strategies/edit src/smart-agent/rag/__tests__/edit-strategies-basic.test.ts
+git commit -m "feat(rag): add DirectEditStrategy and ImmutableEditStrategy"
+```
+
+---
+
+## Task 9: Implement `SimpleRagRegistry`
+
+**Files:**
+- Create: `src/smart-agent/rag/registry/simple-rag-registry.ts`
+- Create: `src/smart-agent/rag/registry/index.ts`
+- Test: `src/smart-agent/rag/__tests__/simple-rag-registry.test.ts`
+
+- [ ] **Step 1: Failing test**
+
+```ts
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { SimpleRagRegistry } from '../registry/simple-rag-registry.js';
+import { InMemoryRag } from '../in-memory-rag.js';
+import { DirectEditStrategy, ImmutableEditStrategy } from '../strategies/edit/index.js';
+import { GlobalUniqueIdStrategy } from '../strategies/id/index.js';
+
+describe('SimpleRagRegistry', () => {
+  it('registers and retrieves rag + editor', () => {
+    const reg = new SimpleRagRegistry();
+    const rag = new InMemoryRag();
+    const ed = new DirectEditStrategy(rag.writer(), new GlobalUniqueIdStrategy());
+    reg.register('notes', rag, ed, { displayName: 'Notes' });
+    assert.equal(reg.get('notes'), rag);
+    assert.equal(reg.getEditor('notes'), ed);
+  });
+
+  it('marks collection as read-only when editor is absent or immutable', () => {
+    const reg = new SimpleRagRegistry();
+    reg.register('corp', new InMemoryRag(), new ImmutableEditStrategy('corp'), { displayName: 'Corp' });
+    reg.register('facts', new InMemoryRag(), undefined, { displayName: 'Facts' });
+    const list = reg.list();
+    const corp = list.find((m) => m.name === 'corp')!;
+    const facts = list.find((m) => m.name === 'facts')!;
+    assert.equal(corp.editable, false);
+    assert.equal(facts.editable, false);
+  });
+
+  it('rejects duplicate names', () => {
+    const reg = new SimpleRagRegistry();
+    reg.register('x', new InMemoryRag(), undefined, { displayName: 'X' });
+    assert.throws(() => reg.register('x', new InMemoryRag(), undefined, { displayName: 'X' }));
+  });
+
+  it('unregister removes entry and returns true when present', () => {
+    const reg = new SimpleRagRegistry();
+    reg.register('x', new InMemoryRag(), undefined, { displayName: 'X' });
+    assert.equal(reg.unregister('x'), true);
+    assert.equal(reg.unregister('x'), false);
+  });
+
+  it('list preserves insertion order', () => {
+    const reg = new SimpleRagRegistry();
+    reg.register('a', new InMemoryRag(), undefined, { displayName: 'A' });
+    reg.register('b', new InMemoryRag(), undefined, { displayName: 'B' });
+    reg.register('c', new InMemoryRag(), undefined, { displayName: 'C' });
+    assert.deepEqual(reg.list().map((m) => m.name), ['a', 'b', 'c']);
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect failure**
+
+- [ ] **Step 3: Implement**
+
+```ts
+// src/smart-agent/rag/registry/simple-rag-registry.ts
+import type {
+  IRag,
+  IRagEditor,
+  IRagRegistry,
+  RagCollectionMeta,
+} from '../../interfaces/rag.js';
+import { ImmutableEditStrategy } from '../strategies/edit/immutable.js';
+
+interface Entry {
+  rag: IRag;
+  editor?: IRagEditor;
+  meta: RagCollectionMeta;
+}
+
+export class SimpleRagRegistry implements IRagRegistry {
+  protected readonly entries = new Map<string, Entry>();
+
+  register(
+    name: string,
+    rag: IRag,
+    editor?: IRagEditor,
+    meta?: Omit<RagCollectionMeta, 'name' | 'editable'>,
+  ): void {
+    if (this.entries.has(name)) {
+      throw new Error(`Collection '${name}' is already registered`);
+    }
+    const editable = Boolean(editor) && !(editor instanceof ImmutableEditStrategy);
+    this.entries.set(name, {
+      rag,
+      editor,
+      meta: {
+        name,
+        displayName: meta?.displayName ?? name,
+        description: meta?.description,
+        tags: meta?.tags,
+        editable,
+      },
+    });
+  }
+
+  unregister(name: string): boolean {
+    return this.entries.delete(name);
+  }
+
+  get(name: string): IRag | undefined {
+    return this.entries.get(name)?.rag;
+  }
+
+  getEditor(name: string): IRagEditor | undefined {
+    return this.entries.get(name)?.editor;
+  }
+
+  list(): readonly RagCollectionMeta[] {
+    return Array.from(this.entries.values()).map((e) => e.meta);
+  }
+}
+```
+
+```ts
+// src/smart-agent/rag/registry/index.ts
+export { SimpleRagRegistry } from './simple-rag-registry.js';
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/smart-agent/rag/registry src/smart-agent/rag/__tests__/simple-rag-registry.test.ts
+git commit -m "feat(rag): add SimpleRagRegistry"
+```
+
+---
+
+## Task 10: Implement `ActiveFilteringRag`
+
+**Files:**
+- Create: `src/smart-agent/rag/corrections/active-filtering-rag.ts`
+- Create: `src/smart-agent/rag/corrections/index.ts`
+- Test: `src/smart-agent/rag/__tests__/active-filtering-rag.test.ts`
+
+- [ ] **Step 1: Failing test**
+
+```ts
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { ActiveFilteringRag } from '../corrections/active-filtering-rag.js';
+import type { IRag } from '../../interfaces/rag.js';
+import type { RagResult } from '../../interfaces/types.js';
+import { TextOnlyEmbedding } from '../query-embedding.js';
+
+function stubRag(results: RagResult[]): IRag {
+  return {
+    query: async () => ({ ok: true, value: results }),
+    getById: async (id) => ({
+      ok: true,
+      value: results.find((r) => r.metadata.id === id) ?? null,
+    }),
+    healthCheck: async () => ({ ok: true, value: undefined }),
+  };
+}
+
+describe('ActiveFilteringRag', () => {
+  const results: RagResult[] = [
+    { text: 'a', metadata: { id: '1', canonicalKey: 'a' }, score: 1 },
+    { text: 'b', metadata: { id: '2', canonicalKey: 'b', tags: ['deprecated'] }, score: 0.9 },
+    { text: 'c', metadata: { id: '3', canonicalKey: 'c', tags: ['superseded'] }, score: 0.8 },
+  ];
+  it('hides deprecated and superseded on query by default', async () => {
+    const rag = new ActiveFilteringRag(stubRag(results));
+    const res = await rag.query(new TextOnlyEmbedding('q'), 10);
+    assert.ok(res.ok);
+    assert.deepEqual(res.value.map((r) => r.metadata.id), ['1']);
+  });
+  it('returns all when includeInactive is true', async () => {
+    const rag = new ActiveFilteringRag(stubRag(results));
+    const res = await rag.query(new TextOnlyEmbedding('q'), 10, {
+      ragFilter: { includeInactive: true } as any,
+    });
+    assert.ok(res.ok && res.value.length === 3);
+  });
+  it('getById returns null for deprecated by default', async () => {
+    const rag = new ActiveFilteringRag(stubRag(results));
+    const res = await rag.getById!('2');
+    assert.ok(res.ok && res.value === null);
+  });
+  it('getById returns deprecated when includeInactive is set', async () => {
+    const rag = new ActiveFilteringRag(stubRag(results));
+    const res = await rag.getById!('2', {
+      ragFilter: { includeInactive: true } as any,
+    });
+    assert.ok(res.ok && res.value !== null);
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect failure**
+
+- [ ] **Step 3: Implement**
+
+```ts
+// src/smart-agent/rag/corrections/active-filtering-rag.ts
+import type { IRag } from '../../interfaces/rag.js';
+import type { IQueryEmbedding } from '../../interfaces/query-embedding.js';
+import type {
+  CallOptions,
+  RagError,
+  RagResult,
+  Result,
+} from '../../interfaces/types.js';
+import { filterActive, type CorrectionMetadata } from './metadata.js';
+
+function includeInactive(options?: CallOptions): boolean {
+  return Boolean(
+    (options?.ragFilter as { includeInactive?: boolean } | undefined)
+      ?.includeInactive,
+  );
+}
+
+export class ActiveFilteringRag implements IRag {
+  constructor(private readonly inner: IRag) {}
+
+  async query(
+    embedding: IQueryEmbedding,
+    k: number,
+    options?: CallOptions,
+  ): Promise<Result<RagResult[], RagError>> {
+    const res = await this.inner.query(embedding, k, options);
+    if (!res.ok) return res;
+    const filtered = filterActive(
+      res.value,
+      (r) => r.metadata as CorrectionMetadata,
+      { includeInactive: includeInactive(options) },
+    );
+    return { ok: true, value: filtered };
+  }
+
+  async getById(
+    id: string,
+    options?: CallOptions,
+  ): Promise<Result<RagResult | null, RagError>> {
+    if (!this.inner.getById) {
+      return { ok: true, value: null };
+    }
+    const res = await this.inner.getById(id, options);
+    if (!res.ok || res.value === null) return res;
+    const tags = (res.value.metadata as CorrectionMetadata).tags ?? [];
+    const inactive = tags.includes('deprecated') || tags.includes('superseded');
+    if (inactive && !includeInactive(options)) {
+      return { ok: true, value: null };
+    }
+    return res;
+  }
+
+  healthCheck(options?: CallOptions): Promise<Result<void, RagError>> {
+    return this.inner.healthCheck(options);
+  }
+}
+```
+
+```ts
+// src/smart-agent/rag/corrections/index.ts
+export * from './errors.js';
+export * from './metadata.js';
+export { ActiveFilteringRag } from './active-filtering-rag.js';
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/smart-agent/rag/corrections src/smart-agent/rag/__tests__/active-filtering-rag.test.ts
+git commit -m "feat(rag): add ActiveFilteringRag"
+```
+
+---
+
+## Task 11: Implement `OverlayRag` and `SessionScopedRag` (read-side)
+
+**Files:**
+- Create: `src/smart-agent/rag/overlays/overlay-rag.ts`
+- Create: `src/smart-agent/rag/overlays/session-scoped-rag.ts`
+- Create: `src/smart-agent/rag/overlays/index.ts`
+- Test: `src/smart-agent/rag/__tests__/overlay-rag.test.ts`
+
+- [ ] **Step 1: Failing test**
+
+```ts
+// src/smart-agent/rag/__tests__/overlay-rag.test.ts
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { OverlayRag } from '../overlays/overlay-rag.js';
+import { SessionScopedRag } from '../overlays/session-scoped-rag.js';
+import type { IRag } from '../../interfaces/rag.js';
+import type { RagResult } from '../../interfaces/types.js';
+import { TextOnlyEmbedding } from '../query-embedding.js';
+
+function stub(results: RagResult[], records: Record<string, RagResult> = {}): IRag {
+  return {
+    query: async () => ({ ok: true, value: results }),
+    getById: async (id) => ({ ok: true, value: records[id] ?? null }),
+    healthCheck: async () => ({ ok: true, value: undefined }),
+  };
+}
+
+describe('OverlayRag.query', () => {
+  it('overlay wins on canonicalKey collision regardless of score', async () => {
+    const base = stub([
+      { text: 'old', metadata: { id: 'b1', canonicalKey: 'k' }, score: 0.99 },
+      { text: 'other', metadata: { id: 'b2', canonicalKey: 'x' }, score: 0.5 },
+    ]);
+    const overlay = stub([
+      { text: 'new', metadata: { id: 'o1', canonicalKey: 'k' }, score: 0.1 },
+    ]);
+    const rag = new OverlayRag(base, overlay);
+    const res = await rag.query(new TextOnlyEmbedding('q'), 10);
+    assert.ok(res.ok);
+    const texts = res.value.map((r) => r.text).sort();
+    assert.deepEqual(texts, ['new', 'other']);
+  });
+});
+
+describe('OverlayRag.getById', () => {
+  it('prefers overlay, falls back to base', async () => {
+    const base = stub([], { 'b1': { text: 'base', metadata: { id: 'b1' }, score: 1 } });
+    const overlay = stub([], { 'o1': { text: 'ovr', metadata: { id: 'o1' }, score: 1 } });
+    const rag = new OverlayRag(base, overlay);
+    assert.equal((await rag.getById!('o1')).ok && 'ovr', 'ovr');
+    assert.equal((await rag.getById!('b1')).ok && 'base', 'base');
+    const miss = await rag.getById!('nope');
+    assert.ok(miss.ok && miss.value === null);
+  });
+});
+
+describe('SessionScopedRag', () => {
+  it('includes only overlay records matching sessionId', async () => {
+    const base = stub([{ text: 'b', metadata: { id: 'b', canonicalKey: 'b' }, score: 1 }]);
+    const overlay = stub([
+      { text: 'own', metadata: { id: 'o1', canonicalKey: 'x', sessionId: 'S' }, score: 1 },
+      { text: 'other', metadata: { id: 'o2', canonicalKey: 'y', sessionId: 'X' }, score: 1 },
+    ]);
+    const rag = new SessionScopedRag(base, overlay, 'S');
+    const res = await rag.query(new TextOnlyEmbedding('q'), 10);
+    assert.ok(res.ok);
+    const texts = res.value.map((r) => r.text).sort();
+    assert.deepEqual(texts, ['b', 'own']);
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect failure**
+
+- [ ] **Step 3: Implement `OverlayRag`**
+
+```ts
+// src/smart-agent/rag/overlays/overlay-rag.ts
+import type { IRag } from '../../interfaces/rag.js';
+import type { IQueryEmbedding } from '../../interfaces/query-embedding.js';
+import type {
+  CallOptions,
+  RagError,
+  RagResult,
+  Result,
+} from '../../interfaces/types.js';
+
+export class OverlayRag implements IRag {
+  constructor(
+    protected readonly base: IRag,
+    protected readonly overlay: IRag,
+  ) {}
+
+  async query(
+    embedding: IQueryEmbedding,
+    k: number,
+    options?: CallOptions,
+  ): Promise<Result<RagResult[], RagError>> {
+    const [baseRes, overlayRes] = await Promise.all([
+      this.base.query(embedding, k, options),
+      this.overlay.query(embedding, k, options),
+    ]);
+    if (!baseRes.ok) return baseRes;
+    if (!overlayRes.ok) return overlayRes;
+    const overlayList = this.filterOverlay(overlayRes.value);
+    const overlayKeys = new Set(
+      overlayList
+        .map((r) => r.metadata.canonicalKey)
+        .filter((k): k is string => typeof k === 'string'),
+    );
+    const baseKept = baseRes.value.filter((r) => {
+      const key = r.metadata.canonicalKey;
+      return typeof key !== 'string' || !overlayKeys.has(key);
+    });
+    const merged = [...overlayList, ...baseKept]
+      .sort((a, b) => b.score - a.score)
+      .slice(0, k);
+    return { ok: true, value: merged };
+  }
+
+  async getById(
+    id: string,
+    options?: CallOptions,
+  ): Promise<Result<RagResult | null, RagError>> {
+    if (this.overlay.getById) {
+      const o = await this.overlay.getById(id, options);
+      if (!o.ok) return o;
+      if (o.value !== null && this.overlayAllows(o.value)) return o;
+    }
+    if (!this.base.getById) return { ok: true, value: null };
+    return this.base.getById(id, options);
+  }
+
+  async healthCheck(options?: CallOptions): Promise<Result<void, RagError>> {
+    const [a, b] = await Promise.all([
+      this.base.healthCheck(options),
+      this.overlay.healthCheck(options),
+    ]);
+    if (!a.ok) return a;
+    return b;
+  }
+
+  /** Hook for subclasses to drop overlay rows (e.g. by sessionId). */
+  protected filterOverlay(results: RagResult[]): RagResult[] {
+    return results;
+  }
+
+  protected overlayAllows(_result: RagResult): boolean {
+    return true;
+  }
+}
+```
+
+```ts
+// src/smart-agent/rag/overlays/session-scoped-rag.ts
+import type { IRag } from '../../interfaces/rag.js';
+import type { RagResult } from '../../interfaces/types.js';
+import { OverlayRag } from './overlay-rag.js';
+
+export class SessionScopedRag extends OverlayRag {
+  constructor(
+    base: IRag,
+    overlay: IRag,
+    private readonly sessionId: string,
+    private readonly ttlMs?: number,
+  ) {
+    super(base, overlay);
+  }
+
+  protected override filterOverlay(results: RagResult[]): RagResult[] {
+    const cutoff =
+      this.ttlMs !== undefined ? Date.now() - this.ttlMs : undefined;
+    return results.filter((r) => this.matches(r, cutoff));
+  }
+
+  protected override overlayAllows(result: RagResult): boolean {
+    const cutoff =
+      this.ttlMs !== undefined ? Date.now() - this.ttlMs : undefined;
+    return this.matches(result, cutoff);
+  }
+
+  private matches(result: RagResult, cutoffMs: number | undefined): boolean {
+    if (result.metadata.sessionId !== this.sessionId) return false;
+    if (cutoffMs !== undefined) {
+      const createdMs =
+        typeof result.metadata.createdAt === 'number'
+          ? result.metadata.createdAt
+          : undefined;
+      if (createdMs !== undefined && createdMs < cutoffMs) return false;
+    }
+    return true;
+  }
+}
+```
+
+```ts
+// src/smart-agent/rag/overlays/index.ts
+export { OverlayRag } from './overlay-rag.js';
+export { SessionScopedRag } from './session-scoped-rag.js';
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/smart-agent/rag/overlays src/smart-agent/rag/__tests__/overlay-rag.test.ts
+git commit -m "feat(rag): add OverlayRag and SessionScopedRag read-side layers"
+```
+
+---
+
+## Task 12: Implement `OverlayEditStrategy` and `SessionScopedEditStrategy`
+
+**Files:**
+- Create: `src/smart-agent/rag/strategies/edit/overlay.ts`
+- Create: `src/smart-agent/rag/strategies/edit/session-scoped.ts`
+- Modify: `src/smart-agent/rag/strategies/edit/index.ts`
+- Test: `src/smart-agent/rag/__tests__/edit-strategies-overlay.test.ts`
+
+- [ ] **Step 1: Failing test**
+
+```ts
+// src/smart-agent/rag/__tests__/edit-strategies-overlay.test.ts
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  OverlayEditStrategy,
+  SessionScopedEditStrategy,
+} from '../strategies/edit/index.js';
+import { GlobalUniqueIdStrategy, SessionScopedIdStrategy } from '../strategies/id/index.js';
+import type { IRagBackendWriter } from '../../interfaces/rag.js';
+
+function fakeWriter() {
+  const rows = new Map<string, { text: string; meta: any }>();
+  const writer: IRagBackendWriter = {
+    upsertRaw: async (id, text, meta) => {
+      rows.set(id, { text, meta });
+      return { ok: true, value: undefined };
+    },
+    deleteByIdRaw: async (id) => ({ ok: true, value: rows.delete(id) }),
+  };
+  return { writer, rows };
+}
+
+describe('OverlayEditStrategy', () => {
+  it('writes only to overlay writer', async () => {
+    const { writer, rows } = fakeWriter();
+    const ed = new OverlayEditStrategy(writer, new GlobalUniqueIdStrategy());
+    const res = await ed.upsert('v', { id: 'x' });
+    assert.ok(res.ok && res.value.id === 'x');
+    assert.equal(rows.size, 1);
+  });
+});
+
+describe('SessionScopedEditStrategy', () => {
+  it('stamps sessionId on every write', async () => {
+    const { writer, rows } = fakeWriter();
+    const ed = new SessionScopedEditStrategy(
+      writer,
+      'S',
+      new SessionScopedIdStrategy('S'),
+    );
+    const res = await ed.upsert('v', { id: 'x' });
+    assert.ok(res.ok);
+    const row = rows.get(res.value.id)!;
+    assert.equal(row.meta.sessionId, 'S');
+    assert.equal(res.value.id, 'S:x');
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect failure**
+
+- [ ] **Step 3: Implement**
+
+```ts
+// src/smart-agent/rag/strategies/edit/overlay.ts
+import { DirectEditStrategy } from './direct.js';
+import type {
+  IIdStrategy,
+  IRagBackendWriter,
+} from '../../../interfaces/rag.js';
+
+export class OverlayEditStrategy extends DirectEditStrategy {
+  constructor(overlayWriter: IRagBackendWriter, idStrategy: IIdStrategy) {
+    super(overlayWriter, idStrategy);
+  }
+}
+```
+
+```ts
+// src/smart-agent/rag/strategies/edit/session-scoped.ts
+import type {
+  IIdStrategy,
+  IRagBackendWriter,
+  IRagEditor,
+} from '../../../interfaces/rag.js';
+import type {
+  CallOptions,
+  RagError,
+  RagMetadata,
+  Result,
+} from '../../../interfaces/types.js';
+import { MissingIdError } from '../../corrections/errors.js';
+
+export class SessionScopedEditStrategy implements IRagEditor {
+  constructor(
+    private readonly writer: IRagBackendWriter,
+    private readonly sessionId: string,
+    private readonly idStrategy: IIdStrategy,
+    private readonly ttlMs?: number,
+  ) {}
+
+  async upsert(
+    text: string,
+    metadata: RagMetadata,
+    options?: CallOptions,
+  ): Promise<Result<{ id: string }, RagError>> {
+    const stamped: RagMetadata = {
+      ...metadata,
+      sessionId: this.sessionId,
+      createdAt:
+        typeof metadata.createdAt === 'number' ? metadata.createdAt : Date.now(),
+    };
+    let id: string;
+    try {
+      id = this.idStrategy.resolve(stamped, text);
+    } catch (e) {
+      if (e instanceof MissingIdError) return { ok: false, error: e };
+      throw e;
+    }
+    const res = await this.writer.upsertRaw(
+      id,
+      text,
+      { ...stamped, id },
+      options,
+    );
+    return res.ok ? { ok: true, value: { id } } : res;
+  }
+
+  async deleteById(
+    id: string,
+    options?: CallOptions,
+  ): Promise<Result<boolean, RagError>> {
+    return this.writer.deleteByIdRaw(id, options);
+  }
+}
+```
+
+Update the edit index barrel:
+
+```ts
+// src/smart-agent/rag/strategies/edit/index.ts
+export { DirectEditStrategy } from './direct.js';
+export { ImmutableEditStrategy } from './immutable.js';
+export { OverlayEditStrategy } from './overlay.js';
+export { SessionScopedEditStrategy } from './session-scoped.js';
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/smart-agent/rag/strategies/edit src/smart-agent/rag/__tests__/edit-strategies-overlay.test.ts
+git commit -m "feat(rag): add OverlayEditStrategy and SessionScopedEditStrategy"
+```
+
+---
+
+## Task 13: Migrate callers, drop `IRag.upsert` / `IRag.clear`, require `getById`
+
+**Files:**
+- Modify: `src/smart-agent/interfaces/rag.ts`
+- Modify: `src/smart-agent/rag/in-memory-rag.ts`, `vector-rag.ts`, `qdrant-rag.ts`
+- Modify: `src/smart-agent/rag/tool-indexing-strategy.ts`
+- Modify: `src/smart-agent/rag/preprocessor.ts`
+- Modify: any builder / pipeline code that currently calls `rag.upsert(...)`
+- Modify: `src/smart-agent/rag/__tests__/in-memory-rag.test.ts` (and sibling existing tests) to use writer/editor instead of `rag.upsert`
+
+This is the breaking change. Keep the loop tight: find all call sites, switch them to the new API, remove the old methods last.
+
+- [ ] **Step 1: Find all call sites**
+
+Run:
+```
+rg -n "\.upsert\(" src/ --glob '!**/__tests__/**'
+rg -n "rag\.clear\(" src/
+```
+
+- [ ] **Step 2: Introduce an editor everywhere `rag.upsert` was called**
+
+For each call site:
+- If the caller already has an `IRagRegistry`, use `registry.getEditor(name).upsert(...)`.
+- If the caller only has an `IRag` today, inject an `IRagEditor` alongside (widen the constructor / factory signature). Prefer `DirectEditStrategy(rag.writer(), new GlobalUniqueIdStrategy())` as the default for paths that used to just dump records.
+
+Key files:
+- `tool-indexing-strategy.ts` — accept `IRagEditor` as a constructor arg, replace `rag.upsert(...)` with `editor.upsert(...)`.
+- `preprocessor.ts` — same.
+- Any builder in `src/smart-agent/builder.ts` or `providers.ts` that constructs these — plumb the editor through.
+
+- [ ] **Step 3: Update existing tests**
+
+Tests that call `rag.upsert(...)` to seed state must switch to the writer:
+
+```ts
+const rag = new InMemoryRag();
+const writer = rag.writer();
+await writer.upsertRaw('id-1', 'hello world', { id: 'id-1' });
+```
+
+Or, for higher-level tests, use a `DirectEditStrategy`.
+
+- [ ] **Step 4: Remove from `IRag`**
+
+Edit `src/smart-agent/interfaces/rag.ts`:
+
+```ts
+export interface IRag {
+  query(
+    embedding: IQueryEmbedding,
+    k: number,
+    options?: CallOptions,
+  ): Promise<Result<RagResult[], RagError>>;
+
+  getById(
+    id: string,
+    options?: CallOptions,
+  ): Promise<Result<RagResult | null, RagError>>;
+
+  healthCheck(options?: CallOptions): Promise<Result<void, RagError>>;
+}
+```
+
+Delete `upsert` and `clear`. Remove `IPrecomputedVectorRag.upsertPrecomputed` (moved to backend writer; if callers still need it, add it to `IRagBackendWriter` as `upsertPrecomputedRaw` and delete from `IPrecomputedVectorRag`).
+
+- [ ] **Step 5: Remove the old `upsert` / `clear` from each backend** once nothing calls them
+
+- [ ] **Step 6: Run build + all tests**
+
+```
+npm run build
+node --import tsx/esm --test --test-reporter=spec src/smart-agent/rag/__tests__/*.test.ts
+```
+Expected: all pass.
+
+- [ ] **Step 7: Commit**
+
+```
+git add -A src/smart-agent
+git commit -m "refactor(rag)!: drop IRag.upsert/clear; require getById; migrate call sites to IRagEditor
+
+BREAKING CHANGE: IRag no longer exposes upsert or clear. All writes now go
+through IRagEditor, typically via a registry. Backends expose a writer()
+method returning IRagBackendWriter."
+```
+
+---
+
+## Task 14: MCP tool factory
+
+**Files:**
+- Create: `src/smart-agent/rag/mcp-tools/rag-collection-tools.ts`
+- Create: `src/smart-agent/rag/mcp-tools/index.ts`
+- Test: `src/smart-agent/rag/__tests__/rag-collection-tools.test.ts`
+
+- [ ] **Step 1: Failing test**
+
+```ts
+// src/smart-agent/rag/__tests__/rag-collection-tools.test.ts
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { SimpleRagRegistry } from '../registry/simple-rag-registry.js';
+import { InMemoryRag } from '../in-memory-rag.js';
+import { DirectEditStrategy, ImmutableEditStrategy } from '../strategies/edit/index.js';
+import { GlobalUniqueIdStrategy } from '../strategies/id/index.js';
+import { buildRagCollectionToolEntries } from '../mcp-tools/rag-collection-tools.js';
+
+describe('buildRagCollectionToolEntries', () => {
+  const makeRegistry = () => {
+    const reg = new SimpleRagRegistry();
+    const rag = new InMemoryRag();
+    reg.register('notes', rag, new DirectEditStrategy(rag.writer(), new GlobalUniqueIdStrategy()), { displayName: 'Notes' });
+    reg.register('corp', new InMemoryRag(), new ImmutableEditStrategy('corp'), { displayName: 'Corp' });
+    return reg;
+  };
+
+  it('produces rag_add, rag_correct, rag_deprecate (rag_create_collection omitted by default)', () => {
+    const entries = buildRagCollectionToolEntries({ registry: makeRegistry() });
+    const names = entries.map((e) => e.toolDefinition.name).sort();
+    assert.deepEqual(names, ['rag_add', 'rag_correct', 'rag_deprecate']);
+  });
+
+  it('rag_add rejects read-only collection', async () => {
+    const entries = buildRagCollectionToolEntries({ registry: makeRegistry() });
+    const add = entries.find((e) => e.toolDefinition.name === 'rag_add')!;
+    const out = (await add.handler({}, {
+      collection: 'corp',
+      text: 't',
+      canonicalKey: 'k',
+    })) as { ok: boolean; error?: string };
+    assert.equal(out.ok, false);
+    assert.match(out.error!, /read-only/i);
+  });
+
+  it('rag_add writes into editable collection', async () => {
+    const entries = buildRagCollectionToolEntries({ registry: makeRegistry() });
+    const add = entries.find((e) => e.toolDefinition.name === 'rag_add')!;
+    const out = (await add.handler({}, {
+      collection: 'notes',
+      text: 'hello',
+      canonicalKey: 'greeting',
+    })) as { ok: boolean; id?: string };
+    assert.equal(out.ok, true);
+    assert.ok(out.id);
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect failure**
+
+- [ ] **Step 3: Implement**
+
+```ts
+// src/smart-agent/rag/mcp-tools/rag-collection-tools.ts
+import { z } from 'zod';
+import type { IRagRegistry } from '../../interfaces/rag.js';
+import {
+  buildCorrectionMetadata,
+  deprecateMetadata,
+} from '../corrections/metadata.js';
+
+export interface RagToolEntry {
+  toolDefinition: {
+    name: string;
+    description: string;
+    inputSchema: z.ZodRawShape;
+  };
+  handler: (
+    context: object,
+    args: Record<string, unknown>,
+  ) => Promise<unknown>;
+}
+
+export function buildRagCollectionToolEntries(opts: {
+  registry: IRagRegistry;
+}): RagToolEntry[] {
+  const { registry } = opts;
+
+  const resolveEditor = (name: unknown) => {
+    if (typeof name !== 'string') return { ok: false, error: 'collection is required' };
+    const editor = registry.getEditor(name);
+    if (!editor) return { ok: false, error: `Collection '${name}' is read-only or unknown` };
+    return { ok: true as const, editor };
+  };
+
+  const addTool: RagToolEntry = {
+    toolDefinition: {
+      name: 'rag_add',
+      description: 'Add a new document to a RAG collection.',
+      inputSchema: {
+        collection: z.string(),
+        text: z.string(),
+        canonicalKey: z.string(),
+        tags: z.array(z.string()).optional(),
+      },
+    },
+    handler: async (_ctx, args) => {
+      const r = resolveEditor(args.collection);
+      if (!r.ok) return r;
+      const res = await r.editor.upsert(String(args.text), {
+        canonicalKey: String(args.canonicalKey),
+        tags: args.tags as string[] | undefined,
+      });
+      return res.ok ? { ok: true, id: res.value.id } : { ok: false, error: res.error.message };
+    },
+  };
+
+  const correctTool: RagToolEntry = {
+    toolDefinition: {
+      name: 'rag_correct',
+      description:
+        'Supersede a document with a new corrected version. Marks the predecessor as superseded.',
+      inputSchema: {
+        collection: z.string(),
+        predecessorId: z.string(),
+        predecessorCanonicalKey: z.string(),
+        newText: z.string(),
+        reason: z.string(),
+      },
+    },
+    handler: async (_ctx, args) => {
+      const r = resolveEditor(args.collection);
+      if (!r.ok) return r;
+      const predecessorMeta = {
+        canonicalKey: String(args.predecessorCanonicalKey),
+      };
+      // First: upsert the new entry to discover its id.
+      const newRes = await r.editor.upsert(String(args.newText), {
+        canonicalKey: predecessorMeta.canonicalKey,
+      });
+      if (!newRes.ok) return { ok: false, error: newRes.error.message };
+
+      const { predecessor } = buildCorrectionMetadata({
+        predecessor: predecessorMeta,
+        predecessorId: String(args.predecessorId),
+        newEntryId: newRes.value.id,
+        reason: String(args.reason),
+      });
+      const supRes = await r.editor.upsert('', {
+        ...predecessor,
+        id: String(args.predecessorId),
+      });
+      if (!supRes.ok) return { ok: false, error: supRes.error.message };
+      return {
+        ok: true,
+        predecessorId: String(args.predecessorId),
+        newId: newRes.value.id,
+      };
+    },
+  };
+
+  const deprecateTool: RagToolEntry = {
+    toolDefinition: {
+      name: 'rag_deprecate',
+      description: 'Mark a document as deprecated (idempotent).',
+      inputSchema: {
+        collection: z.string(),
+        id: z.string(),
+        canonicalKey: z.string(),
+        reason: z.string(),
+      },
+    },
+    handler: async (_ctx, args) => {
+      const r = resolveEditor(args.collection);
+      if (!r.ok) return r;
+      const meta = deprecateMetadata(
+        { canonicalKey: String(args.canonicalKey) },
+        String(args.reason),
+      );
+      const res = await r.editor.upsert('', { ...meta, id: String(args.id) });
+      return res.ok ? { ok: true, id: res.value.id } : { ok: false, error: res.error.message };
+    },
+  };
+
+  return [addTool, correctTool, deprecateTool];
+}
+```
+
+```ts
+// src/smart-agent/rag/mcp-tools/index.ts
+export { buildRagCollectionToolEntries, type RagToolEntry } from './rag-collection-tools.js';
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/smart-agent/rag/mcp-tools src/smart-agent/rag/__tests__/rag-collection-tools.test.ts
+git commit -m "feat(rag): add buildRagCollectionToolEntries MCP factory"
+```
+
+---
+
+## Task 15: Public API + version bump
+
+**Files:**
+- Modify: `src/smart-agent/rag/index.ts`
+- Modify: `src/index.ts`
+- Modify: `package.json`
+
+- [ ] **Step 1: Re-export new modules from `src/smart-agent/rag/index.ts`**
+
+Add:
+```ts
+export * from './corrections/index.js';
+export * from './registry/index.js';
+export * from './overlays/index.js';
+export * from './strategies/edit/index.js';
+export * from './strategies/id/index.js';
+export * from './mcp-tools/index.js';
+```
+
+Check for existing exports — keep those intact; just append.
+
+- [ ] **Step 2: Add top-level exports in `src/index.ts`**
+
+Re-export `IRagEditor`, `IIdStrategy`, `IRagRegistry`, `RagCollectionMeta`, `IRagBackendWriter`, strategies, `SimpleRagRegistry`, corrections, `ActiveFilteringRag`, overlay rags, `buildRagCollectionToolEntries`, error types.
+
+- [ ] **Step 3: Bump version**
+
+```
+npm version major --no-git-tag-version
+```
+Expected: `package.json` at `9.0.0`.
+
+- [ ] **Step 4: Commit**
+
+```
+git add src/smart-agent/rag/index.ts src/index.ts package.json package-lock.json
+git commit -m "chore: release 9.0.0 - RAG registry + corrections layer"
+```
+
+---
+
+## Task 16: Final verification
+
+- [ ] **Step 1: Full build**
+
+```
+npm run build
+```
+Expected: clean build.
+
+- [ ] **Step 2: Full test run**
+
+```
+node --import tsx/esm --test --test-reporter=spec src/smart-agent/rag/__tests__/*.test.ts
+```
+Expected: all pass.
+
+- [ ] **Step 3: Lint**
+
+```
+npm run lint
+```
+Expected: clean (auto-fix what Biome rewrites).
+
+- [ ] **Step 4: Smoke test**
+
+```
+npm run test
+```
+(Which runs `build + start` per CLAUDE.md.)
+
+- [ ] **Step 5: Spec grep**
+
+Scan the spec one more time; confirm every named entity exists in the codebase:
+
+```
+rg -n "IRagEditor|IRagRegistry|IIdStrategy|IRagBackendWriter|SimpleRagRegistry|OverlayRag|SessionScopedRag|DirectEditStrategy|ImmutableEditStrategy|OverlayEditStrategy|SessionScopedEditStrategy|CallerProvidedIdStrategy|GlobalUniqueIdStrategy|SessionScopedIdStrategy|CanonicalKeyIdStrategy|ActiveFilteringRag|buildRagCollectionToolEntries|ReadOnlyError|MissingIdError" src/
+```
+
+- [ ] **Step 6: Delete the spec + plan once the PR is merged** (per retention policy: spec/plan live in git only while work is in progress).
+
+---
+
+## Notes
+
+- **No `ExpositionFilteringRag` coupling.** `ActiveFilteringRag` is independent — consumers compose them externally if needed.
+- **`rag_create_collection`** intentionally omitted from Task 14. If a consumer needs it, they pass a collection-factory hook and the factory adds a fourth entry. Ship that in a follow-up; design already supports it without breaking.
+- **Overlay TTL** uses `metadata.createdAt` (milliseconds). If `createdAt` isn't stamped, TTL filtering is skipped for that record (lenient). Stamping happens in `SessionScopedEditStrategy.upsert`.
+- **`CanonicalKeyCollisionError`** is declared but not thrown anywhere in this plan — it's reserved for a future strict-overlay variant. Do not remove it; that's the single source of truth if/when we add strict mode.

--- a/docs/superpowers/specs/2026-04-22-rag-registry-corrections-design.md
+++ b/docs/superpowers/specs/2026-04-22-rag-registry-corrections-design.md
@@ -21,7 +21,7 @@ Upstreaming with an explicit interface split also unlocks heterogeneous collecti
 - Ship four edit strategies and four id strategies as first-class, composable classes.
 - Ship a pure-logic corrections module and `ActiveFilteringRag` wrapper.
 - Ship one MCP tool factory that produces `rag_*` entries bound to the registry.
-- Migrate existing backends (`VectorRag`, `InMemoryRag`, `QdrantRag`, `OllamaRag`) to the new split.
+- Migrate existing backends (`VectorRag`, `QdrantRag`, `InMemoryRag`) to the new split. Convenience subclasses like `OllamaRag` (which just wires `OllamaEmbedder` into `VectorRag`) inherit the migration automatically.
 - **Breaking:** drop `IRag.upsert`; `getById` becomes required. Major version bump.
 
 Out of scope: persistence of registry state, XSUAA/auth scoping (consumers subclass `SimpleRagRegistry`), endpoint/completions fallback (#100), prompt-injected tools (#102).
@@ -232,10 +232,10 @@ All four check `registry.getEditor(name) !== undefined` before any mutation.
 
 ### Existing backends
 
-`VectorRag`, `InMemoryRag`, `QdrantRag`, `OllamaRag` today implement a unified `IRag` with `upsert`. After the split:
+The three real backends — `VectorRag` (and any `*Embedder + VectorRag` subclass like `OllamaRag`), `QdrantRag`, `InMemoryRag` — today implement a unified `IRag` with `upsert`. After the split:
 
-- They implement the new `IRag` (read-only surface + `getById`). `getById` must be implemented natively (`InMemoryRag`: Map lookup; `QdrantRag`: point retrieve by id; `OllamaRag`: delegate to underlying store).
-- Their write methods (`upsertInternal`, `deleteByIdInternal`) become the primitives used by `DirectEditStrategy`. `DirectEditStrategy` holds a reference to the concrete backend's writable surface via a narrow `IRagBackendWriter` interface exported alongside each backend.
+- They implement the new `IRag` (read surface + `getById`). `getById` is implemented natively (`InMemoryRag`: Map lookup; `VectorRag`: metadata index lookup; `QdrantRag`: point retrieve by id).
+- Their write methods become the primitives used by `DirectEditStrategy`. `DirectEditStrategy` holds a reference to the backend's writable surface via a narrow `IRagBackendWriter` interface exported alongside each backend.
 - `IPrecomputedVectorRag.upsertPrecomputed` moves to the backend-writer surface for the same reason.
 
 ### Call sites

--- a/docs/superpowers/specs/2026-04-22-rag-registry-corrections-design.md
+++ b/docs/superpowers/specs/2026-04-22-rag-registry-corrections-design.md
@@ -1,0 +1,281 @@
+# RAG Registry and Corrections Layer — Design Spec
+
+**Date:** 2026-04-22
+**Status:** Draft → In Review
+**Related:** [issue #103](https://github.com/fr0ster/llm-agent/issues/103)
+
+## Motivation
+
+Downstream consumers of `llm-agent` (e.g. `cloud-llm-hub`) currently re-implement four concerns that naturally belong upstream:
+
+1. A collection **registry** mapping names to heterogeneous `IRag` instances (in-memory, Qdrant, remote vector server, MCP tool catalog) under one API.
+2. A **corrections metadata convention** (`canonicalKey`, `tags`, `supersededBy`, `deprecatedAt`, `deprecatedReason`) with pure-logic helpers.
+3. A **retrieval wrapper** that hides `deprecated` / `superseded` from default retrieval with opt-in `includeInactive`.
+4. **MCP tools** (`rag_create_collection`, `rag_add`, `rag_correct`, `rag_deprecate`) that let agents self-manage the correction layer.
+
+Upstreaming with an explicit interface split also unlocks heterogeneous collection sets per registry, first-class immutability, and pluggable edit/id strategies.
+
+## Scope
+
+- Split `IRag` (read) from `IRagEditor` (write); introduce `IRagRegistry`.
+- Ship four edit strategies and four id strategies as first-class, composable classes.
+- Ship a pure-logic corrections module and `ActiveFilteringRag` wrapper.
+- Ship one MCP tool factory that produces `rag_*` entries bound to the registry.
+- Migrate existing backends (`VectorRag`, `InMemoryRag`, `QdrantRag`, `OllamaRag`) to the new split.
+- **Breaking:** drop `IRag.upsert`; `getById` becomes required. Major version bump.
+
+Out of scope: persistence of registry state, XSUAA/auth scoping (consumers subclass `SimpleRagRegistry`), endpoint/completions fallback (#100), prompt-injected tools (#102).
+
+## Decisions (resolved questions)
+
+| # | Question | Decision |
+|---|---|---|
+| 1 | `getById` on `IRag` | **Required** immediately. Major version bump. |
+| 2 | id shape in `IRagEditor.upsert` | id is **always** resolved; determined by pluggable `IIdStrategy`. `upsert` returns `{ id: string }`. No anonymous records. |
+| 3 | File layout for strategies | **Grouped subfolders:** `rag/strategies/edit/`, `rag/strategies/id/`, `rag/registry/`, `rag/corrections/`, `rag/mcp-tools/`. |
+| 4 | Overlay collision on `canonicalKey` | **Overlay always wins.** Base record is dropped even with higher similarity. Tag filtering is handled separately by `ActiveFilteringRag`. |
+
+## Interfaces
+
+All interfaces live in `src/smart-agent/interfaces/rag.ts`. Prefix `I` per project convention.
+
+```ts
+export interface IRag {
+  query(
+    embedding: IQueryEmbedding,
+    k: number,
+    options?: CallOptions & { ragFilter?: RagFilter },
+  ): Promise<Result<RagResult[], RagError>>;
+
+  /** Fetch a single document by its metadata id. Returns null if not found. */
+  getById(id: string, options?: CallOptions): Promise<Result<RagResult | null, RagError>>;
+
+  healthCheck(options?: CallOptions): Promise<Result<void, RagError>>;
+}
+
+export interface IRagEditor {
+  /**
+   * Insert or overwrite a document. The final id is resolved by the editor's
+   * IIdStrategy and always returned.
+   */
+  upsert(
+    text: string,
+    metadata: RagMetadata,
+    options?: CallOptions,
+  ): Promise<Result<{ id: string }, RagError>>;
+
+  /** Delete by id. Returns true if deleted, false if absent. */
+  deleteById(id: string, options?: CallOptions): Promise<Result<boolean, RagError>>;
+
+  clear?(): Promise<Result<void, RagError>>;
+}
+
+export interface IIdStrategy {
+  /** Always returns a valid id; throws a typed error when required input is missing. */
+  resolve(metadata: RagMetadata, text: string): string;
+}
+
+export interface RagCollectionMeta {
+  readonly name: string;
+  readonly displayName: string;
+  readonly description?: string;
+  readonly editable: boolean;
+  readonly tags?: readonly string[];
+}
+
+export interface IRagRegistry {
+  register(
+    name: string,
+    rag: IRag,
+    editor?: IRagEditor,
+    meta?: Omit<RagCollectionMeta, 'name' | 'editable'>,
+  ): void;
+  unregister(name: string): boolean;
+  get(name: string): IRag | undefined;
+  getEditor(name: string): IRagEditor | undefined;
+  list(): readonly RagCollectionMeta[];
+}
+```
+
+## File layout
+
+```
+src/smart-agent/rag/
+  strategies/
+    edit/
+      direct.ts                  DirectEditStrategy
+      immutable.ts               ImmutableEditStrategy
+      overlay.ts                 OverlayEditStrategy
+      session-scoped.ts          SessionScopedEditStrategy
+      index.ts
+    id/
+      caller-provided.ts         CallerProvidedIdStrategy
+      session-scoped.ts          SessionScopedIdStrategy
+      global-unique.ts           GlobalUniqueIdStrategy
+      canonical-key.ts           CanonicalKeyIdStrategy
+      index.ts
+  registry/
+    simple-rag-registry.ts       SimpleRagRegistry
+    index.ts
+  corrections/
+    metadata.ts                  validate / deprecate / buildCorrection / filterActive
+    active-filtering-rag.ts      ActiveFilteringRag
+    errors.ts                    ReadOnlyError, MissingIdError, CanonicalKeyCollisionError
+    index.ts
+  mcp-tools/
+    rag-collection-tools.ts      buildRagCollectionToolEntries
+    index.ts
+  __tests__/
+    (existing + one test file per new module)
+```
+
+## Edit strategies
+
+| Class | Semantics |
+|---|---|
+| `DirectEditStrategy(rag, idStrategy)` | Forwards `upsert`/`deleteById` to a single backing `IRag` that also exposes a private write path. Used for editable stores (memory, Qdrant). |
+| `ImmutableEditStrategy()` | All mutating calls return `Err(new ReadOnlyError(collectionName))`. No state. Used for managed/ops-owned KBs. |
+| `OverlayEditStrategy(base, overlay, idStrategy)` | Writes go to `overlay` only. `query` runs on both; **overlay wins** on matching `canonicalKey` (base hit dropped regardless of score). `getById` tries overlay first, then base. |
+| `SessionScopedEditStrategy(base, sessionRag, sessionId, idStrategy, ttlMs?)` | Wraps `OverlayEditStrategy` with a session id. Overlay is scoped to that session; `clear()` flushes only session records. Optional TTL for auto-expiry. |
+
+## Id strategies
+
+| Class | Semantics |
+|---|---|
+| `CallerProvidedIdStrategy` | `metadata.id` required. Missing → throws `MissingIdError`. |
+| `SessionScopedIdStrategy(sessionId)` | If `metadata.id` given → `${sessionId}:${metadata.id}`. Else if `canonicalKey` given → `${sessionId}:${canonicalKey}`. Else → `${sessionId}:${uuid()}`. |
+| `GlobalUniqueIdStrategy` | Returns `metadata.id` if present; otherwise uuid v4. |
+| `CanonicalKeyIdStrategy` | Requires `metadata.canonicalKey`. Returns `${canonicalKey}:v${version}` where version derives from metadata (default 1). Used by corrections chain. |
+
+## Corrections module
+
+Pure logic, no I/O. Lives in `rag/corrections/metadata.ts`.
+
+```ts
+export type CorrectionTag = 'verified' | 'deprecated' | 'superseded' | 'correction';
+
+export interface CorrectionMetadata {
+  canonicalKey: string;
+  tags?: CorrectionTag[];
+  sessionId?: string;
+  supersededBy?: string;
+  deprecatedAt?: number;      // unix seconds
+  deprecatedReason?: string;
+}
+
+export function validateCorrectionMetadata(meta: CorrectionMetadata): void;
+
+export function deprecateMetadata(
+  current: CorrectionMetadata,
+  reason: string,
+  nowSeconds?: number,
+): CorrectionMetadata;
+
+export function buildCorrectionMetadata(input: {
+  predecessor: CorrectionMetadata;
+  predecessorId: string;
+  newEntryId: string;
+  reason: string;
+}): { predecessor: CorrectionMetadata; next: CorrectionMetadata };
+
+export function filterActive<T>(
+  items: readonly T[],
+  getMeta: (item: T) => CorrectionMetadata | undefined,
+  options?: { includeInactive?: boolean },
+): T[];
+```
+
+`ActiveFilteringRag` wraps any `IRag`: on `query`, applies `filterActive` unless `options.ragFilter?.includeInactive === true`. On `getById`, returns null when the item has `deprecated` / `superseded` tag unless `includeInactive` is set. Composable with existing `ExpositionFilteringRag`.
+
+## MCP tool factory
+
+```ts
+export interface RagToolEntry {
+  toolDefinition: {
+    name: string;
+    description: string;
+    inputSchema: z.ZodRawShape;
+  };
+  handler: (context: {}, args: Record<string, unknown>) => Promise<unknown>;
+}
+
+export function buildRagCollectionToolEntries(opts: {
+  registry: IRagRegistry;
+}): RagToolEntry[];
+```
+
+Tools (four entries):
+
+- **`rag_create_collection`** — optional; requires a consumer-provided factory hook. If not supplied, tool is omitted from entries. Most deployments register collections ahead of time.
+- **`rag_add`** — validates `canonicalKey`; rejects read-only collections with `ReadOnlyError`; calls `editor.upsert`.
+- **`rag_correct`** — uses `buildCorrectionMetadata`; two `upsert` calls (predecessor marked superseded + new entry); returns both ids.
+- **`rag_deprecate`** — uses `deprecateMetadata`; single `upsert`; idempotent.
+
+All four check `registry.getEditor(name) !== undefined` before any mutation.
+
+## Migration
+
+### Existing backends
+
+`VectorRag`, `InMemoryRag`, `QdrantRag`, `OllamaRag` today implement a unified `IRag` with `upsert`. After the split:
+
+- They implement the new `IRag` (read-only surface + `getById`). `getById` must be implemented natively (`InMemoryRag`: Map lookup; `QdrantRag`: point retrieve by id; `OllamaRag`: delegate to underlying store).
+- Their write methods (`upsertInternal`, `deleteByIdInternal`) become the primitives used by `DirectEditStrategy`. `DirectEditStrategy` holds a reference to the concrete backend's writable surface via a narrow `IRagBackendWriter` interface exported alongside each backend.
+- `IPrecomputedVectorRag.upsertPrecomputed` moves to the backend-writer surface for the same reason.
+
+### Call sites
+
+All existing callers of `rag.upsert(...)` migrate to `editor.upsert(...)` via registry lookup. Affected: `src/smart-agent/rag/tool-indexing-strategy.ts`, `src/smart-agent/rag/preprocessor.ts`, and any builder/pipeline code that seeds RAG content.
+
+### Public API
+
+- **Remove:** `IRag.upsert`, `IRag.clear`.
+- **Add:** `IRagEditor`, `IIdStrategy`, `IRagRegistry`, `RagCollectionMeta`, all strategies, `SimpleRagRegistry`, corrections module, `ActiveFilteringRag`, `buildRagCollectionToolEntries`, error types.
+- Major version bump (9.0.0).
+
+### Consumer (`cloud-llm-hub`) after migration
+
+```ts
+class BtpRagRegistry extends SimpleRagRegistry {
+  // XSUAA role checks, CF persistence, user/global scoping.
+}
+
+const registry: IRagRegistry = getBtpRagRegistry();
+registry.register('corp-facts', corpQdrant, new ImmutableEditStrategy());
+registry.register('user-kb', userQdrant,
+  new DirectEditStrategy(userQdrantWriter, new CallerProvidedIdStrategy()));
+registry.register('session', overlayRag,
+  new OverlayEditStrategy(corpQdrant, new InMemoryRagWriter(),
+    new SessionScopedIdStrategy(sessionId)));
+
+const entries = [...coreEntries, ...buildRagCollectionToolEntries({ registry })];
+```
+
+## Error types
+
+Defined in `rag/corrections/errors.ts`:
+
+- `ReadOnlyError(collectionName)` — editor refused mutation.
+- `MissingIdError(strategy)` — id strategy required id that wasn't provided.
+- `CanonicalKeyCollisionError(key)` — overlay detected write colliding with base when colliding semantics are needed (reserved; currently unused due to "overlay always wins").
+
+All extend a typed `RagError` variant compatible with the existing `Result<_, RagError>` pattern.
+
+## Testing
+
+Per-module unit tests in `src/smart-agent/rag/__tests__/`:
+
+- Each edit strategy: happy path, error path, compose-with-id-strategy.
+- Each id strategy: required-input behavior, formatting.
+- `SimpleRagRegistry`: register/unregister, get, getEditor, list.
+- `corrections/metadata.ts`: all four helpers, edge cases (missing tags, double-deprecate).
+- `ActiveFilteringRag`: filters deprecated/superseded by default, surfaces them with `includeInactive`.
+- `buildRagCollectionToolEntries`: each tool handler behavior, read-only rejection, `canonicalKey` validation.
+
+Existing backend tests updated for the new read/write split.
+
+## Open items for implementation plan
+
+- Concrete shape of `IRagBackendWriter` per backend (may be identical or diverge).
+- Whether `rag_create_collection` ships in the first version or is deferred — design allows either without breaking.
+- Registry listing order (insertion vs alphabetical vs meta-tag-grouped) — defaulting to insertion order.

--- a/docs/superpowers/specs/2026-04-22-rag-registry-corrections-design.md
+++ b/docs/superpowers/specs/2026-04-22-rag-registry-corrections-design.md
@@ -200,7 +200,7 @@ export function filterActive<T>(
 ): T[];
 ```
 
-`ActiveFilteringRag` wraps any `IRag`: on `query`, applies `filterActive` unless `options.ragFilter?.includeInactive === true`. On `getById`, returns null when the item has `deprecated` / `superseded` tag unless `includeInactive` is set. Composable with existing `ExpositionFilteringRag`.
+`ActiveFilteringRag` wraps any `IRag`: on `query`, applies `filterActive` unless `options.ragFilter?.includeInactive === true`. On `getById`, returns null when the item has `deprecated` / `superseded` tag unless `includeInactive` is set.
 
 ## MCP tool factory
 
@@ -265,7 +265,7 @@ registry.register(
   'session',
   new SessionScopedRag(corpQdrant, sessionOverlay, sessionId),
   new SessionScopedEditStrategy(
-    sessionOverlay.writer(),
+    sessionOverlayWriter,
     sessionId,
     new SessionScopedIdStrategy(sessionId),
   ),
@@ -299,7 +299,6 @@ Existing backend tests updated for the new read/write split.
 
 ## Open items for implementation plan
 
-- Concrete shape of `IRagBackendWriter` per backend (may be identical or diverge).
+- Concrete shape of `IRagBackendWriter` per backend, including whether backends expose it via `rag.writer()` or a separate writer class.
 - Whether `rag_create_collection` ships in the first version or is deferred — design allows either without breaking.
 - Registry listing order (insertion vs alphabetical vs meta-tag-grouped) — defaulting to insertion order.
-- Shape of the companion writer exposed by `InMemoryRag` / `QdrantRag` / `OllamaRag` (`rag.writer()` accessor vs separate writer class). Resolve in the implementation plan.

--- a/docs/superpowers/specs/2026-04-22-rag-registry-corrections-design.md
+++ b/docs/superpowers/specs/2026-04-22-rag-registry-corrections-design.md
@@ -101,12 +101,16 @@ export interface IRagRegistry {
 
 ```
 src/smart-agent/rag/
+  overlays/
+    overlay-rag.ts               OverlayRag (implements IRag)
+    session-scoped-rag.ts        SessionScopedRag (implements IRag)
+    index.ts
   strategies/
     edit/
       direct.ts                  DirectEditStrategy
       immutable.ts               ImmutableEditStrategy
-      overlay.ts                 OverlayEditStrategy
-      session-scoped.ts          SessionScopedEditStrategy
+      overlay.ts                 OverlayEditStrategy (write-only)
+      session-scoped.ts          SessionScopedEditStrategy (write-only)
       index.ts
     id/
       caller-provided.ts         CallerProvidedIdStrategy
@@ -129,14 +133,25 @@ src/smart-agent/rag/
     (existing + one test file per new module)
 ```
 
-## Edit strategies
+## Read-side: overlay RAGs
+
+Read behavior of layered collections lives in `IRag` implementations, not in edit strategies. Registered as the `rag` argument to `registry.register(...)`, paired with a matching write-only edit strategy.
 
 | Class | Semantics |
 |---|---|
-| `DirectEditStrategy(rag, idStrategy)` | Forwards `upsert`/`deleteById` to a single backing `IRag` that also exposes a private write path. Used for editable stores (memory, Qdrant). |
+| `OverlayRag(base, overlay)` | Implements `IRag`. `query` calls both and merges with **overlay wins** on matching `canonicalKey` (base hit dropped regardless of score). `getById` tries `overlay` first, then `base`. `healthCheck` requires both healthy. |
+| `SessionScopedRag(base, overlay, sessionId, ttlMs?)` | Extends overlay semantics with session-scoped filtering: overlay hits are included only when their `metadata.sessionId === sessionId` and (if TTL is set) within the TTL window. `clear` on the overlay-writer flushes just that session. |
+
+## Edit strategies
+
+All edit strategies are **write-only** — they implement `IRagEditor` and have no `query` / `getById` responsibility.
+
+| Class | Semantics |
+|---|---|
+| `DirectEditStrategy(writer, idStrategy)` | Forwards `upsert`/`deleteById` to a single `IRagBackendWriter`. Used for editable stores (memory, Qdrant). |
 | `ImmutableEditStrategy()` | All mutating calls return `Err(new ReadOnlyError(collectionName))`. No state. Used for managed/ops-owned KBs. |
-| `OverlayEditStrategy(base, overlay, idStrategy)` | Writes go to `overlay` only. `query` runs on both; **overlay wins** on matching `canonicalKey` (base hit dropped regardless of score). `getById` tries overlay first, then base. |
-| `SessionScopedEditStrategy(base, sessionRag, sessionId, idStrategy, ttlMs?)` | Wraps `OverlayEditStrategy` with a session id. Overlay is scoped to that session; `clear()` flushes only session records. Optional TTL for auto-expiry. |
+| `OverlayEditStrategy(overlayWriter, idStrategy)` | Writes go to the overlay writer only. Does not know about the base. Intended to be paired with `OverlayRag` in the registry. |
+| `SessionScopedEditStrategy(overlayWriter, sessionId, idStrategy, ttlMs?)` | Same as `OverlayEditStrategy` but stamps `metadata.sessionId` on every write and passes `sessionId` to the id strategy. Paired with `SessionScopedRag`. `clear()` removes only records matching `sessionId`. |
 
 ## Id strategies
 
@@ -244,9 +259,17 @@ const registry: IRagRegistry = getBtpRagRegistry();
 registry.register('corp-facts', corpQdrant, new ImmutableEditStrategy());
 registry.register('user-kb', userQdrant,
   new DirectEditStrategy(userQdrantWriter, new CallerProvidedIdStrategy()));
-registry.register('session', overlayRag,
-  new OverlayEditStrategy(corpQdrant, new InMemoryRagWriter(),
-    new SessionScopedIdStrategy(sessionId)));
+
+const sessionOverlay = new InMemoryRag();  // IRag with a companion writer
+registry.register(
+  'session',
+  new SessionScopedRag(corpQdrant, sessionOverlay, sessionId),
+  new SessionScopedEditStrategy(
+    sessionOverlay.writer(),
+    sessionId,
+    new SessionScopedIdStrategy(sessionId),
+  ),
+);
 
 const entries = [...coreEntries, ...buildRagCollectionToolEntries({ registry })];
 ```
@@ -279,3 +302,4 @@ Existing backend tests updated for the new read/write split.
 - Concrete shape of `IRagBackendWriter` per backend (may be identical or diverge).
 - Whether `rag_create_collection` ships in the first version or is deferred — design allows either without breaking.
 - Registry listing order (insertion vs alphabetical vs meta-tag-grouped) — defaulting to insertion order.
+- Shape of the companion writer exposed by `InMemoryRag` / `QdrantRag` / `OllamaRag` (`rag.writer()` accessor vs separate writer class). Resolve in the implementation plan.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcp-abap-adt/llm-agent",
-  "version": "8.5.0",
+  "version": "9.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/llm-agent",
-      "version": "8.5.0",
+      "version": "9.0.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/llm-agent",
-  "version": "8.5.0",
+  "version": "9.0.0",
   "description": "Core components for building Smart LLM agents, plus a default MCP-orchestrated OpenAI-compatible server implementation.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,13 +147,9 @@ export type {
   IEmbedder,
   IEmbedderBatch,
   IEmbedResult,
-  IPrecomputedVectorRag,
   IRag,
 } from './smart-agent/interfaces/rag.js';
-export {
-  isBatchEmbedder,
-  supportsPrecomputed,
-} from './smart-agent/interfaces/rag.js';
+export { isBatchEmbedder } from './smart-agent/interfaces/rag.js';
 export type { ILlmRateLimiter } from './smart-agent/interfaces/rate-limiter.js';
 // Request Logger
 export type {

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,7 +147,12 @@ export type {
   IEmbedder,
   IEmbedderBatch,
   IEmbedResult,
+  IIdStrategy,
   IRag,
+  IRagBackendWriter,
+  IRagEditor,
+  IRagRegistry,
+  RagCollectionMeta,
 } from './smart-agent/interfaces/rag.js';
 export { isBatchEmbedder } from './smart-agent/interfaces/rag.js';
 export type { ILlmRateLimiter } from './smart-agent/interfaces/rate-limiter.js';
@@ -239,8 +244,25 @@ export {
   type RagResolutionOptions,
   resolveEmbedder,
 } from './smart-agent/providers.js';
+// RAG Corrections, Registry, Overlays, and Strategies
+export {
+  ActiveFilteringRag,
+  buildCorrectionMetadata,
+  CanonicalKeyCollisionError,
+  type CorrectionMetadata,
+  CorrectionTag,
+  deprecateMetadata,
+  filterActive,
+  MissingIdError,
+  ReadOnlyError,
+  validateCorrectionMetadata,
+} from './smart-agent/rag/corrections/index.js';
 export { builtInEmbedderFactories } from './smart-agent/rag/embedder-factories.js';
 export { InMemoryRag } from './smart-agent/rag/in-memory-rag.js';
+export {
+  buildRagCollectionToolEntries,
+  type RagToolEntry,
+} from './smart-agent/rag/mcp-tools/index.js';
 export {
   OllamaEmbedder,
   type OllamaEmbedderConfig,
@@ -250,6 +272,10 @@ export {
   OpenAiEmbedder,
   type OpenAiEmbedderConfig,
 } from './smart-agent/rag/openai-embedder.js';
+export {
+  OverlayRag,
+  SessionScopedRag,
+} from './smart-agent/rag/overlays/index.js';
 // RAG Preprocessors
 export type {
   IDocumentEnricher,
@@ -279,6 +305,7 @@ export {
   LlmQueryExpander,
   NoopQueryExpander,
 } from './smart-agent/rag/query-expander.js';
+export { SimpleRagRegistry } from './smart-agent/rag/registry/index.js';
 export {
   SapAiCoreEmbedder,
   type SapAiCoreEmbedderConfig,
@@ -299,6 +326,18 @@ export {
   VectorOnlyStrategy,
   WeightedFusionStrategy,
 } from './smart-agent/rag/search-strategy.js';
+export {
+  DirectEditStrategy,
+  ImmutableEditStrategy,
+  OverlayEditStrategy,
+  SessionScopedEditStrategy,
+} from './smart-agent/rag/strategies/edit/index.js';
+export {
+  CallerProvidedIdStrategy,
+  CanonicalKeyIdStrategy,
+  GlobalUniqueIdStrategy,
+  SessionScopedIdStrategy,
+} from './smart-agent/rag/strategies/id/index.js';
 export {
   VectorRag,
   type VectorRagConfig,

--- a/src/smart-agent/agent.ts
+++ b/src/smart-agent/agent.ts
@@ -292,7 +292,7 @@ export class SmartAgent {
       if (!result.ok) continue;
       for (const tool of result.value) {
         const text = `Tool: ${tool.name} — ${tool.description}`;
-        await toolsRag.upsert(text, { id: `tool:${tool.name}` });
+        await toolsRag.writer?.()?.upsertRaw(`tool:${tool.name}`, text, {});
       }
     }
   }

--- a/src/smart-agent/builder.ts
+++ b/src/smart-agent/builder.ts
@@ -47,7 +47,6 @@ import {
   type IEmbedder,
   type IRag,
   isBatchEmbedder,
-  supportsPrecomputed,
 } from './interfaces/rag.js';
 import type { ILlmRateLimiter } from './interfaces/rate-limiter.js';
 import type { IRequestLogger } from './interfaces/request-logger.js';
@@ -692,7 +691,7 @@ export class SmartAgentBuilder {
               if (
                 storeEmbedder &&
                 isBatchEmbedder(storeEmbedder) &&
-                supportsPrecomputed(toolsRag)
+                toolsRag.writer?.()?.upsertPrecomputedRaw !== undefined
               ) {
                 // Batch path: single HTTP call for all tools
                 const texts = tools.map(
@@ -703,11 +702,21 @@ export class SmartAgentBuilder {
                   const embedResults = await storeEmbedder.embedBatch(texts);
                   const batchDuration = Date.now() - batchStart;
                   for (let i = 0; i < tools.length; i++) {
-                    const result = await toolsRag.upsertPrecomputed(
-                      texts[i],
-                      embedResults[i].vector,
-                      { id: `tool:${tools[i].name}` },
-                    );
+                    const toolWriter = toolsRag.writer?.();
+                    const result = toolWriter?.upsertPrecomputedRaw
+                      ? await toolWriter.upsertPrecomputedRaw(
+                          `tool:${tools[i].name}`,
+                          texts[i],
+                          embedResults[i].vector,
+                          {},
+                        )
+                      : toolWriter
+                        ? await toolWriter.upsertRaw(
+                            `tool:${tools[i].name}`,
+                            texts[i],
+                            {},
+                          )
+                        : ({ ok: true, value: undefined } as const);
                     if (!result.ok) {
                       log?.log({
                         type: 'warning',
@@ -756,10 +765,10 @@ export class SmartAgentBuilder {
                     const t = tools[i];
                     const text = `Tool: ${t.name} — ${t.description}`;
                     const embedStart = Date.now();
-                    const result = await toolsRag.upsert(text, {
-                      id: `tool:${t.name}`,
-                    });
-                    if (!result.ok) {
+                    const result = await toolsRag
+                      .writer?.()
+                      ?.upsertRaw(`tool:${t.name}`, text, {});
+                    if (result && !result.ok) {
                       log?.log({
                         type: 'warning',
                         traceId: 'builder',
@@ -791,10 +800,10 @@ export class SmartAgentBuilder {
                   const t = tools[i];
                   const text = `Tool: ${t.name} — ${t.description}`;
                   const embedStart = Date.now();
-                  const result = await toolsRag.upsert(text, {
-                    id: `tool:${t.name}`,
-                  });
-                  if (!result.ok) {
+                  const result = await toolsRag
+                    .writer?.()
+                    ?.upsertRaw(`tool:${t.name}`, text, {});
+                  if (result && !result.ok) {
                     log?.log({
                       type: 'warning',
                       traceId: 'builder',
@@ -936,10 +945,10 @@ export class SmartAgentBuilder {
         for (const s of skillsResult.value) {
           const text = `Skill: ${s.name}\n${s.description}`;
           const embedStart = Date.now();
-          const result = await toolsRag.upsert(text, {
-            id: `skill:${s.name}`,
-          });
-          if (!result.ok) {
+          const result = await toolsRag
+            .writer?.()
+            ?.upsertRaw(`skill:${s.name}`, text, {});
+          if (result && !result.ok) {
             log?.log({
               type: 'warning',
               traceId: 'builder',

--- a/src/smart-agent/interfaces/rag.ts
+++ b/src/smart-agent/interfaces/rag.ts
@@ -35,19 +35,6 @@ export interface EmbedderFactoryConfig {
 export type EmbedderFactory = (cfg: EmbedderFactoryConfig) => IEmbedder;
 
 export interface IRag {
-  /**
-   * Store a text chunk with its metadata.
-   *
-   * If `metadata.id` is provided, implementations MUST treat it as an
-   * idempotent key — repeated upserts with the same id replace the
-   * previous record instead of creating duplicates.
-   */
-  upsert(
-    text: string,
-    metadata: RagMetadata,
-    options?: CallOptions,
-  ): Promise<Result<void, RagError>>;
-
   query(
     embedding: IQueryEmbedding,
     k: number,
@@ -55,13 +42,15 @@ export interface IRag {
   ): Promise<Result<RagResult[], RagError>>;
 
   healthCheck(options?: CallOptions): Promise<Result<void, RagError>>;
-  /** Clear all records. Used for session-scoped store cleanup. Optional — not all backends support it. */
-  clear?(): void;
+
   /** Fetch a single document by its metadata id. Returns null if not found. */
-  getById?(
+  getById(
     id: string,
     options?: CallOptions,
   ): Promise<Result<RagResult | null, RagError>>;
+
+  /** Returns a backend writer if this implementation supports writes. */
+  writer?(): IRagBackendWriter | undefined;
 }
 
 export interface IEmbedderBatch extends IEmbedder {
@@ -73,19 +62,6 @@ export function isBatchEmbedder(e: IEmbedder): e is IEmbedderBatch {
     'embedBatch' in e &&
     typeof (e as { embedBatch?: unknown }).embedBatch === 'function'
   );
-}
-
-export interface IPrecomputedVectorRag extends IRag {
-  upsertPrecomputed(
-    text: string,
-    vector: number[],
-    metadata: RagMetadata,
-    options?: CallOptions,
-  ): Promise<Result<void, RagError>>;
-}
-
-export function supportsPrecomputed(rag: IRag): rag is IPrecomputedVectorRag {
-  return 'upsertPrecomputed' in rag;
 }
 
 // Added in 9.0 refactor — see docs/superpowers/specs/2026-04-22-rag-registry-corrections-design.md
@@ -120,6 +96,13 @@ export interface IRagBackendWriter {
     options?: CallOptions,
   ): Promise<Result<boolean, RagError>>;
   clearAll?(): Promise<Result<void, RagError>>;
+  upsertPrecomputedRaw?(
+    id: string,
+    text: string,
+    vector: number[],
+    metadata: RagMetadata,
+    options?: CallOptions,
+  ): Promise<Result<void, RagError>>;
 }
 
 export interface RagCollectionMeta {

--- a/src/smart-agent/interfaces/rag.ts
+++ b/src/smart-agent/interfaces/rag.ts
@@ -57,6 +57,11 @@ export interface IRag {
   healthCheck(options?: CallOptions): Promise<Result<void, RagError>>;
   /** Clear all records. Used for session-scoped store cleanup. Optional — not all backends support it. */
   clear?(): void;
+  /** Fetch a single document by its metadata id. Returns null if not found. */
+  getById?(
+    id: string,
+    options?: CallOptions,
+  ): Promise<Result<RagResult | null, RagError>>;
 }
 
 export interface IEmbedderBatch extends IEmbedder {
@@ -81,4 +86,59 @@ export interface IPrecomputedVectorRag extends IRag {
 
 export function supportsPrecomputed(rag: IRag): rag is IPrecomputedVectorRag {
   return 'upsertPrecomputed' in rag;
+}
+
+// Added in 9.0 refactor — see docs/superpowers/specs/2026-04-22-rag-registry-corrections-design.md
+
+export interface IRagEditor {
+  upsert(
+    text: string,
+    metadata: RagMetadata,
+    options?: CallOptions,
+  ): Promise<Result<{ id: string }, RagError>>;
+  deleteById(
+    id: string,
+    options?: CallOptions,
+  ): Promise<Result<boolean, RagError>>;
+  clear?(): Promise<Result<void, RagError>>;
+}
+
+export interface IIdStrategy {
+  /** Always returns a valid id; throws MissingIdError when required input is missing. */
+  resolve(metadata: RagMetadata, text: string): string;
+}
+
+export interface IRagBackendWriter {
+  upsertRaw(
+    id: string,
+    text: string,
+    metadata: RagMetadata,
+    options?: CallOptions,
+  ): Promise<Result<void, RagError>>;
+  deleteByIdRaw(
+    id: string,
+    options?: CallOptions,
+  ): Promise<Result<boolean, RagError>>;
+  clearAll?(): Promise<Result<void, RagError>>;
+}
+
+export interface RagCollectionMeta {
+  readonly name: string;
+  readonly displayName: string;
+  readonly description?: string;
+  readonly editable: boolean;
+  readonly tags?: readonly string[];
+}
+
+export interface IRagRegistry {
+  register(
+    name: string,
+    rag: IRag,
+    editor?: IRagEditor,
+    meta?: Omit<RagCollectionMeta, 'name' | 'editable'>,
+  ): void;
+  unregister(name: string): boolean;
+  get(name: string): IRag | undefined;
+  getEditor(name: string): IRagEditor | undefined;
+  list(): readonly RagCollectionMeta[];
 }

--- a/src/smart-agent/pipeline/handlers/__tests__/history-upsert.test.ts
+++ b/src/smart-agent/pipeline/handlers/__tests__/history-upsert.test.ts
@@ -5,7 +5,8 @@ import type {
   HistoryTurn,
   IHistorySummarizer,
 } from '../../../interfaces/history-summarizer.js';
-import type { LlmError, Result } from '../../../interfaces/types.js';
+import type { IRag } from '../../../interfaces/rag.js';
+import type { LlmError, RagError, Result } from '../../../interfaces/types.js';
 
 import { summarizeAndStore } from '../history-upsert.js';
 
@@ -33,18 +34,36 @@ function makeFakeSummarizer(response: string): IHistorySummarizer {
   };
 }
 
-function makeFakeRag(): { upserted: Array<{ text: string; meta: unknown }> } & {
-  upsert: (
-    text: string,
-    meta: unknown,
-  ) => Promise<Result<void, { message: string }>>;
+function makeFakeRag(): IRag & {
+  upserted: Array<{ id: string; text: string; meta: unknown }>;
 } {
-  const upserted: Array<{ text: string; meta: unknown }> = [];
+  const upserted: Array<{ id: string; text: string; meta: unknown }> = [];
   return {
     upserted,
-    upsert: async (text: string, meta: unknown) => {
-      upserted.push({ text, meta });
+    async query(): Promise<Result<[], RagError>> {
+      return { ok: true, value: [] };
+    },
+    async healthCheck(): Promise<Result<void, RagError>> {
       return { ok: true, value: undefined };
+    },
+    async getById(): Promise<Result<null, RagError>> {
+      return { ok: true, value: null };
+    },
+    writer() {
+      return {
+        upsertRaw: async (
+          id: string,
+          text: string,
+          meta: unknown,
+        ): Promise<Result<void, RagError>> => {
+          upserted.push({ id, text, meta });
+          return { ok: true, value: undefined };
+        },
+        deleteByIdRaw: async (): Promise<Result<boolean, RagError>> => ({
+          ok: true,
+          value: false,
+        }),
+      };
     },
   };
 }
@@ -69,22 +88,32 @@ describe('history-upsert: summarizeAndStore', () => {
       turn,
       summarizer,
       memory,
-      rag: rag as never,
+      rag,
       sessionId: 's1',
     });
 
     assert.equal(rag.upserted.length, 1);
     assert.equal(rag.upserted[0].text, 'Created class ZCL_TEST in ZDEV');
+    assert.equal(rag.upserted[0].id, 'turn:s1:0');
     assert.deepEqual(memory.getRecent('s1', 10), [
       'Created class ZCL_TEST in ZDEV',
     ]);
   });
 
-  it('still pushes to memory when RAG upsert fails (best-effort)', async () => {
+  it('still pushes to memory when RAG writer is absent (best-effort)', async () => {
     const memory = makeFakeMemory();
     const summarizer = makeFakeSummarizer('summary text');
-    const rag = {
-      upsert: async () => ({ ok: false, error: { message: 'RAG down' } }),
+    // RAG with no writer
+    const rag: IRag = {
+      async query() {
+        return { ok: true, value: [] };
+      },
+      async healthCheck() {
+        return { ok: true, value: undefined };
+      },
+      async getById() {
+        return { ok: true, value: null };
+      },
     };
 
     const turn: HistoryTurn = {
@@ -101,7 +130,51 @@ describe('history-upsert: summarizeAndStore', () => {
       turn,
       summarizer,
       memory,
-      rag: rag as never,
+      rag,
+      sessionId: 's1',
+    });
+    assert.deepEqual(memory.getRecent('s1', 10), ['summary text']);
+  });
+
+  it('still pushes to memory when RAG upsertRaw fails (best-effort)', async () => {
+    const memory = makeFakeMemory();
+    const summarizer = makeFakeSummarizer('summary text');
+    const rag: IRag = {
+      async query() {
+        return { ok: true, value: [] };
+      },
+      async healthCheck() {
+        return { ok: true, value: undefined };
+      },
+      async getById() {
+        return { ok: true, value: null };
+      },
+      writer() {
+        return {
+          upsertRaw: async () => ({
+            ok: false as const,
+            error: { message: 'RAG down' } as RagError,
+          }),
+          deleteByIdRaw: async () => ({ ok: true as const, value: false }),
+        };
+      },
+    };
+
+    const turn: HistoryTurn = {
+      sessionId: 's1',
+      turnIndex: 0,
+      userText: 'x',
+      assistantText: 'y',
+      toolCalls: [],
+      toolResults: [],
+      timestamp: 1000,
+    };
+
+    await summarizeAndStore({
+      turn,
+      summarizer,
+      memory,
+      rag,
       sessionId: 's1',
     });
     assert.deepEqual(memory.getRecent('s1', 10), ['summary text']);
@@ -132,7 +205,7 @@ describe('history-upsert: summarizeAndStore', () => {
       turn,
       summarizer,
       memory,
-      rag: rag as never,
+      rag,
       sessionId: 's1',
     });
     assert.deepEqual(memory.getRecent('s1', 10), ['do something → done it']);

--- a/src/smart-agent/pipeline/handlers/history-upsert.ts
+++ b/src/smart-agent/pipeline/handlers/history-upsert.ts
@@ -45,13 +45,19 @@ export async function summarizeAndStore(
     log?.('history_summarize_failed', { error: result.error.message });
   }
 
-  const upsertResult = await rag.upsert(
-    summary,
-    { id: `turn:${sessionId}:${turn.turnIndex}` },
-    options,
-  );
-  if (!upsertResult.ok) {
-    log?.('history_upsert_failed', { error: upsertResult.error.message });
+  const ragWriter = rag.writer?.();
+  if (!ragWriter) {
+    log?.('history_upsert_failed', { error: 'RAG writer not available' });
+  } else {
+    const upsertResult = await ragWriter.upsertRaw(
+      `turn:${sessionId}:${turn.turnIndex}`,
+      summary,
+      {},
+      options,
+    );
+    if (!upsertResult.ok) {
+      log?.('history_upsert_failed', { error: upsertResult.error.message });
+    }
   }
 
   memory.pushRecent(sessionId, summary);

--- a/src/smart-agent/rag/__tests__/active-filtering-rag.test.ts
+++ b/src/smart-agent/rag/__tests__/active-filtering-rag.test.ts
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { IRag } from '../../interfaces/rag.js';
+import type { RagResult } from '../../interfaces/types.js';
+import { ActiveFilteringRag } from '../corrections/active-filtering-rag.js';
+import { TextOnlyEmbedding } from '../query-embedding.js';
+
+function stubRag(results: RagResult[]): IRag {
+  return {
+    query: async () => ({ ok: true, value: results }),
+    getById: async (id) => ({
+      ok: true,
+      value: results.find((r) => r.metadata.id === id) ?? null,
+    }),
+    healthCheck: async () => ({ ok: true, value: undefined }),
+    upsert: async () => ({ ok: true, value: undefined }),
+  } as IRag;
+}
+
+describe('ActiveFilteringRag', () => {
+  const results: RagResult[] = [
+    { text: 'a', metadata: { id: '1', canonicalKey: 'a' }, score: 1 },
+    {
+      text: 'b',
+      metadata: { id: '2', canonicalKey: 'b', tags: ['deprecated'] },
+      score: 0.9,
+    },
+    {
+      text: 'c',
+      metadata: { id: '3', canonicalKey: 'c', tags: ['superseded'] },
+      score: 0.8,
+    },
+  ];
+  it('hides deprecated and superseded on query by default', async () => {
+    const rag = new ActiveFilteringRag(stubRag(results));
+    const res = await rag.query(new TextOnlyEmbedding('q'), 10);
+    assert.ok(res.ok);
+    assert.deepEqual(
+      res.value.map((r) => r.metadata.id),
+      ['1'],
+    );
+  });
+  it('returns all when includeInactive is true', async () => {
+    const rag = new ActiveFilteringRag(stubRag(results));
+    const res = await rag.query(new TextOnlyEmbedding('q'), 10, {
+      ragFilter: { includeInactive: true } as Record<string, unknown>,
+    });
+    assert.ok(res.ok && res.value.length === 3);
+  });
+  it('getById returns null for deprecated by default', async () => {
+    const rag = new ActiveFilteringRag(stubRag(results));
+    const res = await rag.getById?.('2');
+    assert.ok(res?.ok && res.value === null);
+  });
+  it('getById returns deprecated when includeInactive is set', async () => {
+    const rag = new ActiveFilteringRag(stubRag(results));
+    const res = await rag.getById?.('2', {
+      ragFilter: { includeInactive: true } as Record<string, unknown>,
+    });
+    assert.ok(res?.ok && res.value !== null);
+  });
+});

--- a/src/smart-agent/rag/__tests__/corrections-errors.test.ts
+++ b/src/smart-agent/rag/__tests__/corrections-errors.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { RagError } from '../../interfaces/types.js';
+import {
+  CanonicalKeyCollisionError,
+  MissingIdError,
+  ReadOnlyError,
+} from '../corrections/errors.js';
+
+describe('corrections errors', () => {
+  it('ReadOnlyError extends RagError with code', () => {
+    const e = new ReadOnlyError('corp-facts');
+    assert.ok(e instanceof RagError);
+    assert.equal(e.code, 'RAG_READ_ONLY');
+    assert.match(e.message, /corp-facts/);
+  });
+
+  it('MissingIdError extends RagError with code', () => {
+    const e = new MissingIdError('CallerProvidedIdStrategy');
+    assert.ok(e instanceof RagError);
+    assert.equal(e.code, 'RAG_MISSING_ID');
+    assert.match(e.message, /CallerProvidedIdStrategy/);
+  });
+
+  it('CanonicalKeyCollisionError extends RagError with code', () => {
+    const e = new CanonicalKeyCollisionError('doc-42');
+    assert.ok(e instanceof RagError);
+    assert.equal(e.code, 'RAG_CANONICAL_KEY_COLLISION');
+    assert.match(e.message, /doc-42/);
+  });
+});

--- a/src/smart-agent/rag/__tests__/corrections-metadata.test.ts
+++ b/src/smart-agent/rag/__tests__/corrections-metadata.test.ts
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  buildCorrectionMetadata,
+  type CorrectionMetadata,
+  deprecateMetadata,
+  filterActive,
+  validateCorrectionMetadata,
+} from '../corrections/metadata.js';
+
+describe('validateCorrectionMetadata', () => {
+  it('passes with canonicalKey', () => {
+    validateCorrectionMetadata({ canonicalKey: 'k' });
+  });
+  it('throws when canonicalKey missing', () => {
+    assert.throws(() =>
+      validateCorrectionMetadata({ canonicalKey: '' as string }),
+    );
+  });
+});
+
+describe('deprecateMetadata', () => {
+  it('adds deprecated tag with reason and timestamp', () => {
+    const out = deprecateMetadata({ canonicalKey: 'k' }, 'outdated', 1000);
+    assert.deepEqual(out.tags, ['deprecated']);
+    assert.equal(out.deprecatedReason, 'outdated');
+    assert.equal(out.deprecatedAt, 1000);
+  });
+  it('is idempotent', () => {
+    const once = deprecateMetadata({ canonicalKey: 'k' }, 'r', 1);
+    const twice = deprecateMetadata(once, 'r', 1);
+    assert.deepEqual(twice.tags, ['deprecated']);
+  });
+});
+
+describe('buildCorrectionMetadata', () => {
+  it('marks predecessor superseded and next as correction', () => {
+    const { predecessor, next } = buildCorrectionMetadata({
+      predecessor: { canonicalKey: 'k' },
+      predecessorId: 'k:v1',
+      newEntryId: 'k:v2',
+      reason: 'typo fix',
+    });
+    assert.ok(predecessor.tags?.includes('superseded'));
+    assert.equal(predecessor.supersededBy, 'k:v2');
+    assert.ok(next.tags?.includes('correction'));
+    assert.equal(next.canonicalKey, 'k');
+  });
+});
+
+describe('filterActive', () => {
+  interface Item {
+    meta: CorrectionMetadata;
+  }
+  const items: Item[] = [
+    { meta: { canonicalKey: 'a' } },
+    { meta: { canonicalKey: 'b', tags: ['deprecated'] as const } },
+    { meta: { canonicalKey: 'c', tags: ['superseded'] as const } },
+    { meta: { canonicalKey: 'd', tags: ['verified'] as const } },
+  ];
+  it('hides deprecated and superseded by default', () => {
+    const out = filterActive(items, (i) => i.meta);
+    assert.deepEqual(
+      out.map((i) => i.meta.canonicalKey),
+      ['a', 'd'],
+    );
+  });
+  it('returns all when includeInactive is true', () => {
+    const out = filterActive(items, (i) => i.meta, {
+      includeInactive: true,
+    });
+    assert.equal(out.length, 4);
+  });
+});

--- a/src/smart-agent/rag/__tests__/edit-strategies-basic.test.ts
+++ b/src/smart-agent/rag/__tests__/edit-strategies-basic.test.ts
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { IRagBackendWriter } from '../../interfaces/rag.js';
+import { ReadOnlyError } from '../corrections/errors.js';
+import {
+  DirectEditStrategy,
+  ImmutableEditStrategy,
+} from '../strategies/edit/index.js';
+import { GlobalUniqueIdStrategy } from '../strategies/id/index.js';
+
+function fakeWriter(): IRagBackendWriter & {
+  calls: Record<string, unknown[]>;
+} {
+  const calls: Record<string, unknown[]> = {
+    upsertRaw: [],
+    deleteByIdRaw: [],
+  };
+  return {
+    calls,
+    upsertRaw: async (id, text, meta) => {
+      calls.upsertRaw.push({ id, text, meta });
+      return { ok: true, value: undefined };
+    },
+    deleteByIdRaw: async (id) => {
+      calls.deleteByIdRaw.push({ id });
+      return { ok: true, value: true };
+    },
+  };
+}
+
+describe('DirectEditStrategy', () => {
+  it('resolves id via strategy and forwards upsert', async () => {
+    const w = fakeWriter();
+    const ed = new DirectEditStrategy(w, new GlobalUniqueIdStrategy());
+    const res = await ed.upsert('hello', { id: 'x' });
+    assert.ok(res.ok);
+    assert.equal(res.value.id, 'x');
+    assert.equal(w.calls.upsertRaw.length, 1);
+  });
+  it('forwards delete', async () => {
+    const w = fakeWriter();
+    const ed = new DirectEditStrategy(w, new GlobalUniqueIdStrategy());
+    const res = await ed.deleteById('x');
+    assert.ok(res.ok);
+    assert.equal(w.calls.deleteByIdRaw.length, 1);
+  });
+});
+
+describe('ImmutableEditStrategy', () => {
+  it('returns ReadOnlyError for upsert', async () => {
+    const ed = new ImmutableEditStrategy('corp-facts');
+    const res = await ed.upsert('t', {});
+    assert.ok(!res.ok);
+    assert.ok(res.error instanceof ReadOnlyError);
+  });
+  it('returns ReadOnlyError for deleteById', async () => {
+    const ed = new ImmutableEditStrategy('corp-facts');
+    const res = await ed.deleteById('x');
+    assert.ok(!res.ok);
+    assert.ok(res.error instanceof ReadOnlyError);
+  });
+});

--- a/src/smart-agent/rag/__tests__/edit-strategies-overlay.test.ts
+++ b/src/smart-agent/rag/__tests__/edit-strategies-overlay.test.ts
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { IRagBackendWriter } from '../../interfaces/rag.js';
+import {
+  OverlayEditStrategy,
+  SessionScopedEditStrategy,
+} from '../strategies/edit/index.js';
+import {
+  GlobalUniqueIdStrategy,
+  SessionScopedIdStrategy,
+} from '../strategies/id/index.js';
+
+function fakeWriter(): {
+  writer: IRagBackendWriter;
+  rows: Map<string, { text: string; meta: Record<string, unknown> }>;
+} {
+  const rows = new Map<
+    string,
+    { text: string; meta: Record<string, unknown> }
+  >();
+  const writer: IRagBackendWriter = {
+    upsertRaw: async (id, text, meta) => {
+      rows.set(id, { text, meta: meta as Record<string, unknown> });
+      return { ok: true, value: undefined };
+    },
+    deleteByIdRaw: async (id) => ({ ok: true, value: rows.delete(id) }),
+  };
+  return { writer, rows };
+}
+
+describe('OverlayEditStrategy', () => {
+  it('writes only to overlay writer with resolved id', async () => {
+    const { writer, rows } = fakeWriter();
+    const ed = new OverlayEditStrategy(writer, new GlobalUniqueIdStrategy());
+    const res = await ed.upsert('v', { id: 'x' });
+    assert.ok(res.ok && res.value.id === 'x');
+    assert.equal(rows.size, 1);
+  });
+});
+
+describe('SessionScopedEditStrategy', () => {
+  it('stamps sessionId on every write and uses the session id strategy', async () => {
+    const { writer, rows } = fakeWriter();
+    const ed = new SessionScopedEditStrategy(
+      writer,
+      'S',
+      new SessionScopedIdStrategy('S'),
+    );
+    const res = await ed.upsert('v', { id: 'x' });
+    assert.ok(res.ok);
+    const row = rows.get(res.value.id);
+    assert.ok(row);
+    assert.equal((row.meta as { sessionId?: string }).sessionId, 'S');
+    assert.equal(res.value.id, 'S:x');
+  });
+  it('stamps createdAt when caller does not provide it', async () => {
+    const { writer, rows } = fakeWriter();
+    const ed = new SessionScopedEditStrategy(
+      writer,
+      'S',
+      new SessionScopedIdStrategy('S'),
+    );
+    const res = await ed.upsert('v', { id: 'y' });
+    assert.ok(res.ok);
+    const row = rows.get(res.value.id);
+    assert.ok(row);
+    assert.equal(
+      typeof (row.meta as { createdAt?: number }).createdAt,
+      'number',
+    );
+  });
+  it('preserves caller-provided createdAt', async () => {
+    const { writer, rows } = fakeWriter();
+    const ed = new SessionScopedEditStrategy(
+      writer,
+      'S',
+      new SessionScopedIdStrategy('S'),
+    );
+    const res = await ed.upsert('v', { id: 'z', createdAt: 123 });
+    assert.ok(res.ok);
+    const row = rows.get(res.value.id);
+    assert.ok(row);
+    assert.equal((row.meta as { createdAt?: number }).createdAt, 123);
+  });
+  it('deleteById forwards to writer', async () => {
+    const { writer, rows } = fakeWriter();
+    rows.set('existing', { text: 't', meta: {} });
+    const ed = new SessionScopedEditStrategy(
+      writer,
+      'S',
+      new SessionScopedIdStrategy('S'),
+    );
+    const res = await ed.deleteById('existing');
+    assert.ok(res.ok && res.value === true);
+  });
+});

--- a/src/smart-agent/rag/__tests__/id-strategies.test.ts
+++ b/src/smart-agent/rag/__tests__/id-strategies.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { MissingIdError } from '../corrections/errors.js';
+import {
+  CallerProvidedIdStrategy,
+  CanonicalKeyIdStrategy,
+  GlobalUniqueIdStrategy,
+  SessionScopedIdStrategy,
+} from '../strategies/id/index.js';
+
+describe('CallerProvidedIdStrategy', () => {
+  it('returns metadata.id when present', () => {
+    const s = new CallerProvidedIdStrategy();
+    assert.equal(s.resolve({ id: 'abc' }, 'text'), 'abc');
+  });
+  it('throws MissingIdError when id absent', () => {
+    const s = new CallerProvidedIdStrategy();
+    assert.throws(() => s.resolve({}, 'text'), MissingIdError);
+  });
+});
+
+describe('GlobalUniqueIdStrategy', () => {
+  it('returns metadata.id when present', () => {
+    const s = new GlobalUniqueIdStrategy();
+    assert.equal(s.resolve({ id: 'abc' }, 'text'), 'abc');
+  });
+  it('generates uuid when id absent', () => {
+    const s = new GlobalUniqueIdStrategy();
+    const id = s.resolve({}, 'text');
+    assert.match(id, /^[0-9a-f-]{36}$/);
+  });
+});
+
+describe('SessionScopedIdStrategy', () => {
+  it('prefixes explicit id with session', () => {
+    const s = new SessionScopedIdStrategy('sess-1');
+    assert.equal(s.resolve({ id: 'x' }, 't'), 'sess-1:x');
+  });
+  it('falls back to canonicalKey', () => {
+    const s = new SessionScopedIdStrategy('sess-1');
+    assert.equal(s.resolve({ canonicalKey: 'doc' }, 't'), 'sess-1:doc');
+  });
+  it('generates session-scoped uuid when neither present', () => {
+    const s = new SessionScopedIdStrategy('sess-1');
+    const id = s.resolve({}, 't');
+    assert.match(id, /^sess-1:[0-9a-f-]{36}$/);
+  });
+});
+
+describe('CanonicalKeyIdStrategy', () => {
+  it('uses canonicalKey with default version', () => {
+    const s = new CanonicalKeyIdStrategy();
+    assert.equal(s.resolve({ canonicalKey: 'doc' }, 't'), 'doc:v1');
+  });
+  it('uses provided version from metadata', () => {
+    const s = new CanonicalKeyIdStrategy();
+    assert.equal(s.resolve({ canonicalKey: 'doc', version: 3 }, 't'), 'doc:v3');
+  });
+  it('throws when canonicalKey missing', () => {
+    const s = new CanonicalKeyIdStrategy();
+    assert.throws(() => s.resolve({}, 't'), MissingIdError);
+  });
+});

--- a/src/smart-agent/rag/__tests__/in-memory-rag.test.ts
+++ b/src/smart-agent/rag/__tests__/in-memory-rag.test.ts
@@ -196,3 +196,46 @@ describe('InMemoryRag', () => {
     });
   });
 });
+
+describe('InMemoryRag.getById', () => {
+  it('returns stored record by metadata.id', async () => {
+    const rag = new InMemoryRag();
+    await rag.upsert('hello world', { id: 'r1' });
+    const got = await rag.getById?.('r1');
+    assert.ok(got?.ok);
+    assert.ok(got?.value);
+    assert.equal(got?.value?.text, 'hello world');
+  });
+  it('returns null for unknown id', async () => {
+    const rag = new InMemoryRag();
+    const got = await rag.getById?.('missing');
+    assert.ok(got?.ok);
+    assert.equal(got?.value, null);
+  });
+});
+
+describe('InMemoryRag backend writer', () => {
+  it('exposes IRagBackendWriter via writer()', async () => {
+    const rag = new InMemoryRag();
+    const w = rag.writer();
+    const up = await w.upsertRaw('id-1', 'hi', {});
+    assert.ok(up.ok);
+    const got = await rag.getById?.('id-1');
+    assert.ok(got?.ok && got?.value?.text === 'hi');
+    const del = await w.deleteByIdRaw('id-1');
+    assert.ok(del.ok && del.value === true);
+    const delAgain = await w.deleteByIdRaw('id-1');
+    assert.ok(delAgain.ok && delAgain.value === false);
+  });
+  it('clearAll empties the store', async () => {
+    const rag = new InMemoryRag();
+    const w = rag.writer();
+    await w.upsertRaw('x', 'text', {});
+    const cleared = await w.clearAll?.();
+    assert.ok(cleared?.ok);
+    assert.equal(
+      (await rag.getById?.('x'))?.ok && (await rag.getById?.('x'))?.value,
+      null,
+    );
+  });
+});

--- a/src/smart-agent/rag/__tests__/overlay-rag.test.ts
+++ b/src/smart-agent/rag/__tests__/overlay-rag.test.ts
@@ -1,0 +1,174 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { IRag } from '../../interfaces/rag.js';
+import type { RagResult } from '../../interfaces/types.js';
+import { OverlayRag } from '../overlays/overlay-rag.js';
+import { SessionScopedRag } from '../overlays/session-scoped-rag.js';
+import { TextOnlyEmbedding } from '../query-embedding.js';
+
+function stub(
+  results: RagResult[],
+  records: Record<string, RagResult> = {},
+): IRag {
+  return {
+    query: async () => ({ ok: true, value: results }),
+    getById: async (id) => ({ ok: true, value: records[id] ?? null }),
+    healthCheck: async () => ({ ok: true, value: undefined }),
+  } as IRag;
+}
+
+describe('OverlayRag.query', () => {
+  it('overlay wins on canonicalKey collision regardless of score', async () => {
+    const base = stub([
+      { text: 'old', metadata: { id: 'b1', canonicalKey: 'k' }, score: 0.99 },
+      { text: 'other', metadata: { id: 'b2', canonicalKey: 'x' }, score: 0.5 },
+    ]);
+    const overlay = stub([
+      { text: 'new', metadata: { id: 'o1', canonicalKey: 'k' }, score: 0.1 },
+    ]);
+    const rag = new OverlayRag(base, overlay);
+    const res = await rag.query(new TextOnlyEmbedding('q'), 10);
+    assert.ok(res.ok);
+    const texts = res.value.map((r) => r.text).sort();
+    assert.deepEqual(texts, ['new', 'other']);
+  });
+  it('passes base records through when overlay has no canonicalKey match', async () => {
+    const base = stub([
+      { text: 'b', metadata: { id: 'b', canonicalKey: 'k' }, score: 1 },
+    ]);
+    const overlay = stub([]);
+    const rag = new OverlayRag(base, overlay);
+    const res = await rag.query(new TextOnlyEmbedding('q'), 10);
+    assert.ok(res.ok);
+    assert.deepEqual(
+      res.value.map((r) => r.text),
+      ['b'],
+    );
+  });
+  it('respects k limit after merge', async () => {
+    const base = stub([
+      { text: 'b1', metadata: { id: 'b1', canonicalKey: 'x1' }, score: 0.5 },
+      { text: 'b2', metadata: { id: 'b2', canonicalKey: 'x2' }, score: 0.4 },
+    ]);
+    const overlay = stub([
+      { text: 'o1', metadata: { id: 'o1', canonicalKey: 'y1' }, score: 0.9 },
+      { text: 'o2', metadata: { id: 'o2', canonicalKey: 'y2' }, score: 0.8 },
+    ]);
+    const rag = new OverlayRag(base, overlay);
+    const res = await rag.query(new TextOnlyEmbedding('q'), 2);
+    assert.ok(res.ok);
+    assert.equal(res.value.length, 2);
+    assert.deepEqual(
+      res.value.map((r) => r.text),
+      ['o1', 'o2'],
+    );
+  });
+});
+
+describe('OverlayRag.getById', () => {
+  it('prefers overlay, falls back to base, null when both miss', async () => {
+    const base = stub([], {
+      b1: { text: 'base', metadata: { id: 'b1' }, score: 1 },
+    });
+    const overlay = stub([], {
+      o1: { text: 'ovr', metadata: { id: 'o1' }, score: 1 },
+    });
+    const rag = new OverlayRag(base, overlay);
+    const fromOverlay = await rag.getById?.('o1');
+    assert.ok(fromOverlay?.ok && fromOverlay.value?.text === 'ovr');
+    const fromBase = await rag.getById?.('b1');
+    assert.ok(fromBase?.ok && fromBase.value?.text === 'base');
+    const miss = await rag.getById?.('nope');
+    assert.ok(miss?.ok && miss.value === null);
+  });
+});
+
+describe('OverlayRag.healthCheck', () => {
+  it('requires both healthy', async () => {
+    const base = stub([]);
+    const overlay = {
+      query: async () => ({ ok: true, value: [] }),
+      getById: async () => ({ ok: true, value: null }),
+      healthCheck: async () => ({
+        ok: false,
+        error: { code: 'FAIL', message: 'x' } as unknown,
+      }),
+    } as unknown as IRag;
+    const rag = new OverlayRag(base, overlay);
+    const res = await rag.healthCheck();
+    assert.ok(!res.ok);
+  });
+});
+
+describe('SessionScopedRag', () => {
+  it('includes only overlay records matching sessionId', async () => {
+    const base = stub([
+      { text: 'b', metadata: { id: 'b', canonicalKey: 'b' }, score: 1 },
+    ]);
+    const overlay = stub([
+      {
+        text: 'own',
+        metadata: { id: 'o1', canonicalKey: 'x', sessionId: 'S' },
+        score: 1,
+      },
+      {
+        text: 'other',
+        metadata: { id: 'o2', canonicalKey: 'y', sessionId: 'X' },
+        score: 1,
+      },
+    ]);
+    const rag = new SessionScopedRag(base, overlay, 'S');
+    const res = await rag.query(new TextOnlyEmbedding('q'), 10);
+    assert.ok(res.ok);
+    const texts = res.value.map((r) => r.text).sort();
+    assert.deepEqual(texts, ['b', 'own']);
+  });
+  it('excludes overlay records older than ttlMs', async () => {
+    const base = stub([]);
+    const now = Date.now();
+    const overlay = stub([
+      {
+        text: 'fresh',
+        metadata: {
+          id: 'f',
+          canonicalKey: 'f',
+          sessionId: 'S',
+          createdAt: now,
+        },
+        score: 1,
+      },
+      {
+        text: 'stale',
+        metadata: {
+          id: 's',
+          canonicalKey: 's',
+          sessionId: 'S',
+          createdAt: now - 60_000,
+        },
+        score: 1,
+      },
+    ]);
+    const rag = new SessionScopedRag(base, overlay, 'S', 10_000);
+    const res = await rag.query(new TextOnlyEmbedding('q'), 10);
+    assert.ok(res.ok);
+    assert.deepEqual(
+      res.value.map((r) => r.text),
+      ['fresh'],
+    );
+  });
+  it('getById rejects overlay record with wrong sessionId', async () => {
+    const base = stub([], {
+      x: { text: 'base', metadata: { id: 'x' }, score: 1 },
+    });
+    const overlay = stub([], {
+      x: {
+        text: 'ovr',
+        metadata: { id: 'x', sessionId: 'WRONG' },
+        score: 1,
+      },
+    });
+    const rag = new SessionScopedRag(base, overlay, 'RIGHT');
+    const res = await rag.getById?.('x');
+    assert.ok(res?.ok && res.value?.text === 'base');
+  });
+});

--- a/src/smart-agent/rag/__tests__/qdrant-rag.test.ts
+++ b/src/smart-agent/rag/__tests__/qdrant-rag.test.ts
@@ -87,6 +87,51 @@ function createStubServer(state: StubState): http.Server {
         return;
       }
 
+      // POST /collections/:name/points (retrieve by ids)
+      const retrieveMatch = url.match(/^\/collections\/([^/]+)\/points$/);
+      if (retrieveMatch && req.method === 'POST') {
+        const name = retrieveMatch[1];
+        const data = JSON.parse(body);
+        const coll = state.collections.get(name);
+        if (!coll) {
+          res.writeHead(404);
+          res.end();
+          return;
+        }
+        const ids: string[] = data.ids ?? [];
+        const result = coll
+          .filter((p) => ids.includes(p.id))
+          .map((p) => ({ id: p.id, payload: p.payload }));
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ result }));
+        return;
+      }
+
+      // POST /collections/:name/points/delete
+      const deleteMatch = url.match(/^\/collections\/([^/]+)\/points\/delete$/);
+      if (deleteMatch && req.method === 'POST') {
+        const name = deleteMatch[1];
+        const data = JSON.parse(body);
+        const coll = state.collections.get(name);
+        if (!coll) {
+          res.writeHead(404);
+          res.end();
+          return;
+        }
+        if (data.filter && Object.keys(data.filter).length === 0) {
+          coll.length = 0;
+        } else if (Array.isArray(data.points)) {
+          const ids = new Set<string>(data.points);
+          state.collections.set(
+            name,
+            coll.filter((p) => !ids.has(p.id)),
+          );
+        }
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ result: { status: 'completed' } }));
+        return;
+      }
+
       // POST /collections/:name/points/search
       const searchMatch = url.match(/^\/collections\/([^/]+)\/points\/search$/);
       if (searchMatch && req.method === 'POST') {
@@ -224,5 +269,61 @@ describe('QdrantRag', () => {
     });
     const result = await rag.healthCheck();
     assert.ok(result.ok);
+  });
+
+  it('getById returns the stored record via deterministic UUID', async () => {
+    state.collections.set('test-get', []);
+    const rag = new QdrantRag({
+      url: baseUrl,
+      collectionName: 'test-get',
+      embedder: makeEmbedder(),
+    });
+    await rag.upsert('hello', { id: 'r1' });
+    const got = await rag.getById?.('r1');
+    assert.ok(got.ok);
+    assert.ok(got.value);
+    assert.equal(got.value?.text, 'hello');
+  });
+
+  it('getById returns null for unknown id', async () => {
+    state.collections.set('test-get-miss', []);
+    const rag = new QdrantRag({
+      url: baseUrl,
+      collectionName: 'test-get-miss',
+      embedder: makeEmbedder(),
+    });
+    const got = await rag.getById?.('nope');
+    assert.ok(got.ok);
+    assert.equal(got.value, null);
+  });
+
+  it('writer().deleteByIdRaw removes the point', async () => {
+    state.collections.set('test-del', []);
+    const rag = new QdrantRag({
+      url: baseUrl,
+      collectionName: 'test-del',
+      embedder: makeEmbedder(),
+    });
+    const w = rag.writer();
+    await w.upsertRaw('r1', 'hi', {});
+    assert.equal(state.collections.get('test-del')?.length, 1);
+    const del = await w.deleteByIdRaw('r1');
+    assert.ok(del.ok);
+    assert.equal(state.collections.get('test-del')?.length, 0);
+  });
+
+  it('writer().clearAll empties the collection', async () => {
+    state.collections.set('test-clear', []);
+    const rag = new QdrantRag({
+      url: baseUrl,
+      collectionName: 'test-clear',
+      embedder: makeEmbedder(),
+    });
+    const w = rag.writer();
+    await w.upsertRaw('a', 't', {});
+    await w.upsertRaw('b', 't', {});
+    const cleared = await w.clearAll?.();
+    assert.ok(cleared.ok);
+    assert.equal(state.collections.get('test-clear')?.length, 0);
   });
 });

--- a/src/smart-agent/rag/__tests__/rag-collection-tools.test.ts
+++ b/src/smart-agent/rag/__tests__/rag-collection-tools.test.ts
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { InMemoryRag } from '../in-memory-rag.js';
+import { buildRagCollectionToolEntries } from '../mcp-tools/rag-collection-tools.js';
+import { SimpleRagRegistry } from '../registry/simple-rag-registry.js';
+import {
+  DirectEditStrategy,
+  ImmutableEditStrategy,
+} from '../strategies/edit/index.js';
+import { GlobalUniqueIdStrategy } from '../strategies/id/index.js';
+
+function makeRegistry() {
+  const reg = new SimpleRagRegistry();
+  const rag = new InMemoryRag();
+  reg.register(
+    'notes',
+    rag,
+    new DirectEditStrategy(rag.writer(), new GlobalUniqueIdStrategy()),
+    { displayName: 'Notes' },
+  );
+  reg.register('corp', new InMemoryRag(), new ImmutableEditStrategy('corp'), {
+    displayName: 'Corp',
+  });
+  return reg;
+}
+
+describe('buildRagCollectionToolEntries', () => {
+  it('produces rag_add, rag_correct, rag_deprecate', () => {
+    const entries = buildRagCollectionToolEntries({ registry: makeRegistry() });
+    const names = entries.map((e) => e.toolDefinition.name).sort();
+    assert.deepEqual(names, ['rag_add', 'rag_correct', 'rag_deprecate']);
+  });
+
+  it('rag_add rejects unknown collection', async () => {
+    const entries = buildRagCollectionToolEntries({ registry: makeRegistry() });
+    const add = entries.find((e) => e.toolDefinition.name === 'rag_add');
+    assert.ok(add);
+    const out = (await add.handler(
+      {},
+      {
+        collection: 'does-not-exist',
+        text: 't',
+        canonicalKey: 'k',
+      },
+    )) as { ok: boolean; error?: string };
+    assert.equal(out.ok, false);
+    assert.ok(out.error);
+  });
+
+  it('rag_add rejects read-only collection', async () => {
+    const entries = buildRagCollectionToolEntries({ registry: makeRegistry() });
+    const add = entries.find((e) => e.toolDefinition.name === 'rag_add');
+    assert.ok(add);
+    const out = (await add.handler(
+      {},
+      {
+        collection: 'corp',
+        text: 't',
+        canonicalKey: 'k',
+      },
+    )) as { ok: boolean; error?: string };
+    assert.equal(out.ok, false);
+  });
+
+  it('rag_add writes into editable collection', async () => {
+    const entries = buildRagCollectionToolEntries({ registry: makeRegistry() });
+    const add = entries.find((e) => e.toolDefinition.name === 'rag_add');
+    assert.ok(add);
+    const out = (await add.handler(
+      {},
+      {
+        collection: 'notes',
+        text: 'hello',
+        canonicalKey: 'greeting',
+      },
+    )) as { ok: boolean; id?: string };
+    assert.equal(out.ok, true);
+    assert.ok(typeof out.id === 'string');
+  });
+
+  it('rag_deprecate marks record deprecated via upsert', async () => {
+    const reg = makeRegistry();
+    const entries = buildRagCollectionToolEntries({ registry: reg });
+    const dep = entries.find((e) => e.toolDefinition.name === 'rag_deprecate');
+    assert.ok(dep);
+    const out = (await dep.handler(
+      {},
+      {
+        collection: 'notes',
+        id: 'x',
+        canonicalKey: 'k',
+        reason: 'outdated',
+      },
+    )) as { ok: boolean; id?: string };
+    assert.equal(out.ok, true);
+  });
+
+  it('rag_correct supersedes and returns both ids', async () => {
+    const reg = makeRegistry();
+    const entries = buildRagCollectionToolEntries({ registry: reg });
+    const cor = entries.find((e) => e.toolDefinition.name === 'rag_correct');
+    assert.ok(cor);
+    const out = (await cor.handler(
+      {},
+      {
+        collection: 'notes',
+        predecessorId: 'k:v1',
+        predecessorCanonicalKey: 'k',
+        newText: 'fixed',
+        reason: 'typo',
+      },
+    )) as { ok: boolean; predecessorId?: string; newId?: string };
+    assert.equal(out.ok, true);
+    assert.equal(out.predecessorId, 'k:v1');
+    assert.ok(typeof out.newId === 'string');
+  });
+});

--- a/src/smart-agent/rag/__tests__/simple-rag-registry.test.ts
+++ b/src/smart-agent/rag/__tests__/simple-rag-registry.test.ts
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { InMemoryRag } from '../in-memory-rag.js';
+import { SimpleRagRegistry } from '../registry/simple-rag-registry.js';
+import {
+  DirectEditStrategy,
+  ImmutableEditStrategy,
+} from '../strategies/edit/index.js';
+import { GlobalUniqueIdStrategy } from '../strategies/id/index.js';
+
+describe('SimpleRagRegistry', () => {
+  it('registers and retrieves rag + editor', () => {
+    const reg = new SimpleRagRegistry();
+    const rag = new InMemoryRag();
+    const ed = new DirectEditStrategy(
+      rag.writer(),
+      new GlobalUniqueIdStrategy(),
+    );
+    reg.register('notes', rag, ed, { displayName: 'Notes' });
+    assert.equal(reg.get('notes'), rag);
+    assert.equal(reg.getEditor('notes'), ed);
+  });
+
+  it('marks collection as editable only when editor is concrete (not Immutable)', () => {
+    const reg = new SimpleRagRegistry();
+    const rag = new InMemoryRag();
+    reg.register(
+      'editable',
+      rag,
+      new DirectEditStrategy(rag.writer(), new GlobalUniqueIdStrategy()),
+      { displayName: 'Editable' },
+    );
+    reg.register('corp', new InMemoryRag(), new ImmutableEditStrategy('corp'), {
+      displayName: 'Corp',
+    });
+    reg.register('facts', new InMemoryRag(), undefined, {
+      displayName: 'Facts',
+    });
+    const list = reg.list();
+    const edit = list.find((m) => m.name === 'editable');
+    const corp = list.find((m) => m.name === 'corp');
+    const facts = list.find((m) => m.name === 'facts');
+    assert.equal(edit?.editable, true);
+    assert.equal(corp?.editable, false);
+    assert.equal(facts?.editable, false);
+  });
+
+  it('rejects duplicate names', () => {
+    const reg = new SimpleRagRegistry();
+    reg.register('x', new InMemoryRag(), undefined, { displayName: 'X' });
+    assert.throws(() =>
+      reg.register('x', new InMemoryRag(), undefined, { displayName: 'X' }),
+    );
+  });
+
+  it('unregister removes entry and returns true when present', () => {
+    const reg = new SimpleRagRegistry();
+    reg.register('x', new InMemoryRag(), undefined, { displayName: 'X' });
+    assert.equal(reg.unregister('x'), true);
+    assert.equal(reg.unregister('x'), false);
+  });
+
+  it('list preserves insertion order', () => {
+    const reg = new SimpleRagRegistry();
+    reg.register('a', new InMemoryRag(), undefined, { displayName: 'A' });
+    reg.register('b', new InMemoryRag(), undefined, { displayName: 'B' });
+    reg.register('c', new InMemoryRag(), undefined, { displayName: 'C' });
+    assert.deepEqual(
+      reg.list().map((m) => m.name),
+      ['a', 'b', 'c'],
+    );
+  });
+
+  it('defaults displayName to name when not provided', () => {
+    const reg = new SimpleRagRegistry();
+    reg.register('x', new InMemoryRag());
+    const [m] = reg.list();
+    assert.equal(m.displayName, 'x');
+  });
+});

--- a/src/smart-agent/rag/__tests__/vector-rag-writer.test.ts
+++ b/src/smart-agent/rag/__tests__/vector-rag-writer.test.ts
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { IEmbedder } from '../../interfaces/rag.js';
+import { TextOnlyEmbedding } from '../query-embedding.js';
+import { VectorRag } from '../vector-rag.js';
+
+const fakeEmbedder: IEmbedder = {
+  embed: async (text) => ({
+    vector: Array.from(text.slice(0, 8).padEnd(8, ' ')).map(
+      (c) => c.charCodeAt(0) / 255,
+    ),
+  }),
+};
+
+describe('VectorRag.getById', () => {
+  it('retrieves by metadata.id after upsert', async () => {
+    const rag = new VectorRag(fakeEmbedder);
+    await rag.upsert('hello', { id: 'v1' });
+    const got = await rag.getById?.('v1');
+    assert.ok(got?.ok);
+    assert.ok(got?.value);
+    assert.equal(got?.value?.text, 'hello');
+  });
+  it('returns null for unknown id', async () => {
+    const rag = new VectorRag(fakeEmbedder);
+    const got = await rag.getById?.('nope');
+    assert.ok(got?.ok);
+    assert.equal(got?.value, null);
+  });
+});
+
+describe('VectorRag backend writer', () => {
+  it('upsertRaw adds a record', async () => {
+    const rag = new VectorRag(fakeEmbedder);
+    const w = rag.writer();
+    const up = await w.upsertRaw('v1', 'hi there', {});
+    assert.ok(up.ok);
+    const got = await rag.getById?.('v1');
+    assert.ok(got?.ok && got.value?.text === 'hi there');
+  });
+  it('deleteByIdRaw removes the record and returns whether it existed', async () => {
+    const rag = new VectorRag(fakeEmbedder);
+    const w = rag.writer();
+    await w.upsertRaw('v1', 'hi', {});
+    const first = await w.deleteByIdRaw('v1');
+    assert.ok(first.ok && first.value === true);
+    const miss = await w.deleteByIdRaw('v1');
+    assert.ok(miss.ok && miss.value === false);
+    const got = await rag.getById?.('v1');
+    assert.ok(got?.ok && got.value === null);
+  });
+  it('queries skip deleted records', async () => {
+    const rag = new VectorRag(fakeEmbedder);
+    const w = rag.writer();
+    await w.upsertRaw('v1', 'keepable', {});
+    await w.upsertRaw('v2', 'removable', {});
+    await w.deleteByIdRaw('v2');
+    const res = await rag.query(new TextOnlyEmbedding('removable'), 10);
+    assert.ok(res.ok);
+    const texts = res.value.map((r) => r.text);
+    assert.ok(!texts.includes('removable'));
+  });
+  it('clearAll empties the store', async () => {
+    const rag = new VectorRag(fakeEmbedder);
+    const w = rag.writer();
+    await w.upsertRaw('v1', 'x', {});
+    const cleared = await w.clearAll?.();
+    assert.ok(cleared?.ok);
+    const got = await rag.getById?.('v1');
+    assert.ok(got?.ok && got.value === null);
+  });
+});

--- a/src/smart-agent/rag/corrections/active-filtering-rag.ts
+++ b/src/smart-agent/rag/corrections/active-filtering-rag.ts
@@ -1,0 +1,56 @@
+import type { IQueryEmbedding } from '../../interfaces/query-embedding.js';
+import type { IRag } from '../../interfaces/rag.js';
+import type {
+  CallOptions,
+  RagError,
+  RagResult,
+  Result,
+} from '../../interfaces/types.js';
+import { type CorrectionMetadata, filterActive } from './metadata.js';
+
+function includeInactive(options?: CallOptions): boolean {
+  return Boolean(
+    (options?.ragFilter as { includeInactive?: boolean } | undefined)
+      ?.includeInactive,
+  );
+}
+
+export class ActiveFilteringRag implements IRag {
+  constructor(private readonly inner: IRag) {}
+
+  async query(
+    embedding: IQueryEmbedding,
+    k: number,
+    options?: CallOptions,
+  ): Promise<Result<RagResult[], RagError>> {
+    const res = await this.inner.query(embedding, k, options);
+    if (!res.ok) return res;
+    const filtered = filterActive(
+      res.value,
+      (r) => r.metadata as CorrectionMetadata,
+      { includeInactive: includeInactive(options) },
+    );
+    return { ok: true, value: filtered };
+  }
+
+  async getById(
+    id: string,
+    options?: CallOptions,
+  ): Promise<Result<RagResult | null, RagError>> {
+    if (!this.inner.getById) {
+      return { ok: true, value: null };
+    }
+    const res = await this.inner.getById(id, options);
+    if (!res.ok || res.value === null) return res;
+    const tags = (res.value.metadata as CorrectionMetadata).tags ?? [];
+    const inactive = tags.includes('deprecated') || tags.includes('superseded');
+    if (inactive && !includeInactive(options)) {
+      return { ok: true, value: null };
+    }
+    return res;
+  }
+
+  healthCheck(options?: CallOptions): Promise<Result<void, RagError>> {
+    return this.inner.healthCheck(options);
+  }
+}

--- a/src/smart-agent/rag/corrections/active-filtering-rag.ts
+++ b/src/smart-agent/rag/corrections/active-filtering-rag.ts
@@ -27,7 +27,7 @@ export class ActiveFilteringRag implements IRag {
     if (!res.ok) return res;
     const filtered = filterActive(
       res.value,
-      (r) => r.metadata as CorrectionMetadata,
+      (r) => r.metadata as unknown as CorrectionMetadata,
       { includeInactive: includeInactive(options) },
     );
     return { ok: true, value: filtered };
@@ -37,12 +37,10 @@ export class ActiveFilteringRag implements IRag {
     id: string,
     options?: CallOptions,
   ): Promise<Result<RagResult | null, RagError>> {
-    if (!this.inner.getById) {
-      return { ok: true, value: null };
-    }
     const res = await this.inner.getById(id, options);
     if (!res.ok || res.value === null) return res;
-    const tags = (res.value.metadata as CorrectionMetadata).tags ?? [];
+    const tags =
+      (res.value.metadata as unknown as CorrectionMetadata).tags ?? [];
     const inactive = tags.includes('deprecated') || tags.includes('superseded');
     if (inactive && !includeInactive(options)) {
       return { ok: true, value: null };

--- a/src/smart-agent/rag/corrections/errors.ts
+++ b/src/smart-agent/rag/corrections/errors.ts
@@ -1,0 +1,25 @@
+import { RagError } from '../../interfaces/types.js';
+
+export class ReadOnlyError extends RagError {
+  constructor(collectionName: string) {
+    super(`Collection '${collectionName}' is read-only`, 'RAG_READ_ONLY');
+    this.name = 'ReadOnlyError';
+  }
+}
+
+export class MissingIdError extends RagError {
+  constructor(strategyName: string) {
+    super(`${strategyName} requires metadata.id`, 'RAG_MISSING_ID');
+    this.name = 'MissingIdError';
+  }
+}
+
+export class CanonicalKeyCollisionError extends RagError {
+  constructor(key: string) {
+    super(
+      `canonicalKey '${key}' already exists in base; reserved for future overlay-block semantics`,
+      'RAG_CANONICAL_KEY_COLLISION',
+    );
+    this.name = 'CanonicalKeyCollisionError';
+  }
+}

--- a/src/smart-agent/rag/corrections/index.ts
+++ b/src/smart-agent/rag/corrections/index.ts
@@ -1,0 +1,3 @@
+export { ActiveFilteringRag } from './active-filtering-rag.js';
+export * from './errors.js';
+export * from './metadata.js';

--- a/src/smart-agent/rag/corrections/metadata.ts
+++ b/src/smart-agent/rag/corrections/metadata.ts
@@ -1,0 +1,85 @@
+import { RagError } from '../../interfaces/types.js';
+
+export type CorrectionTag =
+  | 'verified'
+  | 'deprecated'
+  | 'superseded'
+  | 'correction';
+
+export interface CorrectionMetadata {
+  canonicalKey: string;
+  tags?: CorrectionTag[];
+  sessionId?: string;
+  supersededBy?: string;
+  deprecatedAt?: number;
+  deprecatedReason?: string;
+}
+
+export function validateCorrectionMetadata(meta: CorrectionMetadata): void {
+  if (typeof meta.canonicalKey !== 'string' || meta.canonicalKey.length === 0) {
+    throw new RagError(
+      'CorrectionMetadata.canonicalKey must be a non-empty string',
+      'RAG_VALIDATION_ERROR',
+    );
+  }
+}
+
+function withTag(
+  meta: CorrectionMetadata,
+  tag: CorrectionTag,
+): CorrectionMetadata {
+  const existing = meta.tags ?? [];
+  return existing.includes(tag) ? meta : { ...meta, tags: [...existing, tag] };
+}
+
+export function deprecateMetadata(
+  current: CorrectionMetadata,
+  reason: string,
+  nowSeconds?: number,
+): CorrectionMetadata {
+  validateCorrectionMetadata(current);
+  const stamped: CorrectionMetadata = {
+    ...current,
+    deprecatedReason: reason,
+    deprecatedAt: nowSeconds ?? Math.floor(Date.now() / 1000),
+  };
+  return withTag(stamped, 'deprecated');
+}
+
+export function buildCorrectionMetadata(input: {
+  predecessor: CorrectionMetadata;
+  predecessorId: string;
+  newEntryId: string;
+  reason: string;
+}): { predecessor: CorrectionMetadata; next: CorrectionMetadata } {
+  validateCorrectionMetadata(input.predecessor);
+  const predecessor = withTag(
+    {
+      ...input.predecessor,
+      supersededBy: input.newEntryId,
+      deprecatedReason: input.reason,
+      deprecatedAt: Math.floor(Date.now() / 1000),
+    },
+    'superseded',
+  );
+  const next: CorrectionMetadata = withTag(
+    {
+      canonicalKey: input.predecessor.canonicalKey,
+      sessionId: input.predecessor.sessionId,
+    },
+    'correction',
+  );
+  return { predecessor, next };
+}
+
+export function filterActive<T>(
+  items: readonly T[],
+  getMeta: (item: T) => CorrectionMetadata | undefined,
+  options?: { includeInactive?: boolean },
+): T[] {
+  if (options?.includeInactive) return [...items];
+  return items.filter((item) => {
+    const tags = getMeta(item)?.tags ?? [];
+    return !tags.includes('deprecated') && !tags.includes('superseded');
+  });
+}

--- a/src/smart-agent/rag/in-memory-rag.ts
+++ b/src/smart-agent/rag/in-memory-rag.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import type { IQueryEmbedding } from '../interfaces/query-embedding.js';
-import type { IRag } from '../interfaces/rag.js';
+import type { IRag, IRagBackendWriter } from '../interfaces/rag.js';
 import type {
   CallOptions,
   RagMetadata,
@@ -201,11 +201,42 @@ export class InMemoryRag implements IRag {
     return { ok: true, value: results };
   }
 
+  async getById(
+    id: string,
+    _options?: CallOptions,
+  ): Promise<Result<RagResult | null, RagError>> {
+    const record = this.records.find((r) => r.metadata.id === id);
+    if (!record) return { ok: true, value: null };
+    return {
+      ok: true,
+      value: { text: record.text, metadata: record.metadata, score: 1 },
+    };
+  }
+
   async healthCheck(): Promise<Result<void, RagError>> {
     return { ok: true, value: undefined };
   }
 
   clear(): void {
     this.records.length = 0;
+  }
+
+  writer(): IRagBackendWriter {
+    return {
+      upsertRaw: async (id, text, metadata, options) => {
+        const res = await this.upsert(text, { ...metadata, id }, options);
+        return res.ok ? { ok: true, value: undefined } : res;
+      },
+      deleteByIdRaw: async (id) => {
+        const idx = this.records.findIndex((r) => r.metadata.id === id);
+        if (idx === -1) return { ok: true, value: false };
+        this.records.splice(idx, 1);
+        return { ok: true, value: true };
+      },
+      clearAll: async () => {
+        this.records.length = 0;
+        return { ok: true, value: undefined };
+      },
+    };
   }
 }

--- a/src/smart-agent/rag/index.ts
+++ b/src/smart-agent/rag/index.ts
@@ -1,10 +1,13 @@
+export * from './corrections/index.js';
 export { builtInEmbedderFactories } from './embedder-factories.js';
 export type { InMemoryRagConfig } from './in-memory-rag.js';
 export { InMemoryRag } from './in-memory-rag.js';
+export * from './mcp-tools/index.js';
 export type { OllamaEmbedderConfig } from './ollama-rag.js';
 export { OllamaEmbedder, OllamaRag } from './ollama-rag.js';
 export type { OpenAiEmbedderConfig } from './openai-embedder.js';
 export { OpenAiEmbedder } from './openai-embedder.js';
+export * from './overlays/index.js';
 export type { IDocumentEnricher, IQueryPreprocessor } from './preprocessor.js';
 export {
   ExpandPreprocessor,
@@ -16,6 +19,7 @@ export {
 } from './preprocessor.js';
 export type { QdrantRagConfig } from './qdrant-rag.js';
 export { QdrantRag } from './qdrant-rag.js';
+export * from './registry/index.js';
 export type {
   IScoredResult,
   ISearchCandidate,
@@ -31,5 +35,7 @@ export {
   VectorOnlyStrategy,
   WeightedFusionStrategy,
 } from './search-strategy.js';
+export * from './strategies/edit/index.js';
+export * from './strategies/id/index.js';
 export type { VectorRagConfig } from './vector-rag.js';
 export { VectorRag } from './vector-rag.js';

--- a/src/smart-agent/rag/inverted-index.ts
+++ b/src/smart-agent/rag/inverted-index.ts
@@ -50,6 +50,23 @@ export class InvertedIndex {
     }
   }
 
+  /** Remove a document's contribution from the index. */
+  remove(docId: number, tokens: string[]): void {
+    const oldLength = this.docLengths.get(docId) ?? 0;
+    this.totalTokens -= oldLength;
+    this.docLengths.delete(docId);
+
+    const oldUnique = new Set(tokens);
+    for (const term of oldUnique) {
+      const current = this.termDf.get(term) ?? 0;
+      if (current <= 1) {
+        this.termDf.delete(term);
+      } else {
+        this.termDf.set(term, current - 1);
+      }
+    }
+  }
+
   /** O(1) document frequency lookup for a term. */
   getDocFrequency(term: string): number {
     return this.termDf.get(term) ?? 0;

--- a/src/smart-agent/rag/mcp-tools/index.ts
+++ b/src/smart-agent/rag/mcp-tools/index.ts
@@ -1,0 +1,4 @@
+export {
+  buildRagCollectionToolEntries,
+  type RagToolEntry,
+} from './rag-collection-tools.js';

--- a/src/smart-agent/rag/mcp-tools/rag-collection-tools.ts
+++ b/src/smart-agent/rag/mcp-tools/rag-collection-tools.ts
@@ -1,0 +1,132 @@
+import { z } from 'zod';
+import type { IRagRegistry } from '../../interfaces/rag.js';
+import {
+  buildCorrectionMetadata,
+  deprecateMetadata,
+} from '../corrections/metadata.js';
+
+export interface RagToolEntry {
+  toolDefinition: {
+    name: string;
+    description: string;
+    inputSchema: z.ZodRawShape;
+  };
+  handler: (context: object, args: Record<string, unknown>) => Promise<unknown>;
+}
+
+export function buildRagCollectionToolEntries(opts: {
+  registry: IRagRegistry;
+}): RagToolEntry[] {
+  const { registry } = opts;
+
+  const resolveEditor = (name: unknown) => {
+    if (typeof name !== 'string') {
+      return { ok: false as const, error: 'collection is required' };
+    }
+    const editor = registry.getEditor(name);
+    if (!editor) {
+      return {
+        ok: false as const,
+        error: `Collection '${name}' is read-only or unknown`,
+      };
+    }
+    return { ok: true as const, editor };
+  };
+
+  const addTool: RagToolEntry = {
+    toolDefinition: {
+      name: 'rag_add',
+      description: 'Add a new document to a RAG collection.',
+      inputSchema: {
+        collection: z.string(),
+        text: z.string(),
+        canonicalKey: z.string(),
+        tags: z.array(z.string()).optional(),
+      },
+    },
+    handler: async (_ctx, args) => {
+      const r = resolveEditor(args.collection);
+      if (!r.ok) return r;
+      const res = await r.editor.upsert(String(args.text), {
+        canonicalKey: String(args.canonicalKey),
+        tags: args.tags as string[] | undefined,
+      });
+      return res.ok
+        ? { ok: true, id: res.value.id }
+        : { ok: false, error: res.error.message };
+    },
+  };
+
+  const correctTool: RagToolEntry = {
+    toolDefinition: {
+      name: 'rag_correct',
+      description:
+        'Supersede a document with a new corrected version. Marks the predecessor as superseded.',
+      inputSchema: {
+        collection: z.string(),
+        predecessorId: z.string(),
+        predecessorCanonicalKey: z.string(),
+        newText: z.string(),
+        reason: z.string(),
+      },
+    },
+    handler: async (_ctx, args) => {
+      const r = resolveEditor(args.collection);
+      if (!r.ok) return r;
+      const predecessorMeta = {
+        canonicalKey: String(args.predecessorCanonicalKey),
+      };
+      const newRes = await r.editor.upsert(String(args.newText), {
+        canonicalKey: predecessorMeta.canonicalKey,
+      });
+      if (!newRes.ok) return { ok: false, error: newRes.error.message };
+
+      const { predecessor } = buildCorrectionMetadata({
+        predecessor: predecessorMeta,
+        predecessorId: String(args.predecessorId),
+        newEntryId: newRes.value.id,
+        reason: String(args.reason),
+      });
+      const supRes = await r.editor.upsert('', {
+        ...predecessor,
+        id: String(args.predecessorId),
+      });
+      if (!supRes.ok) return { ok: false, error: supRes.error.message };
+      return {
+        ok: true,
+        predecessorId: String(args.predecessorId),
+        newId: newRes.value.id,
+      };
+    },
+  };
+
+  const deprecateTool: RagToolEntry = {
+    toolDefinition: {
+      name: 'rag_deprecate',
+      description: 'Mark a document as deprecated (idempotent).',
+      inputSchema: {
+        collection: z.string(),
+        id: z.string(),
+        canonicalKey: z.string(),
+        reason: z.string(),
+      },
+    },
+    handler: async (_ctx, args) => {
+      const r = resolveEditor(args.collection);
+      if (!r.ok) return r;
+      const meta = deprecateMetadata(
+        { canonicalKey: String(args.canonicalKey) },
+        String(args.reason),
+      );
+      const res = await r.editor.upsert('', {
+        ...meta,
+        id: String(args.id),
+      });
+      return res.ok
+        ? { ok: true, id: res.value.id }
+        : { ok: false, error: res.error.message };
+    },
+  };
+
+  return [addTool, correctTool, deprecateTool];
+}

--- a/src/smart-agent/rag/overlays/index.ts
+++ b/src/smart-agent/rag/overlays/index.ts
@@ -1,0 +1,2 @@
+export { OverlayRag } from './overlay-rag.js';
+export { SessionScopedRag } from './session-scoped-rag.js';

--- a/src/smart-agent/rag/overlays/overlay-rag.ts
+++ b/src/smart-agent/rag/overlays/overlay-rag.ts
@@ -3,7 +3,6 @@ import type { IRag } from '../../interfaces/rag.js';
 import type {
   CallOptions,
   RagError,
-  RagMetadata,
   RagResult,
   Result,
 } from '../../interfaces/types.js';
@@ -46,12 +45,9 @@ export class OverlayRag implements IRag {
     id: string,
     options?: CallOptions,
   ): Promise<Result<RagResult | null, RagError>> {
-    if (this.overlay.getById) {
-      const o = await this.overlay.getById(id, options);
-      if (!o.ok) return o;
-      if (o.value !== null && this.overlayAllows(o.value)) return o;
-    }
-    if (!this.base.getById) return { ok: true, value: null };
+    const o = await this.overlay.getById(id, options);
+    if (!o.ok) return o;
+    if (o.value !== null && this.overlayAllows(o.value)) return o;
     return this.base.getById(id, options);
   }
 
@@ -62,16 +58,6 @@ export class OverlayRag implements IRag {
     ]);
     if (!a.ok) return a;
     return b;
-  }
-
-  // Required by IRag but not meaningful for a read-only overlay wrapper.
-  // Delegates to base to satisfy the interface.
-  async upsert(
-    text: string,
-    metadata: RagMetadata,
-    options?: CallOptions,
-  ): Promise<Result<void, RagError>> {
-    return this.base.upsert(text, metadata, options);
   }
 
   /** Hook for subclasses to drop overlay rows (e.g. by sessionId). */

--- a/src/smart-agent/rag/overlays/overlay-rag.ts
+++ b/src/smart-agent/rag/overlays/overlay-rag.ts
@@ -1,0 +1,85 @@
+import type { IQueryEmbedding } from '../../interfaces/query-embedding.js';
+import type { IRag } from '../../interfaces/rag.js';
+import type {
+  CallOptions,
+  RagError,
+  RagMetadata,
+  RagResult,
+  Result,
+} from '../../interfaces/types.js';
+
+export class OverlayRag implements IRag {
+  constructor(
+    protected readonly base: IRag,
+    protected readonly overlay: IRag,
+  ) {}
+
+  async query(
+    embedding: IQueryEmbedding,
+    k: number,
+    options?: CallOptions,
+  ): Promise<Result<RagResult[], RagError>> {
+    const [baseRes, overlayRes] = await Promise.all([
+      this.base.query(embedding, k, options),
+      this.overlay.query(embedding, k, options),
+    ]);
+    if (!baseRes.ok) return baseRes;
+    if (!overlayRes.ok) return overlayRes;
+
+    const overlayList = this.filterOverlay(overlayRes.value);
+    const overlayKeys = new Set(
+      overlayList
+        .map((r) => r.metadata.canonicalKey)
+        .filter((key): key is string => typeof key === 'string'),
+    );
+    const baseKept = baseRes.value.filter((r) => {
+      const key = r.metadata.canonicalKey;
+      return typeof key !== 'string' || !overlayKeys.has(key);
+    });
+    const merged = [...overlayList, ...baseKept]
+      .sort((a, b) => b.score - a.score)
+      .slice(0, k);
+    return { ok: true, value: merged };
+  }
+
+  async getById(
+    id: string,
+    options?: CallOptions,
+  ): Promise<Result<RagResult | null, RagError>> {
+    if (this.overlay.getById) {
+      const o = await this.overlay.getById(id, options);
+      if (!o.ok) return o;
+      if (o.value !== null && this.overlayAllows(o.value)) return o;
+    }
+    if (!this.base.getById) return { ok: true, value: null };
+    return this.base.getById(id, options);
+  }
+
+  async healthCheck(options?: CallOptions): Promise<Result<void, RagError>> {
+    const [a, b] = await Promise.all([
+      this.base.healthCheck(options),
+      this.overlay.healthCheck(options),
+    ]);
+    if (!a.ok) return a;
+    return b;
+  }
+
+  // Required by IRag but not meaningful for a read-only overlay wrapper.
+  // Delegates to base to satisfy the interface.
+  async upsert(
+    text: string,
+    metadata: RagMetadata,
+    options?: CallOptions,
+  ): Promise<Result<void, RagError>> {
+    return this.base.upsert(text, metadata, options);
+  }
+
+  /** Hook for subclasses to drop overlay rows (e.g. by sessionId). */
+  protected filterOverlay(results: RagResult[]): RagResult[] {
+    return results;
+  }
+
+  protected overlayAllows(_result: RagResult): boolean {
+    return true;
+  }
+}

--- a/src/smart-agent/rag/overlays/session-scoped-rag.ts
+++ b/src/smart-agent/rag/overlays/session-scoped-rag.ts
@@ -1,0 +1,38 @@
+import type { IRag } from '../../interfaces/rag.js';
+import type { RagResult } from '../../interfaces/types.js';
+import { OverlayRag } from './overlay-rag.js';
+
+export class SessionScopedRag extends OverlayRag {
+  constructor(
+    base: IRag,
+    overlay: IRag,
+    private readonly sessionId: string,
+    private readonly ttlMs?: number,
+  ) {
+    super(base, overlay);
+  }
+
+  protected override filterOverlay(results: RagResult[]): RagResult[] {
+    const cutoff =
+      this.ttlMs !== undefined ? Date.now() - this.ttlMs : undefined;
+    return results.filter((r) => this.matches(r, cutoff));
+  }
+
+  protected override overlayAllows(result: RagResult): boolean {
+    const cutoff =
+      this.ttlMs !== undefined ? Date.now() - this.ttlMs : undefined;
+    return this.matches(result, cutoff);
+  }
+
+  private matches(result: RagResult, cutoffMs: number | undefined): boolean {
+    if (result.metadata.sessionId !== this.sessionId) return false;
+    if (cutoffMs !== undefined) {
+      const createdMs =
+        typeof result.metadata.createdAt === 'number'
+          ? result.metadata.createdAt
+          : undefined;
+      if (createdMs !== undefined && createdMs < cutoffMs) return false;
+    }
+    return true;
+  }
+}

--- a/src/smart-agent/rag/qdrant-rag.ts
+++ b/src/smart-agent/rag/qdrant-rag.ts
@@ -1,5 +1,9 @@
 import type { IQueryEmbedding } from '../interfaces/query-embedding.js';
-import type { IEmbedder, IPrecomputedVectorRag } from '../interfaces/rag.js';
+import type {
+  IEmbedder,
+  IPrecomputedVectorRag,
+  IRagBackendWriter,
+} from '../interfaces/rag.js';
 import {
   type CallOptions,
   RagError,
@@ -262,6 +266,50 @@ export class QdrantRag implements IPrecomputedVectorRag {
     }
   }
 
+  async getById(
+    id: string,
+    options?: CallOptions,
+  ): Promise<Result<RagResult | null, RagError>> {
+    if (options?.signal?.aborted) {
+      return { ok: false, error: new RagError('Aborted', 'ABORTED') };
+    }
+    try {
+      const pointId = await deterministicUUID(id);
+      const res = await this._fetch(
+        `/collections/${this.collectionName}/points`,
+        {
+          method: 'POST',
+          body: JSON.stringify({ ids: [pointId], with_payload: true }),
+        },
+        options?.signal,
+      );
+      if (!res.ok) {
+        const body = await res.text();
+        return {
+          ok: false,
+          error: new RagError(`Qdrant retrieve failed: ${body}`, 'QUERY_ERROR'),
+        };
+      }
+      const json = (await res.json()) as {
+        result: Array<{ id: string; payload: Record<string, unknown> }>;
+      };
+      const hit = json.result?.[0];
+      if (!hit) return { ok: true, value: null };
+      const { text: hitText, ...rest } = hit.payload;
+      return {
+        ok: true,
+        value: {
+          text: String(hitText ?? ''),
+          metadata: rest as RagMetadata,
+          score: 1,
+        },
+      };
+    } catch (err) {
+      if (err instanceof RagError) return { ok: false, error: err };
+      return { ok: false, error: new RagError(String(err), 'QUERY_ERROR') };
+    }
+  }
+
   async healthCheck(options?: CallOptions): Promise<Result<void, RagError>> {
     try {
       const res = await this._fetch(
@@ -288,5 +336,69 @@ export class QdrantRag implements IPrecomputedVectorRag {
         ),
       };
     }
+  }
+
+  writer(): IRagBackendWriter {
+    return {
+      upsertRaw: async (id, text, metadata, options) => {
+        const res = await this.upsert(text, { ...metadata, id }, options);
+        return res.ok ? { ok: true, value: undefined } : res;
+      },
+      deleteByIdRaw: async (id, options) => {
+        try {
+          const pointId = await deterministicUUID(id);
+          const res = await this._fetch(
+            `/collections/${this.collectionName}/points/delete`,
+            {
+              method: 'POST',
+              body: JSON.stringify({ points: [pointId] }),
+            },
+            options?.signal,
+          );
+          if (!res.ok) {
+            const body = await res.text();
+            return {
+              ok: false,
+              error: new RagError(
+                `Qdrant delete failed: ${body}`,
+                'DELETE_ERROR',
+              ),
+            };
+          }
+          return { ok: true, value: true };
+        } catch (err) {
+          if (err instanceof RagError) return { ok: false, error: err };
+          return {
+            ok: false,
+            error: new RagError(String(err), 'DELETE_ERROR'),
+          };
+        }
+      },
+      clearAll: async () => {
+        try {
+          const res = await this._fetch(
+            `/collections/${this.collectionName}/points/delete`,
+            {
+              method: 'POST',
+              body: JSON.stringify({ filter: {} }),
+            },
+          );
+          if (!res.ok) {
+            const body = await res.text();
+            return {
+              ok: false,
+              error: new RagError(
+                `Qdrant clear failed: ${body}`,
+                'CLEAR_ERROR',
+              ),
+            };
+          }
+          return { ok: true, value: undefined };
+        } catch (err) {
+          if (err instanceof RagError) return { ok: false, error: err };
+          return { ok: false, error: new RagError(String(err), 'CLEAR_ERROR') };
+        }
+      },
+    };
   }
 }

--- a/src/smart-agent/rag/qdrant-rag.ts
+++ b/src/smart-agent/rag/qdrant-rag.ts
@@ -1,9 +1,5 @@
 import type { IQueryEmbedding } from '../interfaces/query-embedding.js';
-import type {
-  IEmbedder,
-  IPrecomputedVectorRag,
-  IRagBackendWriter,
-} from '../interfaces/rag.js';
+import type { IEmbedder, IRag, IRagBackendWriter } from '../interfaces/rag.js';
 import {
   type CallOptions,
   RagError,
@@ -34,7 +30,7 @@ export interface QdrantRagConfig {
   timeoutMs?: number;
 }
 
-export class QdrantRag implements IPrecomputedVectorRag {
+export class QdrantRag implements IRag {
   private readonly url: string;
   private readonly collectionName: string;
   private readonly embedder: IEmbedder;
@@ -398,6 +394,14 @@ export class QdrantRag implements IPrecomputedVectorRag {
           if (err instanceof RagError) return { ok: false, error: err };
           return { ok: false, error: new RagError(String(err), 'CLEAR_ERROR') };
         }
+      },
+      upsertPrecomputedRaw: async (id, text, vector, metadata, options) => {
+        return this.upsertPrecomputed(
+          text,
+          vector,
+          { ...metadata, id },
+          options,
+        );
       },
     };
   }

--- a/src/smart-agent/rag/registry/index.ts
+++ b/src/smart-agent/rag/registry/index.ts
@@ -1,0 +1,1 @@
+export { SimpleRagRegistry } from './simple-rag-registry.js';

--- a/src/smart-agent/rag/registry/simple-rag-registry.ts
+++ b/src/smart-agent/rag/registry/simple-rag-registry.ts
@@ -1,0 +1,57 @@
+import type {
+  IRag,
+  IRagEditor,
+  IRagRegistry,
+  RagCollectionMeta,
+} from '../../interfaces/rag.js';
+import { ImmutableEditStrategy } from '../strategies/edit/immutable.js';
+
+interface Entry {
+  rag: IRag;
+  editor?: IRagEditor;
+  meta: RagCollectionMeta;
+}
+
+export class SimpleRagRegistry implements IRagRegistry {
+  protected readonly entries = new Map<string, Entry>();
+
+  register(
+    name: string,
+    rag: IRag,
+    editor?: IRagEditor,
+    meta?: Omit<RagCollectionMeta, 'name' | 'editable'>,
+  ): void {
+    if (this.entries.has(name)) {
+      throw new Error(`Collection '${name}' is already registered`);
+    }
+    const editable =
+      Boolean(editor) && !(editor instanceof ImmutableEditStrategy);
+    this.entries.set(name, {
+      rag,
+      editor,
+      meta: {
+        name,
+        displayName: meta?.displayName ?? name,
+        description: meta?.description,
+        tags: meta?.tags,
+        editable,
+      },
+    });
+  }
+
+  unregister(name: string): boolean {
+    return this.entries.delete(name);
+  }
+
+  get(name: string): IRag | undefined {
+    return this.entries.get(name)?.rag;
+  }
+
+  getEditor(name: string): IRagEditor | undefined {
+    return this.entries.get(name)?.editor;
+  }
+
+  list(): readonly RagCollectionMeta[] {
+    return Array.from(this.entries.values()).map((e) => e.meta);
+  }
+}

--- a/src/smart-agent/rag/strategies/edit/direct.ts
+++ b/src/smart-agent/rag/strategies/edit/direct.ts
@@ -1,0 +1,52 @@
+import type {
+  IIdStrategy,
+  IRagBackendWriter,
+  IRagEditor,
+} from '../../../interfaces/rag.js';
+import type {
+  CallOptions,
+  RagError,
+  RagMetadata,
+  Result,
+} from '../../../interfaces/types.js';
+import { MissingIdError } from '../../corrections/errors.js';
+
+export class DirectEditStrategy implements IRagEditor {
+  constructor(
+    protected readonly writer: IRagBackendWriter,
+    protected readonly idStrategy: IIdStrategy,
+  ) {}
+
+  async upsert(
+    text: string,
+    metadata: RagMetadata,
+    options?: CallOptions,
+  ): Promise<Result<{ id: string }, RagError>> {
+    let id: string;
+    try {
+      id = this.idStrategy.resolve(metadata, text);
+    } catch (e) {
+      if (e instanceof MissingIdError) return { ok: false, error: e };
+      throw e;
+    }
+    const res = await this.writer.upsertRaw(
+      id,
+      text,
+      { ...metadata, id },
+      options,
+    );
+    return res.ok ? { ok: true, value: { id } } : res;
+  }
+
+  async deleteById(
+    id: string,
+    options?: CallOptions,
+  ): Promise<Result<boolean, RagError>> {
+    return this.writer.deleteByIdRaw(id, options);
+  }
+
+  async clear(): Promise<Result<void, RagError>> {
+    if (this.writer.clearAll) return this.writer.clearAll();
+    return { ok: true, value: undefined };
+  }
+}

--- a/src/smart-agent/rag/strategies/edit/immutable.ts
+++ b/src/smart-agent/rag/strategies/edit/immutable.ts
@@ -1,0 +1,15 @@
+import type { IRagEditor } from '../../../interfaces/rag.js';
+import type { RagError, Result } from '../../../interfaces/types.js';
+import { ReadOnlyError } from '../../corrections/errors.js';
+
+export class ImmutableEditStrategy implements IRagEditor {
+  constructor(private readonly collectionName = 'immutable') {}
+
+  async upsert(): Promise<Result<{ id: string }, RagError>> {
+    return { ok: false, error: new ReadOnlyError(this.collectionName) };
+  }
+
+  async deleteById(): Promise<Result<boolean, RagError>> {
+    return { ok: false, error: new ReadOnlyError(this.collectionName) };
+  }
+}

--- a/src/smart-agent/rag/strategies/edit/index.ts
+++ b/src/smart-agent/rag/strategies/edit/index.ts
@@ -1,0 +1,2 @@
+export { DirectEditStrategy } from './direct.js';
+export { ImmutableEditStrategy } from './immutable.js';

--- a/src/smart-agent/rag/strategies/edit/index.ts
+++ b/src/smart-agent/rag/strategies/edit/index.ts
@@ -1,2 +1,4 @@
 export { DirectEditStrategy } from './direct.js';
 export { ImmutableEditStrategy } from './immutable.js';
+export { OverlayEditStrategy } from './overlay.js';
+export { SessionScopedEditStrategy } from './session-scoped.js';

--- a/src/smart-agent/rag/strategies/edit/overlay.ts
+++ b/src/smart-agent/rag/strategies/edit/overlay.ts
@@ -1,0 +1,7 @@
+import { DirectEditStrategy } from './direct.js';
+
+/**
+ * Write-only edit strategy that pairs with OverlayRag on the read side.
+ * Delegates to a single overlay writer; does not know about the base store.
+ */
+export class OverlayEditStrategy extends DirectEditStrategy {}

--- a/src/smart-agent/rag/strategies/edit/session-scoped.ts
+++ b/src/smart-agent/rag/strategies/edit/session-scoped.ts
@@ -1,0 +1,66 @@
+import type {
+  IIdStrategy,
+  IRagBackendWriter,
+  IRagEditor,
+} from '../../../interfaces/rag.js';
+import type {
+  CallOptions,
+  RagError,
+  RagMetadata,
+  Result,
+} from '../../../interfaces/types.js';
+import { MissingIdError } from '../../corrections/errors.js';
+
+/**
+ * Stamps sessionId (and createdAt if missing) on every write before delegating
+ * to the overlay writer. Pairs with SessionScopedRag on the read side.
+ */
+export class SessionScopedEditStrategy implements IRagEditor {
+  constructor(
+    private readonly writer: IRagBackendWriter,
+    private readonly sessionId: string,
+    private readonly idStrategy: IIdStrategy,
+    readonly _ttlMs?: number,
+  ) {}
+
+  async upsert(
+    text: string,
+    metadata: RagMetadata,
+    options?: CallOptions,
+  ): Promise<Result<{ id: string }, RagError>> {
+    const stamped: RagMetadata = {
+      ...metadata,
+      sessionId: this.sessionId,
+      createdAt:
+        typeof metadata.createdAt === 'number'
+          ? metadata.createdAt
+          : Date.now(),
+    };
+    let id: string;
+    try {
+      id = this.idStrategy.resolve(stamped, text);
+    } catch (e) {
+      if (e instanceof MissingIdError) return { ok: false, error: e };
+      throw e;
+    }
+    const res = await this.writer.upsertRaw(
+      id,
+      text,
+      { ...stamped, id },
+      options,
+    );
+    return res.ok ? { ok: true, value: { id } } : res;
+  }
+
+  async deleteById(
+    id: string,
+    options?: CallOptions,
+  ): Promise<Result<boolean, RagError>> {
+    return this.writer.deleteByIdRaw(id, options);
+  }
+
+  async clear(): Promise<Result<void, RagError>> {
+    if (this.writer.clearAll) return this.writer.clearAll();
+    return { ok: true, value: undefined };
+  }
+}

--- a/src/smart-agent/rag/strategies/id/caller-provided.ts
+++ b/src/smart-agent/rag/strategies/id/caller-provided.ts
@@ -1,0 +1,12 @@
+import type { IIdStrategy } from '../../../interfaces/rag.js';
+import type { RagMetadata } from '../../../interfaces/types.js';
+import { MissingIdError } from '../../corrections/errors.js';
+
+export class CallerProvidedIdStrategy implements IIdStrategy {
+  resolve(metadata: RagMetadata, _text: string): string {
+    if (typeof metadata.id !== 'string' || metadata.id.length === 0) {
+      throw new MissingIdError('CallerProvidedIdStrategy');
+    }
+    return metadata.id;
+  }
+}

--- a/src/smart-agent/rag/strategies/id/canonical-key.ts
+++ b/src/smart-agent/rag/strategies/id/canonical-key.ts
@@ -1,0 +1,17 @@
+import type { IIdStrategy } from '../../../interfaces/rag.js';
+import type { RagMetadata } from '../../../interfaces/types.js';
+import { MissingIdError } from '../../corrections/errors.js';
+
+export class CanonicalKeyIdStrategy implements IIdStrategy {
+  resolve(metadata: RagMetadata, _text: string): string {
+    const key = metadata.canonicalKey;
+    if (typeof key !== 'string' || key.length === 0) {
+      throw new MissingIdError('CanonicalKeyIdStrategy');
+    }
+    const version =
+      typeof metadata.version === 'number' && metadata.version > 0
+        ? metadata.version
+        : 1;
+    return `${key}:v${version}`;
+  }
+}

--- a/src/smart-agent/rag/strategies/id/global-unique.ts
+++ b/src/smart-agent/rag/strategies/id/global-unique.ts
@@ -1,0 +1,11 @@
+import { randomUUID } from 'node:crypto';
+import type { IIdStrategy } from '../../../interfaces/rag.js';
+import type { RagMetadata } from '../../../interfaces/types.js';
+
+export class GlobalUniqueIdStrategy implements IIdStrategy {
+  resolve(metadata: RagMetadata, _text: string): string {
+    return typeof metadata.id === 'string' && metadata.id.length > 0
+      ? metadata.id
+      : randomUUID();
+  }
+}

--- a/src/smart-agent/rag/strategies/id/index.ts
+++ b/src/smart-agent/rag/strategies/id/index.ts
@@ -1,0 +1,4 @@
+export { CallerProvidedIdStrategy } from './caller-provided.js';
+export { CanonicalKeyIdStrategy } from './canonical-key.js';
+export { GlobalUniqueIdStrategy } from './global-unique.js';
+export { SessionScopedIdStrategy } from './session-scoped.js';

--- a/src/smart-agent/rag/strategies/id/session-scoped.ts
+++ b/src/smart-agent/rag/strategies/id/session-scoped.ts
@@ -1,0 +1,15 @@
+import { randomUUID } from 'node:crypto';
+import type { IIdStrategy } from '../../../interfaces/rag.js';
+import type { RagMetadata } from '../../../interfaces/types.js';
+
+export class SessionScopedIdStrategy implements IIdStrategy {
+  constructor(private readonly sessionId: string) {}
+
+  resolve(metadata: RagMetadata, _text: string): string {
+    const suffix =
+      (typeof metadata.id === 'string' && metadata.id) ||
+      (typeof metadata.canonicalKey === 'string' && metadata.canonicalKey) ||
+      randomUUID();
+    return `${this.sessionId}:${suffix}`;
+  }
+}

--- a/src/smart-agent/rag/vector-rag.ts
+++ b/src/smart-agent/rag/vector-rag.ts
@@ -1,9 +1,5 @@
 import type { IQueryEmbedding } from '../interfaces/query-embedding.js';
-import type {
-  IEmbedder,
-  IPrecomputedVectorRag,
-  IRagBackendWriter,
-} from '../interfaces/rag.js';
+import type { IEmbedder, IRag, IRagBackendWriter } from '../interfaces/rag.js';
 import {
   type CallOptions,
   RagError,
@@ -45,7 +41,7 @@ export interface VectorRagConfig {
   documentEnrichers?: IDocumentEnricher[];
 }
 
-export class VectorRag implements IPrecomputedVectorRag {
+export class VectorRag implements IRag {
   private records: (StoredRecord | null)[] = [];
   private readonly index = new InvertedIndex();
   private readonly dedupThreshold: number;
@@ -321,6 +317,14 @@ export class VectorRag implements IPrecomputedVectorRag {
         this.records.length = 0;
         this.index.clear();
         return { ok: true, value: undefined };
+      },
+      upsertPrecomputedRaw: async (id, text, vector, metadata, options) => {
+        return this.upsertPrecomputed(
+          text,
+          vector,
+          { ...metadata, id },
+          options,
+        );
       },
     };
   }

--- a/src/smart-agent/rag/vector-rag.ts
+++ b/src/smart-agent/rag/vector-rag.ts
@@ -1,5 +1,9 @@
 import type { IQueryEmbedding } from '../interfaces/query-embedding.js';
-import type { IEmbedder, IPrecomputedVectorRag } from '../interfaces/rag.js';
+import type {
+  IEmbedder,
+  IPrecomputedVectorRag,
+  IRagBackendWriter,
+} from '../interfaces/rag.js';
 import {
   type CallOptions,
   RagError,
@@ -42,7 +46,7 @@ export interface VectorRagConfig {
 }
 
 export class VectorRag implements IPrecomputedVectorRag {
-  private records: StoredRecord[] = [];
+  private records: (StoredRecord | null)[] = [];
   private readonly index = new InvertedIndex();
   private readonly dedupThreshold: number;
   private readonly namespace?: string;
@@ -116,14 +120,13 @@ export class VectorRag implements IPrecomputedVectorRag {
     // Idempotent upsert: if metadata.id matches, replace in-place
     if (metadata.id) {
       for (let i = 0; i < this.records.length; i++) {
-        if (this.records[i].metadata.id === metadata.id) {
-          const oldTokens = this.tokenize(this.records[i].text);
-          this.records[i].text = text;
-          this.records[i].vector = vector;
-          this.records[i].metadata = {
-            ...this.records[i].metadata,
-            ...metadata,
-          };
+        const slot = this.records[i];
+        if (slot === null) continue;
+        if (slot.metadata.id === metadata.id) {
+          const oldTokens = this.tokenize(slot.text);
+          slot.text = text;
+          slot.vector = vector;
+          slot.metadata = { ...slot.metadata, ...metadata };
           this.index.update(i, oldTokens, newTokens);
           return { ok: true, value: undefined };
         }
@@ -131,20 +134,28 @@ export class VectorRag implements IPrecomputedVectorRag {
     }
 
     for (let i = 0; i < this.records.length; i++) {
-      const rec = this.records[i];
-      if (this.cosine(rec.vector, vector) >= this.dedupThreshold) {
-        const oldTokens = this.tokenize(rec.text);
-        rec.text = text;
-        rec.vector = vector;
-        rec.metadata = { ...rec.metadata, ...metadata };
+      const slot = this.records[i];
+      if (slot === null) continue;
+      if (this.cosine(slot.vector, vector) >= this.dedupThreshold) {
+        const oldTokens = this.tokenize(slot.text);
+        slot.text = text;
+        slot.vector = vector;
+        slot.metadata = { ...slot.metadata, ...metadata };
         this.index.update(i, oldTokens, newTokens);
         return { ok: true, value: undefined };
       }
     }
 
-    const docIdx = this.records.length;
-    this.records.push({ text, vector, metadata });
-    this.index.add(docIdx, newTokens);
+    // Reuse a tombstone slot if available
+    const freeIdx = this.records.indexOf(null);
+    if (freeIdx !== -1) {
+      this.records[freeIdx] = { text, vector, metadata };
+      this.index.add(freeIdx, newTokens);
+    } else {
+      const docIdx = this.records.length;
+      this.records.push({ text, vector, metadata });
+      this.index.add(docIdx, newTokens);
+    }
     return { ok: true, value: undefined };
   }
 
@@ -218,22 +229,20 @@ export class VectorRag implements IPrecomputedVectorRag {
       const queryVector = await effectiveEmbedding.toVector();
       const targetNamespace = options?.ragFilter?.namespace;
 
-      const filtered = this.records.filter((r) => {
-        if (r.metadata.ttl !== undefined && r.metadata.ttl < nowSecs)
-          return false;
-        if (
-          targetNamespace !== undefined &&
-          r.metadata.namespace !== targetNamespace
-        )
-          return false;
-        if (
-          this.namespace !== undefined &&
-          r.metadata.namespace !== undefined &&
-          r.metadata.namespace !== this.namespace
-        )
-          return false;
-        return true;
-      });
+      const filtered = this.records.filter(
+        (r): r is StoredRecord =>
+          r !== null &&
+          !(r.metadata.ttl !== undefined && r.metadata.ttl < nowSecs) &&
+          !(
+            targetNamespace !== undefined &&
+            r.metadata.namespace !== targetNamespace
+          ) &&
+          !(
+            this.namespace !== undefined &&
+            r.metadata.namespace !== undefined &&
+            r.metadata.namespace !== this.namespace
+          ),
+      );
 
       const candidates: ISearchCandidate[] = filtered.map((r) => ({
         text: r.text,
@@ -274,6 +283,46 @@ export class VectorRag implements IPrecomputedVectorRag {
         ),
       };
     }
+  }
+
+  async getById(
+    id: string,
+    _options?: CallOptions,
+  ): Promise<Result<RagResult | null, RagError>> {
+    for (const r of this.records) {
+      if (r !== null && r.metadata.id === id) {
+        return {
+          ok: true,
+          value: { text: r.text, metadata: r.metadata, score: 1 },
+        };
+      }
+    }
+    return { ok: true, value: null };
+  }
+
+  writer(): IRagBackendWriter {
+    return {
+      upsertRaw: async (id, text, metadata, options) => {
+        const res = await this.upsert(text, { ...metadata, id }, options);
+        return res.ok ? { ok: true, value: undefined } : res;
+      },
+      deleteByIdRaw: async (id) => {
+        for (let i = 0; i < this.records.length; i++) {
+          const r = this.records[i];
+          if (r !== null && r.metadata.id === id) {
+            this.index.remove(i, this.tokenize(r.text));
+            this.records[i] = null;
+            return { ok: true, value: true };
+          }
+        }
+        return { ok: true, value: false };
+      },
+      clearAll: async () => {
+        this.records.length = 0;
+        this.index.clear();
+        return { ok: true, value: undefined };
+      },
+    };
   }
 
   clear(): void {

--- a/src/smart-agent/resilience/__tests__/fallback-rag.test.ts
+++ b/src/smart-agent/resilience/__tests__/fallback-rag.test.ts
@@ -6,13 +6,15 @@ import { CircuitBreaker } from '../circuit-breaker.js';
 import { FallbackRag } from '../fallback-rag.js';
 
 describe('FallbackRag', () => {
-  it('upserts to both primary and fallback', async () => {
+  it('writer() upserts to both primary and fallback', async () => {
     const primary = makeRag();
     const fallback = makeRag();
     const breaker = new CircuitBreaker();
     const rag = new FallbackRag(primary, fallback, breaker);
 
-    await rag.upsert('test text', { id: 'x' });
+    const w = rag.writer();
+    assert.ok(w, 'writer() should return a writer');
+    await w?.upsertRaw('x', 'test text', {});
     assert.equal(primary.upsertCalls.length, 1);
     assert.equal(fallback.upsertCalls.length, 1);
   });
@@ -62,20 +64,42 @@ describe('FallbackRag', () => {
     assert.ok(result.ok);
   });
 
-  it('upsert returns primary result even if fallback fails', async () => {
+  it('writer() upsertRaw returns primary result even if fallback fails', async () => {
     const primary = makeRag();
-    // Fallback that throws
+    // Fallback whose writer throws
     const fallback = {
       ...makeRag(),
-      async upsert(): Promise<{ ok: true; value: undefined }> {
-        throw new Error('fallback down');
+      writer() {
+        return {
+          upsertRaw: async (): Promise<never> => {
+            throw new Error('fallback down');
+          },
+          deleteByIdRaw: async (): Promise<{ ok: true; value: false }> => ({
+            ok: true,
+            value: false,
+          }),
+        };
       },
     };
     const breaker = new CircuitBreaker();
     const rag = new FallbackRag(primary, fallback, breaker);
 
-    const result = await rag.upsert('text', {});
-    assert.ok(result.ok);
+    const w = rag.writer();
+    assert.ok(w, 'writer() should return a writer');
+    const result = w ? await w.upsertRaw('id1', 'text', {}) : undefined;
+    assert.ok(result?.ok);
     assert.equal(primary.upsertCalls.length, 1);
+  });
+
+  it('writer() returns undefined when neither primary nor fallback has a writer', async () => {
+    // makeRag returns a writer, so strip it to simulate no-writer RAGs
+    const primary = makeRag();
+    const fallback = makeRag();
+    // Override writer to return undefined
+    (primary as { writer?: () => undefined }).writer = () => undefined;
+    (fallback as { writer?: () => undefined }).writer = () => undefined;
+    const breaker = new CircuitBreaker();
+    const rag = new FallbackRag(primary, fallback, breaker);
+    assert.equal(rag.writer(), undefined);
   });
 });

--- a/src/smart-agent/resilience/fallback-rag.ts
+++ b/src/smart-agent/resilience/fallback-rag.ts
@@ -1,19 +1,17 @@
 /**
  * FallbackRag — IRag decorator wrapping a primary and fallback store.
  *
- * - **upsert** — always writes to both stores (best-effort for fallback).
+ * - **write** — writes go through writer(); fans out to both stores (best-effort for fallback).
  * - **query** — uses primary when the embedder breaker is closed/half-open;
  *   routes to fallback when the breaker is open.
  * - **healthCheck** — delegates to primary.
  */
 
 import type { IQueryEmbedding } from '../interfaces/query-embedding.js';
-import type { IRag } from '../interfaces/rag.js';
-import { supportsPrecomputed } from '../interfaces/rag.js';
+import type { IRag, IRagBackendWriter } from '../interfaces/rag.js';
 import type {
   CallOptions,
   RagError,
-  RagMetadata,
   RagResult,
   Result,
 } from '../interfaces/types.js';
@@ -26,16 +24,13 @@ export class FallbackRag implements IRag {
     private readonly embedderBreaker: CircuitBreaker,
   ) {}
 
-  async upsert(
-    text: string,
-    metadata: RagMetadata,
+  async getById(
+    id: string,
     options?: CallOptions,
-  ): Promise<Result<void, RagError>> {
-    const [primaryResult] = await Promise.all([
-      this.primary.upsert(text, metadata, options),
-      this.fallback.upsert(text, metadata, options).catch(() => {}),
-    ]);
-    return primaryResult;
+  ): Promise<Result<RagResult | null, RagError>> {
+    const res = await this.primary.getById(id, options);
+    if (res.ok && res.value !== null) return res;
+    return this.fallback.getById(id, options);
   }
 
   async query(
@@ -49,29 +44,51 @@ export class FallbackRag implements IRag {
     return this.primary.query(embedding, k, options);
   }
 
-  async upsertPrecomputed(
-    text: string,
-    vector: number[],
-    metadata: RagMetadata,
-    options?: CallOptions,
-  ): Promise<Result<void, RagError>> {
-    const primaryResult = supportsPrecomputed(this.primary)
-      ? await this.primary.upsertPrecomputed(text, vector, metadata, options)
-      : await this.primary.upsert(text, metadata, options);
-
-    // Best-effort write to fallback
-    if (supportsPrecomputed(this.fallback)) {
-      this.fallback
-        .upsertPrecomputed(text, vector, metadata, options)
-        .catch(() => {});
-    } else {
-      this.fallback.upsert(text, metadata, options).catch(() => {});
-    }
-
-    return primaryResult;
-  }
-
   async healthCheck(options?: CallOptions): Promise<Result<void, RagError>> {
     return this.primary.healthCheck(options);
+  }
+
+  writer(): IRagBackendWriter | undefined {
+    const pw = this.primary.writer?.();
+    const fw = this.fallback.writer?.();
+    if (!pw && !fw) return undefined;
+    return {
+      upsertRaw: async (id, text, metadata, options) => {
+        const pres = pw
+          ? await pw.upsertRaw(id, text, metadata, options)
+          : ({ ok: true, value: undefined } as const);
+        if (fw) fw.upsertRaw(id, text, metadata, options).catch(() => {});
+        return pres;
+      },
+      deleteByIdRaw: async (id, options) => {
+        const pres = pw
+          ? await pw.deleteByIdRaw(id, options)
+          : ({ ok: true, value: false } as const);
+        if (fw) fw.deleteByIdRaw(id, options).catch(() => {});
+        return pres;
+      },
+      clearAll: async () => {
+        const pres = pw?.clearAll
+          ? await pw.clearAll()
+          : ({ ok: true, value: undefined } as const);
+        if (fw?.clearAll) fw.clearAll().catch(() => {});
+        return pres;
+      },
+      upsertPrecomputedRaw: async (id, text, vector, metadata, options) => {
+        const pres = pw?.upsertPrecomputedRaw
+          ? await pw.upsertPrecomputedRaw(id, text, vector, metadata, options)
+          : pw
+            ? await pw.upsertRaw(id, text, metadata, options)
+            : ({ ok: true, value: undefined } as const);
+        if (fw?.upsertPrecomputedRaw) {
+          fw.upsertPrecomputedRaw(id, text, vector, metadata, options).catch(
+            () => {},
+          );
+        } else if (fw) {
+          fw.upsertRaw(id, text, metadata, options).catch(() => {});
+        }
+        return pres;
+      },
+    };
   }
 }

--- a/src/smart-agent/testing/index.ts
+++ b/src/smart-agent/testing/index.ts
@@ -144,12 +144,8 @@ export function makeRag(
   queryResults: RagResult[] = [],
 ): IRag & { upsertCalls: string[] } {
   const upsertCalls: string[] = [];
-  return {
+  const stub: IRag & { upsertCalls: string[] } = {
     upsertCalls,
-    async upsert(text: string): Promise<Result<void, RagError>> {
-      upsertCalls.push(text);
-      return { ok: true, value: undefined };
-    },
     async query(
       _embedding: IQueryEmbedding,
     ): Promise<Result<RagResult[], RagError>> {
@@ -158,17 +154,33 @@ export function makeRag(
     async healthCheck(): Promise<Result<void, RagError>> {
       return { ok: true, value: undefined };
     },
+    async getById(_id: string): Promise<Result<RagResult | null, RagError>> {
+      return { ok: true, value: null };
+    },
+    writer() {
+      return {
+        upsertRaw: async (
+          _id: string,
+          text: string,
+        ): Promise<Result<void, RagError>> => {
+          upsertCalls.push(text);
+          return { ok: true, value: undefined };
+        },
+        deleteByIdRaw: async (
+          _id: string,
+        ): Promise<Result<boolean, RagError>> => {
+          return { ok: true, value: false };
+        },
+      };
+    },
   };
+  return stub;
 }
 
 export function makeFailingRag(): IRag & { upsertCalls: string[] } {
   const upsertCalls: string[] = [];
-  return {
+  const stub: IRag & { upsertCalls: string[] } = {
     upsertCalls,
-    async upsert(text: string): Promise<Result<void, RagError>> {
-      upsertCalls.push(text);
-      return { ok: false, error: new RagError('Upsert failed') };
-    },
     async query(
       _embedding: IQueryEmbedding,
     ): Promise<Result<RagResult[], RagError>> {
@@ -177,10 +189,14 @@ export function makeFailingRag(): IRag & { upsertCalls: string[] } {
     async healthCheck(): Promise<Result<void, RagError>> {
       return { ok: false, error: new RagError('Health check failed') };
     },
+    async getById(_id: string): Promise<Result<RagResult | null, RagError>> {
+      return { ok: false, error: new RagError('getById failed') };
+    },
   };
+  return stub;
 }
 
-/** RAG stub that records metadata passed to upsert (for session-policy tests). */
+/** RAG stub that records metadata passed to writer().upsertRaw (for session-policy tests). */
 export function makeMetadataRag(queryResults: RagResult[] = []): IRag & {
   upsertCalls: string[];
   upsertMetadata: RagMetadata[];
@@ -189,18 +205,14 @@ export function makeMetadataRag(queryResults: RagResult[] = []): IRag & {
   const upsertCalls: string[] = [];
   const upsertMetadata: RagMetadata[] = [];
   const queryCalls: Array<{ text: string; k: number }> = [];
-  return {
+  const stub: IRag & {
+    upsertCalls: string[];
+    upsertMetadata: RagMetadata[];
+    queryCalls: Array<{ text: string; k: number }>;
+  } = {
     upsertCalls,
     upsertMetadata,
     queryCalls,
-    async upsert(
-      text: string,
-      metadata: RagMetadata,
-    ): Promise<Result<void, RagError>> {
-      upsertCalls.push(text);
-      upsertMetadata.push(metadata);
-      return { ok: true, value: undefined };
-    },
     async query(
       embedding: IQueryEmbedding,
       k: number,
@@ -211,7 +223,29 @@ export function makeMetadataRag(queryResults: RagResult[] = []): IRag & {
     async healthCheck(): Promise<Result<void, RagError>> {
       return { ok: true, value: undefined };
     },
+    async getById(_id: string): Promise<Result<RagResult | null, RagError>> {
+      return { ok: true, value: null };
+    },
+    writer() {
+      return {
+        upsertRaw: async (
+          id: string,
+          text: string,
+          metadata: RagMetadata,
+        ): Promise<Result<void, RagError>> => {
+          upsertCalls.push(text);
+          upsertMetadata.push({ ...metadata, id });
+          return { ok: true, value: undefined };
+        },
+        deleteByIdRaw: async (
+          _id: string,
+        ): Promise<Result<boolean, RagError>> => {
+          return { ok: true, value: false };
+        },
+      };
+    },
   };
+  return stub;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Splits `IRag` (read) from `IRagEditor` (write); introduces `IRagRegistry` with pluggable edit/id strategies, overlay reads, and a corrections layer. Resolves #103.
- `rag.upsert` / `rag.clear` are removed from the `IRag` interface — all writes now go through `IRagBackendWriter` obtained via `rag.writer()`. Concrete backends keep these as class-only helpers.
- Ships a pure-logic corrections module (`canonicalKey` / `tags` / `supersededBy`), `ActiveFilteringRag` wrapper, four edit strategies (Direct / Immutable / Overlay / SessionScoped), four id strategies (CallerProvided / GlobalUnique / SessionScoped / CanonicalKey), and a `buildRagCollectionToolEntries` MCP factory producing `rag_add` / `rag_correct` / `rag_deprecate` handlers.
- **Major version bump: 9.0.0** (breaking change).

## Architecture

Consumers (e.g. `cloud-llm-hub`) become thin adapters: register collections with appropriate edit strategies in `SimpleRagRegistry`, plug `buildRagCollectionToolEntries({ registry })` into their own MCP server, and let the LLM issue `rag_*` tool calls over MCP when skill content directs it. `llm-agent` ships only the mechanism — policy (when to correct, how to name collections) lives in consumer skills and prompts.

Collection provisioning stays **static** in this release — collections are registered at startup. Dynamic provisioning (`rag_create_collection` backed by an `IRagProvider`) is deferred to v9.1.0 so that the breaking API change ships in one tight PR.

## Design & plan

- Spec: `docs/superpowers/specs/2026-04-22-rag-registry-corrections-design.md`
- Plan: `docs/superpowers/plans/2026-04-22-rag-registry-and-corrections.md`
- Both are retained on the branch until merge per the updated spec/plan retention policy (delete after implementation is complete).

## Test plan

- [x] `tsc -p tsconfig.json` clean
- [x] `npx biome check src` — 277 files, no fixes
- [x] RAG + resilience test suite: 209/209 pass (new + existing)
- [ ] Manual smoke with a DeepSeek-configured consumer that exercises `rag_add` via an external MCP server (post-merge, downstream)

🤖 Generated with [Claude Code](https://claude.com/claude-code)