### PR TITLE
fix(ci): ensure server prebuild runs before tsc -b

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.0",
   "workspaces": ["packages/*"],
   "scripts": {
+    "prebuild": "npm run --workspace @mcp-abap-adt/llm-agent-server prebuild",
     "build": "tsc -b packages/llm-agent packages/llm-agent-server",
     "clean": "tsc -b --clean packages/llm-agent packages/llm-agent-server",
     "lint": "biome check --write packages",


### PR DESCRIPTION
Root tsc -b bypassed per-package prebuild → generated/version.ts missing in CI → TS2307. Fixed by adding a root prebuild that delegates to the server workspace.