### PR TITLE
docs: update for v10 package split

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-`@mcp-abap-adt/llm-agent` currently contains two layers:
+`@mcp-abap-adt/llm-agent-server` currently contains two layers:
 
 1. **Legacy core (`src/agents`, `src/llm-providers`, `src/mcp`)**
 - Provider-specific agent implementations and direct MCP integration.
@@ -105,13 +105,13 @@ Files:
 For library embedding, YAML is not required. YAML is only a CLI/runtime convenience for `llm-agent`.
 
 Primary embeddable surfaces:
-- package export `@mcp-abap-adt/llm-agent/smart-server` -> `SmartServer`
-- package export `@mcp-abap-adt/llm-agent/testing` -> deterministic test doubles for consumer integration tests
+- package export `@mcp-abap-adt/llm-agent-server/smart-server` -> `SmartServer`
+- package export `@mcp-abap-adt/llm-agent-server/testing` -> deterministic test doubles for consumer integration tests
 
 Minimal programmatic integration:
 
 ```ts
-import { SmartServer } from '@mcp-abap-adt/llm-agent/smart-server';
+import { SmartServer } from '@mcp-abap-adt/llm-agent-server/smart-server';
 
 const server = new SmartServer({
   llm: {
@@ -651,7 +651,7 @@ classify → summarize
 A consumer can implement `IPipeline` to add stores and stages not present in `DefaultPipeline`:
 
 ```ts
-import type { IPipeline, PipelineDeps, PipelineResult, CallOptions, LlmStreamChunk } from '@mcp-abap-adt/llm-agent';
+import type { IPipeline, PipelineDeps, PipelineResult, CallOptions, LlmStreamChunk } from '@mcp-abap-adt/llm-agent-server';
 
 class MyPipeline implements IPipeline {
   initialize(deps: PipelineDeps): void { /* wire deps */ }
@@ -674,7 +674,7 @@ builder
 Consumers can register custom stage handlers via the builder:
 
 ```ts
-import type { IStageHandler, PipelineContext } from '@mcp-abap-adt/llm-agent';
+import type { IStageHandler, PipelineContext } from '@mcp-abap-adt/llm-agent-server';
 
 class AuditLogHandler implements IStageHandler {
   async execute(ctx: PipelineContext, config: Record<string, unknown>, span: ISpan): Promise<boolean> {

--- a/docs/ASSISTANT_GUIDELINES.md
+++ b/docs/ASSISTANT_GUIDELINES.md
@@ -7,10 +7,10 @@
 
 ## Current Project Snapshot
 
-- Package: `@mcp-abap-adt/llm-agent`
-- Version line: `1.1.x beta`
-- Main runtime: `src/smart-agent` (`SmartServer` + `SmartAgent`)
-- Public exports: `@mcp-abap-adt/llm-agent` (main), `@mcp-abap-adt/llm-agent/smart-server`, `@mcp-abap-adt/llm-agent/testing`, `@mcp-abap-adt/llm-agent/otel`
+- Packages: `@mcp-abap-adt/llm-agent` (core — interfaces, types, RAG impls) and `@mcp-abap-adt/llm-agent-server` (runtime — SmartAgent, LLM providers, MCP client, CLIs)
+- Version line: `10.x`
+- Main runtime: `src/smart-agent` (`SmartServer` + `SmartAgent`) — published as `@mcp-abap-adt/llm-agent-server`
+- Public exports: `@mcp-abap-adt/llm-agent` (core types/interfaces/RAG), `@mcp-abap-adt/llm-agent-server` (runtime), `@mcp-abap-adt/llm-agent-server/smart-server`, `@mcp-abap-adt/llm-agent-server/testing`, `@mcp-abap-adt/llm-agent-server/otel`
 
 Legacy modules under `src/agents`, `src/llm-providers`, and `src/mcp` are still present for compatibility and adapter reuse.
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,12 +1,12 @@
 # Deployment Guide
 
-This guide covers production deployment patterns for `@mcp-abap-adt/llm-agent`, including containerization, process management, serverless patterns, scaling strategies, and operational best practices.
+This guide covers production deployment patterns for `@mcp-abap-adt/llm-agent-server`, including containerization, process management, serverless patterns, scaling strategies, and operational best practices.
 
 ## Quick Start
 
 ```bash
 # 1. Install
-npm install @mcp-abap-adt/llm-agent
+npm install @mcp-abap-adt/llm-agent-server
 
 # 2. Generate config
 npx llm-agent --init   # creates smart-server.yaml
@@ -173,7 +173,7 @@ For file-based logging (when `log:` is set in `smart-server.yaml`), use `logrota
 For serverless environments, use `SmartAgent` programmatically without the HTTP layer:
 
 ```ts
-import { SmartAgentBuilder } from '@mcp-abap-adt/llm-agent';
+import { SmartAgentBuilder } from '@mcp-abap-adt/llm-agent-server';
 
 // Build once per cold start (or pool across invocations)
 const handle = await new SmartAgentBuilder({
@@ -268,7 +268,7 @@ Use this for load balancer health checks and Kubernetes liveness/readiness probe
 Export metrics via `InMemoryMetrics.snapshot()`:
 
 ```ts
-import { InMemoryMetrics } from '@mcp-abap-adt/llm-agent';
+import { InMemoryMetrics } from '@mcp-abap-adt/llm-agent-server';
 
 const metrics = new InMemoryMetrics();
 // Wire into SmartAgentBuilder via .withMetrics(metrics)
@@ -292,7 +292,7 @@ npm install @opentelemetry/api
 ```
 
 ```ts
-import { OtelTracerAdapter } from '@mcp-abap-adt/llm-agent/otel';
+import { OtelTracerAdapter } from '@mcp-abap-adt/llm-agent-server/otel';
 
 const tracer = new OtelTracerAdapter();
 // Wire into SmartAgentBuilder via .withTracer(tracer)

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -109,7 +109,7 @@ the pipeline. Use this to attach domain knowledge bases, user-specific indexes, 
 stores on demand:
 
 ```typescript
-import { SmartAgentBuilder } from '@mcp-abap-adt/llm-agent';
+import { SmartAgentBuilder } from '@mcp-abap-adt/llm-agent-server';
 
 const agent = await new SmartAgentBuilder()
   .withMainLlm(myLlm)
@@ -133,11 +133,8 @@ Use `QdrantRagProvider` so the LLM can create session-scoped collections on dema
 results, correct errors, and let the consumer clean up on disconnect:
 
 ```ts
-import {
-  SmartAgentBuilder,
-  QdrantRagProvider,
-  buildRagCollectionToolEntries,
-} from '@mcp-abap-adt/llm-agent';
+import { SmartAgentBuilder } from '@mcp-abap-adt/llm-agent-server';
+import { QdrantRagProvider, buildRagCollectionToolEntries } from '@mcp-abap-adt/llm-agent';
 
 // 1. Build agent with a Qdrant provider
 const { agent } = await new SmartAgentBuilder({ /* ... */ })
@@ -169,7 +166,7 @@ await agent.closeSession(sessionId);
 ### Programmatic embedding (`SmartServer`)
 
 ```ts
-import { SmartServer } from '@mcp-abap-adt/llm-agent/smart-server';
+import { SmartServer } from '@mcp-abap-adt/llm-agent-server/smart-server';
 
 const server = new SmartServer({
   port: 4004,
@@ -193,7 +190,7 @@ process.on('SIGTERM', async () => {
 ### Custom embedder injection
 
 ```ts
-import { SmartServer } from '@mcp-abap-adt/llm-agent/smart-server';
+import { SmartServer } from '@mcp-abap-adt/llm-agent-server/smart-server';
 
 const server = new SmartServer({
   llm: { apiKey: process.env.DEEPSEEK_API_KEY! },
@@ -209,8 +206,8 @@ const server = new SmartServer({
 ### Structured pipeline with custom stage handler
 
 ```ts
-import { SmartServer } from '@mcp-abap-adt/llm-agent/smart-server';
-import type { IStageHandler, PipelineContext, ISpan } from '@mcp-abap-adt/llm-agent';
+import { SmartServer } from '@mcp-abap-adt/llm-agent-server/smart-server';
+import type { IStageHandler, PipelineContext, ISpan } from '@mcp-abap-adt/llm-agent-server';
 
 class AuditLogHandler implements IStageHandler {
   async execute(ctx: PipelineContext, config: Record<string, unknown>, span: ISpan): Promise<boolean> {
@@ -247,7 +244,7 @@ import {
   SmartAgentBuilder,
   ClaudeSkillManager,
   FileSystemSkillManager,
-} from '@mcp-abap-adt/llm-agent';
+} from '@mcp-abap-adt/llm-agent-server';
 
 // Option 1: Claude-convention directories (~/.claude/skills/ + <project>/.claude/skills/)
 const builder = new SmartAgentBuilder()
@@ -382,8 +379,8 @@ Look for these log entries:
 ### Custom pipeline implementation
 
 ```ts
-import type { IPipeline, PipelineDeps, PipelineResult, CallOptions, LlmStreamChunk } from '@mcp-abap-adt/llm-agent';
-import { SmartAgentBuilder, DefaultPipeline } from '@mcp-abap-adt/llm-agent';
+import type { IPipeline, PipelineDeps, PipelineResult, CallOptions, LlmStreamChunk } from '@mcp-abap-adt/llm-agent-server';
+import { SmartAgentBuilder, DefaultPipeline } from '@mcp-abap-adt/llm-agent-server';
 
 // Extend the default pipeline by wrapping it
 class AuditedPipeline implements IPipeline {
@@ -422,7 +419,7 @@ agent:
 ## Test doubles for consumer integration tests
 
 ```ts
-import { makeLlm, makeMcpClient, makeRag } from '@mcp-abap-adt/llm-agent/testing';
+import { makeLlm, makeMcpClient, makeRag } from '@mcp-abap-adt/llm-agent-server/testing';
 
 const llm = makeLlm([{ content: 'ok' }]);
 const rag = makeRag();

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -1,6 +1,6 @@
 # Integration Guide
 
-This guide explains how to implement custom components for every pluggable interface in `@mcp-abap-adt/llm-agent`. Each interface has a description, method signatures, and a working code example.
+This guide explains how to implement custom components for every pluggable interface in `@mcp-abap-adt/llm-agent` and `@mcp-abap-adt/llm-agent-server`. Each interface has a description, method signatures, and a working code example.
 
 ## Architecture Overview
 
@@ -242,7 +242,7 @@ interface IModelResolver {
 Wraps `makeLlm()` with provider settings. Pass the same provider config used at startup:
 
 ```ts
-import { DefaultModelResolver, SmartServer } from '@mcp-abap-adt/llm-agent';
+import { DefaultModelResolver, SmartServer } from '@mcp-abap-adt/llm-agent-server';
 
 const server = new SmartServer({
   llm: { apiKey: process.env.OPENAI_API_KEY!, model: 'gpt-4o' },
@@ -430,7 +430,8 @@ When `translateQuery: true` is set, the pipeline translates the query to English
 **Example:**
 
 ```ts
-import { SmartAgentBuilder, QdrantRag } from '@mcp-abap-adt/llm-agent';
+import { SmartAgentBuilder } from '@mcp-abap-adt/llm-agent-server';
+import { QdrantRag } from '@mcp-abap-adt/llm-agent';
 
 const { agent } = await new SmartAgentBuilder({ mcp: { type: 'http', url: '...' } })
   .withMainLlm(myLlm)
@@ -546,11 +547,8 @@ class MyDbRagProvider extends AbstractRagProvider {
 ### Builder integration
 
 ```ts
-import {
-  SmartAgentBuilder,
-  QdrantRagProvider,
-  ImmutableEditStrategy,
-} from '@mcp-abap-adt/llm-agent';
+import { SmartAgentBuilder } from '@mcp-abap-adt/llm-agent-server';
+import { QdrantRagProvider, ImmutableEditStrategy } from '@mcp-abap-adt/llm-agent';
 
 const { agent } = await new SmartAgentBuilder({ /* ... */ })
   .withMainLlm(myLlm)
@@ -1075,7 +1073,7 @@ Subprompt types: `action`, `fact`, `chat`, `state`, `feedback`.
 ### Example: Rule-based classifier for simple use cases
 
 ```ts
-import type { ISubpromptClassifier } from '@mcp-abap-adt/llm-agent/smart-server';
+import type { ISubpromptClassifier } from '@mcp-abap-adt/llm-agent-server/smart-server';
 import type { Subprompt, ClassifierError, Result, CallOptions }
   from '@mcp-abap-adt/llm-agent';
 
@@ -1119,7 +1117,7 @@ interface IContextAssembler {
 ### Example: Custom context window packing strategy
 
 ```ts
-import type { IContextAssembler } from '@mcp-abap-adt/llm-agent/smart-server';
+import type { IContextAssembler } from '@mcp-abap-adt/llm-agent-server/smart-server';
 import type { Message, Subprompt, RagResult, McpTool, AssemblerError, Result, CallOptions }
   from '@mcp-abap-adt/llm-agent';
 
@@ -1238,7 +1236,7 @@ class DatabaseSkillManager implements ISkillManager {
 ### Wiring via builder
 
 ```ts
-import { SmartAgentBuilder, ClaudeSkillManager } from '@mcp-abap-adt/llm-agent';
+import { SmartAgentBuilder, ClaudeSkillManager } from '@mcp-abap-adt/llm-agent-server';
 
 const handle = await new SmartAgentBuilder({ mcp: { type: 'http', url: '...' } })
   .withMainLlm(myLlm)
@@ -1262,7 +1260,7 @@ skills:
 
 ```ts
 // In a plugin file:
-import { FileSystemSkillManager } from '@mcp-abap-adt/llm-agent';
+import { FileSystemSkillManager } from '@mcp-abap-adt/llm-agent-server';
 
 export const skillManager = new FileSystemSkillManager(['/opt/shared-skills']);
 ```
@@ -1337,9 +1335,9 @@ class AdapterValidationError extends Error {
 ### Example: custom adapter skeleton
 
 ```ts
-import type { ILlmApiAdapter, ApiRequestContext, ApiSseEvent, NormalizedRequest } from '@mcp-abap-adt/llm-agent';
-import type { SmartAgentResponse, OrchestratorError, LlmStreamChunk, Result } from '@mcp-abap-adt/llm-agent';
-import { AdapterValidationError } from '@mcp-abap-adt/llm-agent';
+import type { ILlmApiAdapter, ApiRequestContext, ApiSseEvent, NormalizedRequest } from '@mcp-abap-adt/llm-agent-server';
+import type { SmartAgentResponse, OrchestratorError, LlmStreamChunk, Result } from '@mcp-abap-adt/llm-agent-server';
+import { AdapterValidationError } from '@mcp-abap-adt/llm-agent-server';
 
 class MyProtocolAdapter implements ILlmApiAdapter {
   readonly name = 'my-protocol';
@@ -1411,7 +1409,7 @@ MCP clients can be injected via three paths (precedence: config > plugin > YAML)
 ### Via SmartServer config
 
 ```ts
-import { SmartServer, MCPClientWrapper, McpClientAdapter } from '@mcp-abap-adt/llm-agent';
+import { SmartServer, MCPClientWrapper, McpClientAdapter } from '@mcp-abap-adt/llm-agent-server';
 
 const wrapper = new MCPClientWrapper({ transport: 'auto', url: 'http://localhost:3001/mcp' });
 await wrapper.connect();
@@ -1427,7 +1425,7 @@ const server = new SmartServer({
 
 ```ts
 // plugins/lazy-mcp.mjs
-import { lazy, MCPClientWrapper, McpClientAdapter } from '@mcp-abap-adt/llm-agent';
+import { lazy, MCPClientWrapper, McpClientAdapter } from '@mcp-abap-adt/llm-agent-server';
 
 const url = process.env.MCP_SERVER_URL;
 
@@ -1482,7 +1480,7 @@ interface IMcpConnectionStrategy {
 import {
   LazyConnectionStrategy,
   SmartAgentBuilder,
-} from '@mcp-abap-adt/llm-agent';
+} from '@mcp-abap-adt/llm-agent-server';
 
 const mcpConfigs = [
   { type: 'http' as const, url: 'http://localhost:3001/mcp/stream/http' },
@@ -1507,14 +1505,14 @@ Controls how the tool-loop calls the LLM. Three built-in strategies:
 **1. `StreamingLlmCallStrategy`** (default) — uses `streamChat()`. Chunks streamed to client in real-time.
 
 ```ts
-import { StreamingLlmCallStrategy } from '@mcp-abap-adt/llm-agent';
+import { StreamingLlmCallStrategy } from '@mcp-abap-adt/llm-agent-server';
 builder.withLlmCallStrategy(new StreamingLlmCallStrategy());
 ```
 
 **2. `NonStreamingLlmCallStrategy`** — uses `chat()`. Full response yielded as a single chunk. Use when streaming is unreliable.
 
 ```ts
-import { NonStreamingLlmCallStrategy } from '@mcp-abap-adt/llm-agent';
+import { NonStreamingLlmCallStrategy } from '@mcp-abap-adt/llm-agent-server';
 builder.withLlmCallStrategy(new NonStreamingLlmCallStrategy());
 ```
 
@@ -1523,7 +1521,7 @@ For `sap-ai-sdk`, this is the recommended production strategy when SAP AI Core s
 **3. `FallbackLlmCallStrategy`** — starts with streaming. On error, logs the cause and automatically switches to `chat()` for the remaining iterations in the same request. Never loses the error cause.
 
 ```ts
-import { FallbackLlmCallStrategy } from '@mcp-abap-adt/llm-agent';
+import { FallbackLlmCallStrategy } from '@mcp-abap-adt/llm-agent-server';
 builder.withLlmCallStrategy(new FallbackLlmCallStrategy(logger));
 ```
 
@@ -1629,7 +1627,7 @@ All ILlm decorators (`NonStreamingLlm`, `RetryLlm`, `CircuitBreakerLlm`, `RateLi
 Swap LLM instances at runtime without restarting the server:
 
 ```typescript
-import { makeLlm } from '@mcp-abap-adt/llm-agent';
+import { makeLlm } from '@mcp-abap-adt/llm-agent-server';
 
 // Create a new classifier LLM
 const newClassifier = makeLlm(
@@ -1657,7 +1655,7 @@ console.log(agent.getActiveConfig());
 Throttle outbound LLM requests to stay within provider rate limits.
 
 ```ts
-import { TokenBucketRateLimiter } from '@mcp-abap-adt/llm-agent';
+import { TokenBucketRateLimiter } from '@mcp-abap-adt/llm-agent-server';
 
 builder.withRateLimiter(new TokenBucketRateLimiter({
   maxRequests: 10,     // max requests per window
@@ -1701,7 +1699,7 @@ interface ITracer {
 }
 ```
 
-Implementations: `NoopTracer` (default), `OtelTracerAdapter` (via `@mcp-abap-adt/llm-agent/otel`).
+Implementations: `NoopTracer` (default), `OtelTracerAdapter` (via `@mcp-abap-adt/llm-agent-server/otel`).
 
 ### ISessionManager
 
@@ -1793,11 +1791,8 @@ When set, only the last N non-system messages from client history are passed to 
 ### Full example
 
 ```ts
-import { SmartAgentBuilder } from '@mcp-abap-adt/llm-agent';
-import {
-  ToolCache, SessionManager, InMemoryMetrics,
-  OllamaEmbedder, QdrantRag,
-} from '@mcp-abap-adt/llm-agent';
+import { SmartAgentBuilder, ToolCache, SessionManager, InMemoryMetrics, OllamaEmbedder } from '@mcp-abap-adt/llm-agent-server';
+import { QdrantRag } from '@mcp-abap-adt/llm-agent';
 
 const metrics = new InMemoryMetrics();
 
@@ -1862,7 +1857,7 @@ await handle.close();
 For YAML-driven configs, inject a custom `IEmbedder` or register embedder factories:
 
 ```ts
-import { SmartServer } from '@mcp-abap-adt/llm-agent/smart-server';
+import { SmartServer } from '@mcp-abap-adt/llm-agent-server/smart-server';
 
 const server = new SmartServer({
   llm: { apiKey: process.env.API_KEY! },
@@ -1925,7 +1920,7 @@ import {
   SmartAgentBuilder,
   type StructuredPipelineDefinition,
   getDefaultStages,
-} from '@mcp-abap-adt/llm-agent';
+} from '@mcp-abap-adt/llm-agent-server';
 
 const pipeline: StructuredPipelineDefinition = {
   version: '1',
@@ -1981,8 +1976,8 @@ Supported operators: `!`, `&&`, `||`, `>`, `<`, `>=`, `<=`, `==`, `!=`
 Register custom handlers for domain-specific pipeline stages:
 
 ```ts
-import type { IStageHandler, PipelineContext } from '@mcp-abap-adt/llm-agent';
-import type { ISpan } from '@mcp-abap-adt/llm-agent';
+import type { IStageHandler, PipelineContext } from '@mcp-abap-adt/llm-agent-server';
+import type { ISpan } from '@mcp-abap-adt/llm-agent-server';
 
 class ContentFilterHandler implements IStageHandler {
   async execute(
@@ -2072,7 +2067,7 @@ pipeline:
 ### Using Default Stages as Base
 
 ```ts
-import { getDefaultStages } from '@mcp-abap-adt/llm-agent';
+import { getDefaultStages } from '@mcp-abap-adt/llm-agent-server';
 
 // Get default stages and insert a custom stage before tool-loop
 const stages = getDefaultStages();
@@ -2127,7 +2122,7 @@ Drop plugin files into a directory. SmartServer scans and loads them at startup.
 **Example plugin file** (`~/.config/llm-agent/plugins/audit-log.ts`):
 
 ```ts
-import type { IStageHandler, PipelineContext, ISpan } from '@mcp-abap-adt/llm-agent';
+import type { IStageHandler, PipelineContext, ISpan } from '@mcp-abap-adt/llm-agent-server';
 
 class AuditLogHandler implements IStageHandler {
   async execute(ctx: PipelineContext, config: Record<string, unknown>, span: ISpan) {
@@ -2159,7 +2154,7 @@ pipeline:
 **Programmatic usage:**
 
 ```ts
-import { FileSystemPluginLoader, getDefaultPluginDirs } from '@mcp-abap-adt/llm-agent';
+import { FileSystemPluginLoader, getDefaultPluginDirs } from '@mcp-abap-adt/llm-agent-server';
 
 const loader = new FileSystemPluginLoader({
   dirs: [...getDefaultPluginDirs(), './my-extra-plugins'],
@@ -2179,7 +2174,7 @@ import {
   LoadedPlugins,
   emptyLoadedPlugins,
   mergePluginExports,
-} from '@mcp-abap-adt/llm-agent';
+} from '@mcp-abap-adt/llm-agent-server';
 
 class NpmPluginLoader implements IPluginLoader {
   constructor(private packages: string[]) {}
@@ -2272,7 +2267,7 @@ See [`docs/examples/plugins/`](examples/plugins/) for 6 complete plugin examples
 
 ## Test Doubles
 
-The library exports comprehensive test double factories via `@mcp-abap-adt/llm-agent/testing`:
+The library exports comprehensive test double factories via `@mcp-abap-adt/llm-agent-server/testing`:
 
 ```ts
 import {
@@ -2290,7 +2285,7 @@ import {
   makeOutputValidator,
   makeSessionManager,
   makeDefaultDeps,
-} from '@mcp-abap-adt/llm-agent/testing';
+} from '@mcp-abap-adt/llm-agent-server/testing';
 ```
 
 ### Example: Testing a custom validator
@@ -2298,7 +2293,7 @@ import {
 ```ts
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { makeLlm, makeDefaultDeps } from '@mcp-abap-adt/llm-agent/testing';
+import { makeLlm, makeDefaultDeps } from '@mcp-abap-adt/llm-agent-server/testing';
 
 describe('JsonSchemaValidator', () => {
   it('rejects invalid JSON', async () => {

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -11,7 +11,7 @@ OpenAI-compatible client (Cline, Cursor, Continue) to it and use it as a drop-in
 ## Install
 
 ```bash
-npm install -g @mcp-abap-adt/llm-agent
+npm install -g @mcp-abap-adt/llm-agent-server
 ```
 
 Or run from source:
@@ -225,7 +225,8 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for full pipeline and programma
 Let the LLM create temporary collections scoped to a session:
 
 ```ts
-import { SmartAgentBuilder, InMemoryRagProvider } from '@mcp-abap-adt/llm-agent';
+import { SmartAgentBuilder } from '@mcp-abap-adt/llm-agent-server';
+import { InMemoryRagProvider } from '@mcp-abap-adt/llm-agent';
 
 const { agent } = await new SmartAgentBuilder({ /* ... */ })
   .withMainLlm(myLlm)

--- a/docs/SAP_AI_CORE.md
+++ b/docs/SAP_AI_CORE.md
@@ -54,7 +54,7 @@ The `@sap-ai-sdk/orchestration` package reads this variable automatically. No ad
 For environments where you cannot set environment variables (e.g., multi-tenant apps, serverless functions), pass credentials programmatically:
 
 ```typescript
-import { SapCoreAIProvider, type SapAICoreCredentials } from '@mcp-abap-adt/llm-agent';
+import { SapCoreAIProvider, type SapAICoreCredentials } from '@mcp-abap-adt/llm-agent-server';
 
 const credentials: SapAICoreCredentials = {
   clientId: 'sb-xxx...',
@@ -112,7 +112,7 @@ npm run dev
 ### Programmatic Usage — Basic
 
 ```typescript
-import { SapCoreAIProvider, SapCoreAIAgent } from '@mcp-abap-adt/llm-agent';
+import { SapCoreAIProvider, SapCoreAIAgent } from '@mcp-abap-adt/llm-agent-server';
 
 const provider = new SapCoreAIProvider({
   model: 'gpt-4o',
@@ -131,7 +131,7 @@ const response = await agent.process('What tools are available?');
 ### Programmatic Usage — With Credentials
 
 ```typescript
-import { SapCoreAIProvider, SapCoreAIAgent } from '@mcp-abap-adt/llm-agent';
+import { SapCoreAIProvider, SapCoreAIAgent } from '@mcp-abap-adt/llm-agent-server';
 
 const provider = new SapCoreAIProvider({
   model: 'claude-3-5-sonnet',

--- a/docs/examples/plugins/01-audit-log.ts
+++ b/docs/examples/plugins/01-audit-log.ts
@@ -22,7 +22,7 @@ import type {
   ISpan,
   IStageHandler,
   PipelineContext,
-} from '@mcp-abap-adt/llm-agent';
+} from '@mcp-abap-adt/llm-agent-server';
 
 class AuditLogHandler implements IStageHandler {
   async execute(

--- a/docs/examples/plugins/04-rate-limiter.ts
+++ b/docs/examples/plugins/04-rate-limiter.ts
@@ -22,7 +22,7 @@ import type {
   ISpan,
   IStageHandler,
   PipelineContext,
-} from '@mcp-abap-adt/llm-agent';
+} from '@mcp-abap-adt/llm-agent-server';
 
 /** Sliding window entry: timestamp of each request */
 const sessionWindows = new Map<string, number[]>();

--- a/docs/examples/plugins/06-multi-export.ts
+++ b/docs/examples/plugins/06-multi-export.ts
@@ -21,15 +21,8 @@
  *       - { id: timing-end, type: request-timer-end }
  */
 
-import type {
-  CallOptions,
-  IQueryExpander,
-  ISpan,
-  IStageHandler,
-  PipelineContext,
-  RagError,
-  Result,
-} from '@mcp-abap-adt/llm-agent';
+import type { ISpan, IStageHandler, PipelineContext } from '@mcp-abap-adt/llm-agent-server';
+import type { CallOptions, IQueryExpander, RagError, Result } from '@mcp-abap-adt/llm-agent';
 
 // ---------------------------------------------------------------------------
 // Stage handler 1: request-timer-start — records pipeline start time


### PR DESCRIPTION
## Summary

- Rewrites all `@mcp-abap-adt/llm-agent` import and install references in user-facing docs to correctly reflect the v10 monorepo split into `@mcp-abap-adt/llm-agent` (core) and `@mcp-abap-adt/llm-agent-server` (runtime).
- `npm install` / `npx` commands updated to `@mcp-abap-adt/llm-agent-server`.
- Sub-path exports `/smart-server`, `/testing`, `/otel` rewritten to `@mcp-abap-adt/llm-agent-server/…`.
- Mixed import statements (core + server symbols in one line) split into two separate imports.
- Core-only symbols (`IRag`, `ILlm`, `IEmbedder`, RAG implementations, strategies, errors, `buildRagCollectionToolEntries`, etc.) left pointing at `@mcp-abap-adt/llm-agent`.
- `docs/ASSISTANT_GUIDELINES.md` updated to reflect dual-package structure.
- `docs/MIGRATION-v10.md` and `docs/superpowers/` untouched per task rules.

## Test plan

- [x] `npm run lint:check` — clean (Biome checks `packages/` only, not `docs/`)
- [x] `npm run build` — pre-existing TS error in `smart-server.ts` (unrelated to doc changes), no new errors
- [x] Manual grep: no remaining `npm install @mcp-abap-adt/llm-agent[^-]` or `npx @mcp-abap-adt/llm-agent[^-]` outside MIGRATION-v10.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)