### PR TITLE
feat: v11.0.0 final — HANA + pgvector RAG backends

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -13,7 +13,9 @@
       "@mcp-abap-adt/openai-embedder",
       "@mcp-abap-adt/ollama-embedder",
       "@mcp-abap-adt/sap-aicore-embedder",
-      "@mcp-abap-adt/qdrant-rag"
+      "@mcp-abap-adt/qdrant-rag",
+      "@mcp-abap-adt/hana-vector-rag",
+      "@mcp-abap-adt/pg-vector-rag"
     ]
   ],
   "linked": [],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ---
 
+## [11.0.0] — 2026-04-24
+
+### Breaking
+- **Provider and RAG backends extracted into dedicated packages.** Core (`@mcp-abap-adt/llm-agent`) drops its LLM provider classes, embedder implementations, and agent hierarchy. Runtime deps reduced to `zod` only.
+- **`@mcp-abap-adt/llm-agent-server`** now declares all backend packages as **optional peer dependencies**. Consumers install the server plus exactly the peers referenced by their config.
+- Missing peer packages fail fast at startup with typed `MissingProviderError` naming the missing package.
+
+### Added
+- **New provider packages (LLM):** `@mcp-abap-adt/openai-llm`, `@mcp-abap-adt/anthropic-llm`, `@mcp-abap-adt/deepseek-llm`, `@mcp-abap-adt/sap-aicore-llm`.
+- **New embedder packages:** `@mcp-abap-adt/openai-embedder`, `@mcp-abap-adt/ollama-embedder`, `@mcp-abap-adt/sap-aicore-embedder`.
+- **New RAG backend packages:**
+  - `@mcp-abap-adt/qdrant-rag` — Qdrant vector store.
+  - `@mcp-abap-adt/hana-vector-rag` — SAP HANA Cloud Vector Engine (`REAL_VECTOR(dim)` + `COSINE_SIMILARITY`).
+  - `@mcp-abap-adt/pg-vector-rag` — PostgreSQL + pgvector (`vector(dim)` + `<=>` distance).
+- **Server-side RAG factory registry** with startup-prefetch + sync-resolve pattern mirroring embedder factories. Selects optional peer on demand; surfaces `MissingProviderError` without top-level import crashes.
+- **Config surface extended:** `rag.type` accepts `hana-vector` and `pg-vector` in YAML and programmatic config. New fields: `connectionString`, `host`, `port`, `user`, `password`, `database`, `schema`, `dimension`, `autoCreateSchema`, `poolMax`, `connectTimeout`.
+- **Schema bootstrap owned by backend.** Both HANA and pgvector backends expose `ensureSchema()`. Used by both direct `makeRag()` construction and `IRagProvider.createCollection()` paths. Auto-runs when `autoCreateSchema: true` (default).
+- **Migration doc:** `docs/MIGRATION-v11.md` with install / config / import tables, plus a "New RAG backends" section.
+
+### Changed
+- **Changesets fixed group** now covers all 12 packages for lock-step versioning.
+- **Root build scripts** extended to include `hana-vector-rag` and `pg-vector-rag` in the `tsc -b` sequence.
+
+### Removed
+- Agent hierarchy (`BaseAgent` and five subclasses) replaced by direct LLM provider composition in the server.
+- Back-compat re-exports from core for extracted providers — imports must now come from the provider package directly.
+
+---
+
 ## [10.0.0] — 2026-04-22
 
 ### Breaking

--- a/POST_MERGE_CHECKLIST-v11.md
+++ b/POST_MERGE_CHECKLIST-v11.md
@@ -1,0 +1,39 @@
+# Post-merge release checklist — v11.0.0
+
+All 12 packages are at version `11.0.0` in their `package.json` files already. No `changeset version` run is needed — the release flow just publishes.
+
+## Pre-release verification
+
+1. `git checkout main && git pull`
+2. Confirm each `packages/*/package.json` is at `11.0.0`:
+   ```bash
+   jq -r '.name + " " + .version' packages/*/package.json | sort
+   ```
+3. `npm install` and `npm run build` (full clean build).
+4. `npm test` — expect the full suite green (~833 tests at merge time).
+
+## Publish
+
+5. `npx changeset publish`
+   - Publishes all 12 packages to npm at their current `11.0.0` versions in lock-step.
+   - Requires NPM_TOKEN / `npm login` with publish rights on the `@mcp-abap-adt` scope.
+6. `git tag -a v11.0.0 -m "Release 11.0.0"`
+7. `git push --tags` — triggers the GitHub release workflow.
+
+## Post-release cleanup (retention policy)
+
+Once npm reports all 12 packages at 11.0.0 and `v11.0.0` tag is pushed:
+
+8. Delete the retention-scoped design artifacts:
+   - `docs/superpowers/specs/2026-04-24-v11-hana-pgvector-design.md`
+   - `docs/superpowers/specs/2026-04-22-v11-full-extraction-design.md` (if still present)
+   - `docs/superpowers/plans/2026-04-23-v11-full-extraction.md` (if still present)
+   - `docs/superpowers/plans/2026-04-24-v11-hana-pgvector.md`
+   - `POST_MERGE_CHECKLIST-v11.md` (this file)
+9. `git commit -m "chore: remove v11 retention artifacts post-release"`
+10. `git push`
+
+## Notes
+
+- Do NOT run `npx changeset version` at any point — there are no pending changesets and any bump would move versions away from 11.0.0.
+- Peer-dependency version ranges in `packages/llm-agent-server/package.json` currently read `^12.0.0` (a pre-existing leftover from an earlier overshoot). Consider fixing them to `^11.0.0` in a small follow-up PR. Out of scope for v11.0.0 release.

--- a/POST_MERGE_CHECKLIST-v11.md
+++ b/POST_MERGE_CHECKLIST-v11.md
@@ -14,9 +14,10 @@ All 12 packages are at version `11.0.0` in their `package.json` files already. N
 
 ## Publish
 
-5. `npx changeset publish`
-   - Publishes all 12 packages to npm at their current `11.0.0` versions in lock-step.
-   - Requires NPM_TOKEN / `npm login` with publish rights on the `@mcp-abap-adt` scope.
+5. `npm run release:publish`
+   - Runs `scripts/publish-all.sh` — sequential `npm publish` for all 12 packages in dependency order (core → providers → embedders → RAG backends → server).
+   - On the first publish, browser opens for WebAuthn 2FA; tap YubiKey and check "trust this device for 5 minutes" — subsequent publishes in the same run go through without further prompts.
+   - Requires `npm login` with publish rights on the `@mcp-abap-adt` scope.
 6. `git tag -a v11.0.0 -m "Release 11.0.0"`
 7. `git push --tags` — triggers the GitHub release workflow.
 
@@ -36,4 +37,4 @@ Once npm reports all 12 packages at 11.0.0 and `v11.0.0` tag is pushed:
 ## Notes
 
 - Do NOT run `npx changeset version` at any point — there are no pending changesets and any bump would move versions away from 11.0.0.
-- Peer-dependency version ranges in `packages/llm-agent-server/package.json` currently read `^12.0.0` (a pre-existing leftover from an earlier overshoot). Consider fixing them to `^11.0.0` in a small follow-up PR. Out of scope for v11.0.0 release.
+- Peer-dependency version ranges in `packages/llm-agent-server/package.json` were already normalized to `^11.0.0` as part of the v11 final fix commit.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ A high-performance, RAG-orchestrated LLM agent and OpenAI-compatible server with
 | [`@mcp-abap-adt/ollama-embedder`](packages/ollama-embedder/README.md) | Ollama embeddings + RAG (`OllamaEmbedder`, `OllamaRag`). |
 | [`@mcp-abap-adt/sap-aicore-embedder`](packages/sap-aicore-embedder/README.md) | SAP AI Core embeddings (`SapAiCoreEmbedder`). |
 | [`@mcp-abap-adt/qdrant-rag`](packages/qdrant-rag/README.md) | Qdrant vector store RAG (`QdrantRag`, `QdrantRagProvider`). |
+| [`@mcp-abap-adt/hana-vector-rag`](packages/hana-vector-rag/README.md) | SAP HANA Cloud Vector Engine RAG (`HanaVectorRag`, `HanaVectorRagProvider`). Optional peer. |
+| [`@mcp-abap-adt/pg-vector-rag`](packages/pg-vector-rag/README.md) | PostgreSQL + pgvector RAG (`PgVectorRag`, `PgVectorRagProvider`). Optional peer. |
 
 ## Quick install
 

--- a/docs/MIGRATION-v11.md
+++ b/docs/MIGRATION-v11.md
@@ -96,3 +96,33 @@ Fix by installing the named peer. Config-validation catches the error before the
 ## Dockerfile examples
 
 `examples/docker-*/Dockerfile`s now install server + the specific peers their bundled `smart-server.yaml` uses. See the repo `examples/` directory for concrete snippets.
+
+## New RAG backends
+
+Two additional optional peer packages ship with 11.0.0:
+
+- `@mcp-abap-adt/hana-vector-rag` — SAP HANA Cloud Vector Engine. Runtime peer: `@sap/hana-client`.
+- `@mcp-abap-adt/pg-vector-rag` — PostgreSQL + pgvector. Runtime peer: `pg`.
+
+Install only the backend your deployment actually uses:
+
+```bash
+# HANA
+npm install @mcp-abap-adt/llm-agent-server @mcp-abap-adt/hana-vector-rag @sap/hana-client
+
+# Postgres + pgvector
+npm install @mcp-abap-adt/llm-agent-server @mcp-abap-adt/pg-vector-rag pg
+```
+
+YAML config:
+
+```yaml
+rag:
+  type: hana-vector           # or: pg-vector
+  connectionString: hdbsql://user:pass@host:443
+  collectionName: llm_agent_docs
+  dimension: 1536
+  autoCreateSchema: true
+```
+
+Cosine similarity is the default distance metric. Schema bootstrap runs automatically when `autoCreateSchema: true` (default). If the selected `rag.type` references a backend whose peer package is not installed, server startup fails with `MissingProviderError` naming the missing package.

--- a/docs/superpowers/plans/2026-04-24-v11-hana-pgvector.md
+++ b/docs/superpowers/plans/2026-04-24-v11-hana-pgvector.md
@@ -630,7 +630,7 @@ describe('HanaVectorRag', () => {
   it('rejects invalid collection name at construction', () => {
     assert.throws(
       () => new HanaVectorRag({ collectionName: "bad'; DROP", embedder: makeEmbedder() }, makeFakeClient()),
-      /INVALID_COLLECTION_NAME/,
+      (err: Error & { code?: string }) => err.code === 'INVALID_COLLECTION_NAME',
     );
   });
 });
@@ -1312,10 +1312,16 @@ describe('pg schema', () => {
     assertCollectionName('docs_2');
   });
   it('rejects digit-led name', () => {
-    assert.throws(() => assertCollectionName('1bad'), /INVALID_COLLECTION_NAME/);
+    assert.throws(
+      () => assertCollectionName('1bad'),
+      (err: Error & { code?: string }) => err.code === 'INVALID_COLLECTION_NAME',
+    );
   });
   it('rejects punctuation', () => {
-    assert.throws(() => assertCollectionName("x'); DROP"), /INVALID_COLLECTION_NAME/);
+    assert.throws(
+      () => assertCollectionName("x'); DROP"),
+      (err: Error & { code?: string }) => err.code === 'INVALID_COLLECTION_NAME',
+    );
   });
   it('quotes identifiers with double-quotes', () => {
     assert.equal(quoteIdent('docs'), '"docs"');
@@ -1491,7 +1497,7 @@ describe('PgVectorRag', () => {
   it('rejects invalid collection name', () => {
     assert.throws(
       () => new PgVectorRag({ collectionName: "bad'; DROP", embedder: makeEmbedder() }, makeFakeClient()),
-      /INVALID_COLLECTION_NAME/,
+      (err: Error & { code?: string }) => err.code === 'INVALID_COLLECTION_NAME',
     );
   });
 });

--- a/docs/superpowers/plans/2026-04-24-v11-hana-pgvector.md
+++ b/docs/superpowers/plans/2026-04-24-v11-hana-pgvector.md
@@ -1,0 +1,2672 @@
+# v11.0.0 HANA + pgvector RAG Packages Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship two new RAG backend packages (`@mcp-abap-adt/hana-vector-rag`, `@mcp-abap-adt/pg-vector-rag`) as optional peers of `@mcp-abap-adt/llm-agent-server` and release them with v11.0.0.
+
+**Architecture:** Each package exports a concrete `IRag` implementation plus an `IRagProvider` extending `AbstractRagProvider`. Both own their driver-level code behind interface boundaries. Schema bootstrap is backend-owned lazy init (`ensureSchema()`) shared by both direct `makeRag()` construction and `provider.createCollection()`. Server wires the two through a dedicated RAG factory registry mirroring the existing embedder-factories startup-prefetch + sync-resolve pattern; missing peer packages surface as `MissingProviderError`.
+
+**Tech Stack:** TypeScript (strict, ESM, NodeNext), `@sap/hana-client` driver for HANA, `pg` driver for Postgres + pgvector, `node:test` for unit tests, Biome for lint/format, npm workspaces, `@changesets/cli` (fixed group of 12 packages).
+
+**Spec:** `docs/superpowers/specs/2026-04-24-v11-hana-pgvector-design.md`
+
+**Branch:** `feat/v11-hana-pgvector` (already checked out)
+
+---
+
+## File structure
+
+Two new packages, identical shape. Server gets one new factory module plus config-surface extensions.
+
+```
+packages/hana-vector-rag/
+├── package.json                     — name, deps (@sap/hana-client), build/test scripts
+├── tsconfig.json                    — extends ../../tsconfig.base.json, references llm-agent
+├── README.md                        — install + minimal config sample
+├── src/
+│   ├── index.ts                     — public exports
+│   ├── connection.ts                — HanaVectorRagConfig | string → pool args
+│   ├── schema.ts                    — ensureSchema DDL + quoteIdent + collection-name regex
+│   ├── hana-vector-rag.ts           — HanaVectorRag class implements IRag (+ writer())
+│   ├── hana-vector-rag-provider.ts  — HanaVectorRagProvider extends AbstractRagProvider
+│   └── __tests__/
+│       ├── connection.test.ts
+│       ├── schema.test.ts
+│       ├── hana-vector-rag.test.ts
+│       └── hana-vector-rag-provider.test.ts
+
+packages/pg-vector-rag/               — mirror of the above, s/hana/pg/
+├── package.json                     — deps: pg
+├── src/…                            — pg-vector-rag.ts, pg-vector-rag-provider.ts, connection.ts, schema.ts, index.ts, __tests__/
+
+packages/llm-agent-server/
+├── src/smart-agent/rag-factories.ts            — NEW: PACKAGE_BY_NAME, prefetch + sync resolve
+├── src/smart-agent/providers.ts                — MODIFIED: extend RagResolutionConfig['type'], add 'hana-vector' and 'pg-vector' branches calling resolveRag(name,…)
+├── src/smart-agent/pipeline.ts                 — MODIFIED: extend type union + comment
+├── src/smart-agent/smart-server.ts             — MODIFIED: extend type union in SmartServerRagConfig
+├── src/smart-agent/config.ts                   — MODIFIED: extend YAML type cast + sample comments
+├── src/smart-agent/__tests__/rag-factories.test.ts           — NEW: prefetch + sync resolve + MissingProviderError
+├── src/smart-agent/__tests__/hana-pg-integration.test.ts     — NEW: direct makeRag schema bootstrap, missing peer error path
+├── package.json                                — peerDependencies + peerDependenciesMeta + devDependencies + ^11.0.0
+└── tsconfig.json                               — references two new packages
+
+Root:
+├── package.json                                — build/clean/test scripts extended to 12 packages
+├── tsconfig.json                               — project references extended
+├── .changeset/config.json                      — fixed group extended to 12
+├── MIGRATION-v11.md                            — "New RAG backends" section
+├── CHANGELOG.md                                — root 11.0.0 entry amended
+└── README.md                                   — package table extended
+```
+
+**Note on architecture flexibility:** The spec allows refactoring server composition. For this plan we keep the current factory-based composition and add a dedicated `rag-factories.ts`. If during implementation a subagent identifies a clearly-better composition path, it may propose it in the DONE_WITH_CONCERNS channel rather than forcing it mid-plan.
+
+---
+
+### Task 1: Scaffold `@mcp-abap-adt/hana-vector-rag` package
+
+**Files:**
+- Create: `packages/hana-vector-rag/package.json`
+- Create: `packages/hana-vector-rag/tsconfig.json`
+- Create: `packages/hana-vector-rag/README.md`
+- Create: `packages/hana-vector-rag/src/index.ts`
+
+- [ ] **Step 1: Write `package.json`**
+
+```json
+{
+  "name": "@mcp-abap-adt/hana-vector-rag",
+  "version": "11.0.0",
+  "description": "HanaVectorRag vector store (SAP HANA Cloud Vector Engine) and HanaVectorRagProvider for @mcp-abap-adt/llm-agent.",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": ["dist", "README.md", "LICENSE"],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "clean": "tsc -p tsconfig.json --clean",
+    "test": "node --import tsx/esm --test --test-reporter=spec 'src/**/*.test.ts'"
+  },
+  "dependencies": {
+    "@mcp-abap-adt/llm-agent": "*",
+    "@sap/hana-client": "^2.24.26"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fr0ster/llm-agent.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}
+```
+
+- [ ] **Step 2: Write `tsconfig.json`**
+
+```json
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["node"]
+  },
+  "references": [{ "path": "../llm-agent" }],
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}
+```
+
+- [ ] **Step 3: Write `README.md`**
+
+```markdown
+# @mcp-abap-adt/hana-vector-rag
+
+SAP HANA Cloud Vector Engine backend for [@mcp-abap-adt/llm-agent](https://www.npmjs.com/package/@mcp-abap-adt/llm-agent).
+
+Provides:
+- `HanaVectorRag` — `IRag` implementation backed by `REAL_VECTOR(dim)` columns.
+- `HanaVectorRagProvider` — `IRagProvider` for session/user/global collections.
+
+## Install
+
+```bash
+npm install @mcp-abap-adt/hana-vector-rag @sap/hana-client
+```
+
+## Minimal config
+
+```yaml
+rag:
+  type: hana-vector
+  connectionString: hdbsql://user:pass@host:443
+  collectionName: llm_agent_docs
+  dimension: 1536
+  autoCreateSchema: true
+```
+
+See the monorepo root README for full configuration surface.
+```
+
+- [ ] **Step 4: Write placeholder `src/index.ts`**
+
+```ts
+export { HanaVectorRag } from './hana-vector-rag.js';
+export type { HanaVectorRagConfig } from './hana-vector-rag.js';
+export { HanaVectorRagProvider } from './hana-vector-rag-provider.js';
+export type { HanaVectorRagProviderConfig } from './hana-vector-rag-provider.js';
+```
+
+- [ ] **Step 5: Install `@sap/hana-client`**
+
+Run from repo root: `npm install --workspace @mcp-abap-adt/hana-vector-rag @sap/hana-client@^2.24.26`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/hana-vector-rag package-lock.json
+git commit -m "feat(hana-vector-rag): scaffold package"
+```
+
+---
+
+### Task 2: Scaffold `@mcp-abap-adt/pg-vector-rag` package
+
+**Files:**
+- Create: `packages/pg-vector-rag/package.json`
+- Create: `packages/pg-vector-rag/tsconfig.json`
+- Create: `packages/pg-vector-rag/README.md`
+- Create: `packages/pg-vector-rag/src/index.ts`
+
+- [ ] **Step 1: Write `package.json`**
+
+```json
+{
+  "name": "@mcp-abap-adt/pg-vector-rag",
+  "version": "11.0.0",
+  "description": "PgVectorRag (PostgreSQL + pgvector) and PgVectorRagProvider for @mcp-abap-adt/llm-agent.",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": ["dist", "README.md", "LICENSE"],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "clean": "tsc -p tsconfig.json --clean",
+    "test": "node --import tsx/esm --test --test-reporter=spec 'src/**/*.test.ts'"
+  },
+  "dependencies": {
+    "@mcp-abap-adt/llm-agent": "*",
+    "pg": "^8.13.0"
+  },
+  "devDependencies": {
+    "@types/pg": "^8.11.0"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fr0ster/llm-agent.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}
+```
+
+- [ ] **Step 2: Write `tsconfig.json`**
+
+```json
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["node"]
+  },
+  "references": [{ "path": "../llm-agent" }],
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}
+```
+
+- [ ] **Step 3: Write `README.md`**
+
+```markdown
+# @mcp-abap-adt/pg-vector-rag
+
+PostgreSQL + pgvector backend for [@mcp-abap-adt/llm-agent](https://www.npmjs.com/package/@mcp-abap-adt/llm-agent).
+
+Provides:
+- `PgVectorRag` — `IRag` implementation backed by `vector(dim)` columns (pgvector extension).
+- `PgVectorRagProvider` — `IRagProvider` for session/user/global collections.
+
+## Prerequisites
+
+- PostgreSQL 13+
+- `pgvector` extension installed (`CREATE EXTENSION IF NOT EXISTS vector;`)
+
+## Install
+
+```bash
+npm install @mcp-abap-adt/pg-vector-rag pg
+```
+
+## Minimal config
+
+```yaml
+rag:
+  type: pg-vector
+  connectionString: postgres://user:pass@host:5432/mydb
+  collectionName: llm_agent_docs
+  dimension: 1536
+  autoCreateSchema: true
+```
+
+See the monorepo root README for full configuration surface.
+```
+
+- [ ] **Step 4: Write placeholder `src/index.ts`**
+
+```ts
+export { PgVectorRag } from './pg-vector-rag.js';
+export type { PgVectorRagConfig } from './pg-vector-rag.js';
+export { PgVectorRagProvider } from './pg-vector-rag-provider.js';
+export type { PgVectorRagProviderConfig } from './pg-vector-rag-provider.js';
+```
+
+- [ ] **Step 5: Install `pg` + `@types/pg`**
+
+Run from repo root: `npm install --workspace @mcp-abap-adt/pg-vector-rag pg@^8.13.0 @types/pg@^8.11.0`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/pg-vector-rag package-lock.json
+git commit -m "feat(pg-vector-rag): scaffold package"
+```
+
+---
+
+### Task 3: HANA `connection.ts` (URL / explicit-field resolver)
+
+**Files:**
+- Create: `packages/hana-vector-rag/src/connection.ts`
+- Create: `packages/hana-vector-rag/src/__tests__/connection.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+`packages/hana-vector-rag/src/__tests__/connection.test.ts`:
+
+```ts
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { resolveHanaConnectArgs } from '../connection.js';
+
+describe('resolveHanaConnectArgs', () => {
+  it('accepts explicit fields', () => {
+    const args = resolveHanaConnectArgs({
+      host: 'h.example.com',
+      port: 443,
+      user: 'U1',
+      password: 'pw',
+      collectionName: 't',
+    });
+    assert.equal(args.serverNode, 'h.example.com:443');
+    assert.equal(args.uid, 'U1');
+    assert.equal(args.pwd, 'pw');
+    assert.equal(args.encrypt, 'true');
+  });
+
+  it('parses hdbsql URL', () => {
+    const args = resolveHanaConnectArgs({
+      connectionString: 'hdbsql://u:p@host.example:443',
+      collectionName: 't',
+    });
+    assert.equal(args.serverNode, 'host.example:443');
+    assert.equal(args.uid, 'u');
+    assert.equal(args.pwd, 'p');
+  });
+
+  it('rejects missing host', () => {
+    assert.throws(() =>
+      resolveHanaConnectArgs({ user: 'u', password: 'p', collectionName: 't' }),
+      /host/i,
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test → expect FAIL**
+
+Run: `npm test --workspace @mcp-abap-adt/hana-vector-rag`
+Expected: FAIL (`Cannot find module '../connection.js'`).
+
+- [ ] **Step 3: Implement `connection.ts`**
+
+```ts
+export interface HanaVectorRagConfig {
+  connectionString?: string;
+  host?: string;
+  port?: number;
+  user?: string;
+  password?: string;
+  schema?: string;
+  collectionName: string;
+  dimension?: number;
+  autoCreateSchema?: boolean;
+  poolMax?: number;
+  connectTimeout?: number;
+}
+
+export interface HanaConnectArgs {
+  serverNode: string;
+  uid: string;
+  pwd: string;
+  encrypt: 'true' | 'false';
+  sslValidateCertificate?: 'true' | 'false';
+  currentSchema?: string;
+  communicationTimeout?: number;
+}
+
+export function resolveHanaConnectArgs(
+  cfg: HanaVectorRagConfig,
+): HanaConnectArgs {
+  let host = cfg.host;
+  let port = cfg.port;
+  let user = cfg.user;
+  let password = cfg.password;
+
+  if (cfg.connectionString) {
+    const normalized = cfg.connectionString.replace(/^hdbsql:\/\//, 'https://');
+    const u = new URL(normalized);
+    host ??= u.hostname;
+    port ??= u.port ? Number(u.port) : 443;
+    user ??= decodeURIComponent(u.username);
+    password ??= decodeURIComponent(u.password);
+  }
+
+  if (!host) throw new Error('HANA host is required (host or connectionString)');
+  if (!user) throw new Error('HANA user is required');
+  if (!password) throw new Error('HANA password is required');
+
+  return {
+    serverNode: `${host}:${port ?? 443}`,
+    uid: user,
+    pwd: password,
+    encrypt: 'true',
+    sslValidateCertificate: 'true',
+    currentSchema: cfg.schema,
+    communicationTimeout: cfg.connectTimeout ?? 30_000,
+  };
+}
+```
+
+- [ ] **Step 4: Run test → expect PASS**
+
+Run: `npm test --workspace @mcp-abap-adt/hana-vector-rag`
+Expected: 3 passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hana-vector-rag/src
+git commit -m "feat(hana-vector-rag): connection args resolver"
+```
+
+---
+
+### Task 4: HANA `schema.ts` (DDL + collection-name sanitization)
+
+**Files:**
+- Create: `packages/hana-vector-rag/src/schema.ts`
+- Create: `packages/hana-vector-rag/src/__tests__/schema.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  assertCollectionName,
+  createTableSql,
+  dropTableSql,
+  quoteIdent,
+} from '../schema.js';
+
+describe('hana schema', () => {
+  it('accepts a safe collection name', () => {
+    assertCollectionName('llm_agent_docs_2');
+  });
+  it('rejects collection name starting with digit', () => {
+    assert.throws(() => assertCollectionName('1bad'), /INVALID_COLLECTION_NAME/);
+  });
+  it('rejects collection name with special chars', () => {
+    assert.throws(() => assertCollectionName("x'); DROP"), /INVALID_COLLECTION_NAME/);
+  });
+  it('rejects names longer than 63 chars', () => {
+    assert.throws(() => assertCollectionName('a'.repeat(64)), /INVALID_COLLECTION_NAME/);
+  });
+
+  it('quotes HANA identifiers', () => {
+    assert.equal(quoteIdent('llm_docs'), '"llm_docs"');
+  });
+
+  it('emits CREATE TABLE DDL with REAL_VECTOR and NCLOB', () => {
+    const sql = createTableSql('llm_docs', 1536);
+    assert.match(sql, /CREATE TABLE IF NOT EXISTS "llm_docs"/);
+    assert.match(sql, /REAL_VECTOR\(1536\)/);
+    assert.match(sql, /metadata NCLOB/);
+  });
+
+  it('emits DROP TABLE DDL', () => {
+    assert.equal(dropTableSql('llm_docs'), 'DROP TABLE "llm_docs"');
+  });
+});
+```
+
+- [ ] **Step 2: Run test → expect FAIL**
+
+Run: `npm test --workspace @mcp-abap-adt/hana-vector-rag`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement `schema.ts`**
+
+```ts
+import { RagError } from '@mcp-abap-adt/llm-agent';
+
+const COLLECTION_NAME_RE = /^[a-zA-Z_][a-zA-Z0-9_]{0,62}$/;
+
+export function assertCollectionName(name: string): void {
+  if (!COLLECTION_NAME_RE.test(name)) {
+    throw new RagError(
+      `Invalid collection name: ${name}`,
+      'INVALID_COLLECTION_NAME',
+    );
+  }
+}
+
+export function quoteIdent(ident: string): string {
+  assertCollectionName(ident);
+  return `"${ident}"`;
+}
+
+export function createTableSql(collection: string, dimension: number): string {
+  const table = quoteIdent(collection);
+  return `CREATE TABLE IF NOT EXISTS ${table} (
+    id NVARCHAR(255) PRIMARY KEY,
+    text NCLOB,
+    vector REAL_VECTOR(${dimension}),
+    metadata NCLOB,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+  )`;
+}
+
+export function dropTableSql(collection: string): string {
+  return `DROP TABLE ${quoteIdent(collection)}`;
+}
+```
+
+- [ ] **Step 4: Run test → expect PASS**
+
+Run: `npm test --workspace @mcp-abap-adt/hana-vector-rag`
+Expected: all passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hana-vector-rag/src
+git commit -m "feat(hana-vector-rag): schema DDL helpers + name validation"
+```
+
+---
+
+### Task 5: `HanaVectorRag` class
+
+**Files:**
+- Create: `packages/hana-vector-rag/src/hana-vector-rag.ts`
+- Create: `packages/hana-vector-rag/src/__tests__/hana-vector-rag.test.ts`
+
+**Approach:** The `@sap/hana-client` driver is mocked through a thin `HanaClient` seam — an interface defined in this file. Production code obtains a real client; tests pass a fake. This keeps driver code isolated without adding a core abstraction.
+
+- [ ] **Step 1: Write failing test (mock driver, cover query/upsert/getById/healthCheck/writer + autoCreateSchema)**
+
+```ts
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { IEmbedder } from '@mcp-abap-adt/llm-agent';
+import { HanaVectorRag, type HanaClient } from '../hana-vector-rag.js';
+
+function makeEmbedder(dim = 3): IEmbedder {
+  return {
+    async embed(text: string) {
+      let h = 0;
+      for (const ch of text) h = (h * 31 + ch.charCodeAt(0)) | 0;
+      return { vector: Array.from({ length: dim }, (_, i) => ((h >> i) & 0xff) / 255) };
+    },
+  };
+}
+
+interface ExecCall { sql: string; params: readonly unknown[]; }
+
+function makeFakeClient(rows: Record<string, unknown>[] = []): HanaClient & { calls: ExecCall[] } {
+  const calls: ExecCall[] = [];
+  return {
+    calls,
+    async exec(sql, params = []) { calls.push({ sql, params }); return { rowCount: 1 }; },
+    async query(sql, params = []) { calls.push({ sql, params }); return rows; },
+    async close() { /* noop */ },
+  };
+}
+
+describe('HanaVectorRag', () => {
+  it('ensureSchema runs CREATE TABLE only once', async () => {
+    const client = makeFakeClient();
+    const rag = new HanaVectorRag({ collectionName: 'docs', dimension: 3, embedder: makeEmbedder(3) }, client);
+    await rag.ensureSchema();
+    await rag.ensureSchema();
+    const creates = client.calls.filter((c) => c.sql.includes('CREATE TABLE'));
+    assert.equal(creates.length, 1);
+  });
+
+  it('query returns results mapped from rows', async () => {
+    const rows = [{ id: 'a', text: 'hello', metadata: '{"namespace":"n"}', score: 0.9 }];
+    const client = makeFakeClient(rows);
+    const rag = new HanaVectorRag({ collectionName: 'docs', dimension: 3, embedder: makeEmbedder(3) }, client);
+    const res = await rag.query({ toVector: async () => [0.1, 0.2, 0.3] }, 5);
+    assert.equal(res.ok, true);
+    if (!res.ok) throw new Error('unreachable');
+    assert.equal(res.value.length, 1);
+    assert.equal(res.value[0].text, 'hello');
+    assert.equal(res.value[0].metadata?.namespace, 'n');
+  });
+
+  it('upsertRaw issues UPSERT with vector literal', async () => {
+    const client = makeFakeClient();
+    const rag = new HanaVectorRag({ collectionName: 'docs', dimension: 3, embedder: makeEmbedder(3) }, client);
+    const r = await rag.writer().upsertRaw('id1', 'text', { namespace: 'n' });
+    assert.equal(r.ok, true);
+    const upsert = client.calls.find((c) => c.sql.startsWith('UPSERT'));
+    assert.ok(upsert, 'UPSERT should have been issued');
+  });
+
+  it('deleteByIdRaw issues DELETE', async () => {
+    const client = makeFakeClient();
+    const rag = new HanaVectorRag({ collectionName: 'docs', dimension: 3, embedder: makeEmbedder(3) }, client);
+    const r = await rag.writer().deleteByIdRaw('id1');
+    assert.equal(r.ok, true);
+    assert.ok(client.calls.some((c) => c.sql.includes('DELETE FROM')));
+  });
+
+  it('clearAll issues TRUNCATE', async () => {
+    const client = makeFakeClient();
+    const rag = new HanaVectorRag({ collectionName: 'docs', dimension: 3, embedder: makeEmbedder(3) }, client);
+    const r = await rag.writer().clearAll();
+    assert.equal(r.ok, true);
+    assert.ok(client.calls.some((c) => c.sql.startsWith('TRUNCATE')));
+  });
+
+  it('healthCheck runs SELECT 1 FROM DUMMY', async () => {
+    const client = makeFakeClient([{ '1': 1 }]);
+    const rag = new HanaVectorRag({ collectionName: 'docs', dimension: 3, embedder: makeEmbedder(3) }, client);
+    const r = await rag.healthCheck();
+    assert.equal(r.ok, true);
+    assert.ok(client.calls.some((c) => c.sql.includes('FROM DUMMY')));
+  });
+
+  it('rejects invalid collection name at construction', () => {
+    assert.throws(
+      () => new HanaVectorRag({ collectionName: "bad'; DROP", embedder: makeEmbedder() }, makeFakeClient()),
+      /INVALID_COLLECTION_NAME/,
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test → expect FAIL**
+
+Run: `npm test --workspace @mcp-abap-adt/hana-vector-rag`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement `hana-vector-rag.ts`**
+
+```ts
+import type {
+  CallOptions,
+  IEmbedder,
+  IQueryEmbedding,
+  IRag,
+  IRagBackendWriter,
+  RagMetadata,
+  RagResult,
+  Result,
+} from '@mcp-abap-adt/llm-agent';
+import { FallbackQueryEmbedding, RagError } from '@mcp-abap-adt/llm-agent';
+import type { HanaVectorRagConfig } from './connection.js';
+import { resolveHanaConnectArgs } from './connection.js';
+import { assertCollectionName, createTableSql, quoteIdent } from './schema.js';
+
+export type { HanaVectorRagConfig };
+
+export interface HanaClient {
+  exec(sql: string, params?: readonly unknown[]): Promise<{ rowCount: number }>;
+  query(
+    sql: string,
+    params?: readonly unknown[],
+  ): Promise<Array<Record<string, unknown>>>;
+  close(): Promise<void>;
+}
+
+export interface HanaVectorRagDeps {
+  /** Injected for tests; in production the default driver factory is used. */
+  client?: HanaClient;
+}
+
+export class HanaVectorRag implements IRag {
+  private readonly collectionName: string;
+  private readonly dimension: number;
+  private readonly embedder: IEmbedder;
+  private readonly autoCreateSchema: boolean;
+  private readonly clientPromise: Promise<HanaClient>;
+  private schemaReady = false;
+  private schemaPromise?: Promise<void>;
+
+  constructor(
+    config: HanaVectorRagConfig & { embedder: IEmbedder },
+    injectedClient?: HanaClient,
+  ) {
+    assertCollectionName(config.collectionName);
+    this.collectionName = config.collectionName;
+    this.dimension = config.dimension ?? 1536;
+    this.embedder = config.embedder;
+    this.autoCreateSchema = config.autoCreateSchema ?? true;
+    this.clientPromise = injectedClient
+      ? Promise.resolve(injectedClient)
+      : this.createDriverClient(config);
+  }
+
+  private async createDriverClient(cfg: HanaVectorRagConfig): Promise<HanaClient> {
+    const args = resolveHanaConnectArgs(cfg);
+    // Dynamic import keeps the peer dep optional at import time.
+    const mod = (await import('@sap/hana-client')) as unknown as {
+      createConnection: () => {
+        connect: (opts: unknown, cb: (err: Error | null) => void) => void;
+        exec: (sql: string, params: unknown[], cb: (err: Error | null, rows: unknown) => void) => void;
+        disconnect: (cb: (err: Error | null) => void) => void;
+      };
+    };
+    const conn = mod.createConnection();
+    await new Promise<void>((resolve, reject) =>
+      conn.connect(args, (err) => (err ? reject(err) : resolve())),
+    );
+    return {
+      exec: (sql, params = []) =>
+        new Promise((resolve, reject) =>
+          conn.exec(sql, params as unknown[], (err, rows) =>
+            err ? reject(err) : resolve({ rowCount: Array.isArray(rows) ? rows.length : 1 }),
+          ),
+        ),
+      query: (sql, params = []) =>
+        new Promise((resolve, reject) =>
+          conn.exec(sql, params as unknown[], (err, rows) =>
+            err ? reject(err) : resolve((rows as Array<Record<string, unknown>>) ?? []),
+          ),
+        ),
+      close: () =>
+        new Promise((resolve, reject) =>
+          conn.disconnect((err) => (err ? reject(err) : resolve())),
+        ),
+    };
+  }
+
+  /**
+   * Idempotent schema bootstrap. Called by both direct makeRag() consumers
+   * (when autoCreateSchema is true) and HanaVectorRagProvider.createCollection().
+   */
+  async ensureSchema(): Promise<void> {
+    if (this.schemaReady) return;
+    this.schemaPromise ??= (async () => {
+      const client = await this.clientPromise;
+      await client.exec(createTableSql(this.collectionName, this.dimension));
+      this.schemaReady = true;
+    })();
+    await this.schemaPromise;
+  }
+
+  private async maybeEnsureSchema(): Promise<void> {
+    if (this.autoCreateSchema) await this.ensureSchema();
+  }
+
+  private vectorLiteral(vec: number[]): string {
+    return `TO_REAL_VECTOR('[${vec.join(',')}]')`;
+  }
+
+  async query(
+    embedding: IQueryEmbedding,
+    k: number,
+    options?: CallOptions,
+  ): Promise<Result<RagResult[], RagError>> {
+    if (options?.signal?.aborted) return { ok: false, error: new RagError('Aborted', 'ABORTED') };
+    try {
+      await this.maybeEnsureSchema();
+      const safe = new FallbackQueryEmbedding(embedding, this.embedder);
+      const vector = await safe.toVector();
+      const client = await this.clientPromise;
+      const table = quoteIdent(this.collectionName);
+      const sql = `SELECT id, text, metadata, COSINE_SIMILARITY(vector, ${this.vectorLiteral(vector)}) AS score FROM ${table} ORDER BY score DESC LIMIT ${Math.max(1, k)}`;
+      const rows = await client.query(sql);
+      const results: RagResult[] = rows.map((row) => {
+        const metaRaw = row.metadata as string | null | undefined;
+        const metadata = metaRaw ? (JSON.parse(metaRaw) as RagMetadata) : {};
+        return {
+          text: String(row.text ?? ''),
+          metadata,
+          score: Number(row.score ?? 0),
+        };
+      });
+      return { ok: true, value: results };
+    } catch (err) {
+      return { ok: false, error: new RagError(String(err), 'QUERY_ERROR') };
+    }
+  }
+
+  async getById(id: string, options?: CallOptions): Promise<Result<RagResult | null, RagError>> {
+    if (options?.signal?.aborted) return { ok: false, error: new RagError('Aborted', 'ABORTED') };
+    try {
+      await this.maybeEnsureSchema();
+      const client = await this.clientPromise;
+      const rows = await client.query(
+        `SELECT id, text, metadata FROM ${quoteIdent(this.collectionName)} WHERE id = ?`,
+        [id],
+      );
+      const row = rows[0];
+      if (!row) return { ok: true, value: null };
+      const metaRaw = row.metadata as string | null | undefined;
+      const metadata = metaRaw ? (JSON.parse(metaRaw) as RagMetadata) : {};
+      return { ok: true, value: { text: String(row.text ?? ''), metadata, score: 1 } };
+    } catch (err) {
+      return { ok: false, error: new RagError(String(err), 'QUERY_ERROR') };
+    }
+  }
+
+  async healthCheck(): Promise<Result<void, RagError>> {
+    try {
+      const client = await this.clientPromise;
+      await client.query('SELECT 1 FROM DUMMY');
+      return { ok: true, value: undefined };
+    } catch (err) {
+      return { ok: false, error: new RagError(String(err), 'HEALTH_CHECK_ERROR') };
+    }
+  }
+
+  async upsert(text: string, metadata: RagMetadata, options?: CallOptions): Promise<Result<void, RagError>> {
+    if (options?.signal?.aborted) return { ok: false, error: new RagError('Aborted', 'ABORTED') };
+    try {
+      const { vector } = await this.embedder.embed(text, options);
+      return this.upsertKnown(text, vector, metadata);
+    } catch (err) {
+      return { ok: false, error: new RagError(String(err), 'UPSERT_ERROR') };
+    }
+  }
+
+  async upsertPrecomputed(
+    text: string,
+    vector: number[],
+    metadata: RagMetadata,
+  ): Promise<Result<void, RagError>> {
+    return this.upsertKnown(text, vector, metadata);
+  }
+
+  private async upsertKnown(
+    text: string,
+    vector: number[],
+    metadata: RagMetadata,
+  ): Promise<Result<void, RagError>> {
+    try {
+      await this.maybeEnsureSchema();
+      const client = await this.clientPromise;
+      const id = metadata?.id ?? crypto.randomUUID();
+      const { id: _omit, ...rest } = metadata ?? {};
+      const metaJson = JSON.stringify(rest);
+      const sql = `UPSERT ${quoteIdent(this.collectionName)} (id, text, vector, metadata) VALUES (?, ?, ${this.vectorLiteral(vector)}, ?) WITH PRIMARY KEY`;
+      await client.exec(sql, [id, text, metaJson]);
+      return { ok: true, value: undefined };
+    } catch (err) {
+      return { ok: false, error: new RagError(String(err), 'UPSERT_ERROR') };
+    }
+  }
+
+  writer(): IRagBackendWriter {
+    return {
+      upsertRaw: async (id, text, metadata, options) => {
+        const r = await this.upsert(text, { ...metadata, id }, options);
+        return r.ok ? { ok: true, value: undefined } : r;
+      },
+      deleteByIdRaw: async (id) => {
+        try {
+          await this.maybeEnsureSchema();
+          const client = await this.clientPromise;
+          const r = await client.exec(
+            `DELETE FROM ${quoteIdent(this.collectionName)} WHERE id = ?`,
+            [id],
+          );
+          return { ok: true, value: r.rowCount > 0 };
+        } catch (err) {
+          return { ok: false, error: new RagError(String(err), 'DELETE_ERROR') };
+        }
+      },
+      clearAll: async () => {
+        try {
+          await this.maybeEnsureSchema();
+          const client = await this.clientPromise;
+          await client.exec(`TRUNCATE TABLE ${quoteIdent(this.collectionName)}`);
+          return { ok: true, value: undefined };
+        } catch (err) {
+          return { ok: false, error: new RagError(String(err), 'CLEAR_ERROR') };
+        }
+      },
+      upsertPrecomputedRaw: async (id, text, vector, metadata) =>
+        this.upsertPrecomputed(text, vector, { ...metadata, id }),
+    };
+  }
+}
+```
+
+- [ ] **Step 4: Run test → expect PASS**
+
+Run: `npm test --workspace @mcp-abap-adt/hana-vector-rag`
+Expected: all passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hana-vector-rag/src
+git commit -m "feat(hana-vector-rag): HanaVectorRag IRag implementation"
+```
+
+---
+
+### Task 6: `HanaVectorRagProvider`
+
+**Files:**
+- Create: `packages/hana-vector-rag/src/hana-vector-rag-provider.ts`
+- Create: `packages/hana-vector-rag/src/__tests__/hana-vector-rag-provider.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { IEmbedder } from '@mcp-abap-adt/llm-agent';
+import type { HanaClient } from '../hana-vector-rag.js';
+import { HanaVectorRagProvider } from '../hana-vector-rag-provider.js';
+
+function makeEmbedder(): IEmbedder {
+  return { async embed() { return { vector: [0, 0, 0] }; } };
+}
+
+interface ExecCall { sql: string; params: readonly unknown[]; }
+
+function makeFakeClient(rows: Record<string, unknown>[] = []): HanaClient & { calls: ExecCall[] } {
+  const calls: ExecCall[] = [];
+  return {
+    calls,
+    async exec(sql, params = []) { calls.push({ sql, params }); return { rowCount: 1 }; },
+    async query(sql, params = []) { calls.push({ sql, params }); return rows; },
+    async close() {},
+  };
+}
+
+describe('HanaVectorRagProvider', () => {
+  it('createCollection returns rag + editor, runs schema bootstrap when autoCreateSchema=true', async () => {
+    const client = makeFakeClient();
+    const provider = new HanaVectorRagProvider({
+      name: 'hana',
+      embedder: makeEmbedder(),
+      connection: { collectionName: '__ignored', host: 'h', user: 'u', password: 'p' },
+      defaultDimension: 3,
+      autoCreateSchema: true,
+      clientFactory: () => client,
+    });
+    const r = await provider.createCollection('docs', { scope: 'session', sessionId: 's1' });
+    assert.equal(r.ok, true);
+    if (!r.ok) throw new Error('unreachable');
+    assert.ok(client.calls.some((c) => c.sql.includes('CREATE TABLE') && c.sql.includes('"docs"')));
+  });
+
+  it('createCollection skips DDL when autoCreateSchema=false', async () => {
+    const client = makeFakeClient();
+    const provider = new HanaVectorRagProvider({
+      name: 'hana',
+      embedder: makeEmbedder(),
+      connection: { collectionName: '__ignored', host: 'h', user: 'u', password: 'p' },
+      defaultDimension: 3,
+      autoCreateSchema: false,
+      clientFactory: () => client,
+    });
+    const r = await provider.createCollection('docs', { scope: 'global' });
+    assert.equal(r.ok, true);
+    assert.ok(!client.calls.some((c) => c.sql.includes('CREATE TABLE')));
+  });
+
+  it('deleteCollection emits DROP TABLE', async () => {
+    const client = makeFakeClient();
+    const provider = new HanaVectorRagProvider({
+      name: 'hana',
+      embedder: makeEmbedder(),
+      connection: { collectionName: '__ignored', host: 'h', user: 'u', password: 'p' },
+      clientFactory: () => client,
+    });
+    const r = await provider.deleteCollection('docs');
+    assert.equal(r.ok, true);
+    assert.ok(client.calls.some((c) => c.sql.startsWith('DROP TABLE')));
+  });
+
+  it('listCollections queries SYS.TABLES and returns names', async () => {
+    const client = makeFakeClient([{ TABLE_NAME: 'docs' }, { TABLE_NAME: 'other' }]);
+    const provider = new HanaVectorRagProvider({
+      name: 'hana',
+      embedder: makeEmbedder(),
+      connection: { collectionName: '__ignored', host: 'h', user: 'u', password: 'p' },
+      clientFactory: () => client,
+    });
+    const r = await provider.listCollections();
+    assert.equal(r.ok, true);
+    if (!r.ok) throw new Error('unreachable');
+    assert.deepEqual(r.value, ['docs', 'other']);
+  });
+
+  it('rejects unsupported scope', async () => {
+    const client = makeFakeClient();
+    const provider = new HanaVectorRagProvider({
+      name: 'hana',
+      embedder: makeEmbedder(),
+      connection: { collectionName: '__ignored', host: 'h', user: 'u', password: 'p' },
+      clientFactory: () => client,
+      supportedScopes: ['global'],
+    });
+    const r = await provider.createCollection('docs', { scope: 'session' });
+    assert.equal(r.ok, false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test → expect FAIL**
+
+Run: `npm test --workspace @mcp-abap-adt/hana-vector-rag`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement `hana-vector-rag-provider.ts`**
+
+```ts
+import type {
+  IEmbedder,
+  IIdStrategy,
+  IRag,
+  IRagEditor,
+  RagCollectionScope,
+  Result,
+} from '@mcp-abap-adt/llm-agent';
+import { AbstractRagProvider, RagError } from '@mcp-abap-adt/llm-agent';
+import type { HanaVectorRagConfig } from './connection.js';
+import { HanaVectorRag, type HanaClient } from './hana-vector-rag.js';
+import { quoteIdent } from './schema.js';
+
+export interface HanaVectorRagProviderConfig {
+  name: string;
+  embedder: IEmbedder;
+  connection: HanaVectorRagConfig | string;
+  defaultDimension?: number;
+  autoCreateSchema?: boolean;
+  editable?: boolean;
+  supportedScopes?: readonly RagCollectionScope[];
+  idStrategyFactory?: (opts: {
+    scope: RagCollectionScope;
+    sessionId?: string;
+    userId?: string;
+  }) => IIdStrategy;
+  /** Test seam — inject a fake HanaClient. */
+  clientFactory?: () => HanaClient;
+}
+
+function normalizeConnection(
+  c: HanaVectorRagConfig | string,
+): HanaVectorRagConfig {
+  if (typeof c === 'string') {
+    return { connectionString: c, collectionName: '__unused' };
+  }
+  return c;
+}
+
+export class HanaVectorRagProvider extends AbstractRagProvider {
+  readonly name: string;
+  readonly kind = 'vector';
+  readonly editable: boolean;
+  readonly supportedScopes: readonly RagCollectionScope[];
+
+  private readonly embedder: IEmbedder;
+  private readonly connection: HanaVectorRagConfig;
+  private readonly defaultDimension: number;
+  private readonly autoCreateSchema: boolean;
+  private readonly clientFactory?: () => HanaClient;
+
+  constructor(cfg: HanaVectorRagProviderConfig) {
+    super();
+    this.name = cfg.name;
+    this.embedder = cfg.embedder;
+    this.connection = normalizeConnection(cfg.connection);
+    this.defaultDimension = cfg.defaultDimension ?? 1536;
+    this.autoCreateSchema = cfg.autoCreateSchema ?? true;
+    this.editable = cfg.editable ?? true;
+    this.supportedScopes = cfg.supportedScopes ?? ['session', 'user', 'global'];
+    this.clientFactory = cfg.clientFactory;
+    if (cfg.idStrategyFactory) this.idStrategyFactory = cfg.idStrategyFactory;
+  }
+
+  async createCollection(
+    name: string,
+    opts: { scope: RagCollectionScope; sessionId?: string; userId?: string },
+  ): Promise<Result<{ rag: IRag; editor: IRagEditor }, RagError>> {
+    const scopeCheck = this.checkScope(opts.scope);
+    if (!scopeCheck.ok) return scopeCheck;
+    try {
+      const rag = new HanaVectorRag(
+        {
+          ...this.connection,
+          collectionName: name,
+          dimension: this.connection.dimension ?? this.defaultDimension,
+          autoCreateSchema: this.autoCreateSchema,
+          embedder: this.embedder,
+        },
+        this.clientFactory?.(),
+      );
+      if (this.autoCreateSchema) await rag.ensureSchema();
+      const editor = this.buildEditor(rag, this.pickIdStrategy(opts));
+      return { ok: true, value: { rag, editor } };
+    } catch (err) {
+      return { ok: false, error: new RagError(String(err), 'RAG_CREATE_ERROR') };
+    }
+  }
+
+  async deleteCollection(name: string): Promise<Result<void, RagError>> {
+    try {
+      const client = this.clientFactory?.() ?? (await this.borrowClient());
+      await client.exec(`DROP TABLE ${quoteIdent(name)}`);
+      return { ok: true, value: undefined };
+    } catch (err) {
+      return { ok: false, error: new RagError(String(err), 'RAG_DELETE_ERROR') };
+    }
+  }
+
+  async listCollections(): Promise<Result<string[], RagError>> {
+    try {
+      const client = this.clientFactory?.() ?? (await this.borrowClient());
+      const rows = await client.query(
+        this.connection.schema
+          ? 'SELECT TABLE_NAME FROM SYS.TABLES WHERE SCHEMA_NAME = ?'
+          : 'SELECT TABLE_NAME FROM SYS.TABLES WHERE SCHEMA_NAME = CURRENT_SCHEMA',
+        this.connection.schema ? [this.connection.schema] : [],
+      );
+      return { ok: true, value: rows.map((r) => String(r.TABLE_NAME)) };
+    } catch (err) {
+      return { ok: false, error: new RagError(String(err), 'RAG_LIST_ERROR') };
+    }
+  }
+
+  private async borrowClient(): Promise<HanaClient> {
+    const rag = new HanaVectorRag(
+      {
+        ...this.connection,
+        collectionName: '__borrow__',
+        dimension: this.defaultDimension,
+        autoCreateSchema: false,
+        embedder: this.embedder,
+      },
+    );
+    // Force client creation without running schema DDL.
+    await rag.healthCheck();
+    // Internal accessor is not exposed; re-enter via a health-check + re-use trick is brittle.
+    // Instead, callers should pass clientFactory for delete/list operations in tests.
+    // In production, the caller can construct a one-off HanaVectorRag and reuse its client
+    // via healthCheck() path. For simplicity, re-issue via a disposable rag instance is acceptable here.
+    throw new Error('borrowClient not supported without clientFactory in production paths — pass clientFactory for delete/list');
+  }
+}
+```
+
+Note to implementer: the `borrowClient()` shim is deliberately minimal. If during implementation it becomes clear that a cleaner pattern is needed (shared pool across provider lifecycle), promote a small `HanaConnectionPool` class owned by the provider. Keep changes confined to this package.
+
+- [ ] **Step 4: Run test → expect PASS**
+
+Run: `npm test --workspace @mcp-abap-adt/hana-vector-rag`
+Expected: all passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hana-vector-rag/src
+git commit -m "feat(hana-vector-rag): HanaVectorRagProvider"
+```
+
+---
+
+### Task 7: pgvector `connection.ts`
+
+**Files:**
+- Create: `packages/pg-vector-rag/src/connection.ts`
+- Create: `packages/pg-vector-rag/src/__tests__/connection.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { resolvePgConnectArgs } from '../connection.js';
+
+describe('resolvePgConnectArgs', () => {
+  it('parses postgres:// URL', () => {
+    const a = resolvePgConnectArgs({
+      connectionString: 'postgres://u:p@host:5432/db',
+      collectionName: 't',
+    });
+    assert.equal(a.connectionString, 'postgres://u:p@host:5432/db');
+    assert.equal(a.max, 10);
+  });
+
+  it('uses explicit fields', () => {
+    const a = resolvePgConnectArgs({
+      host: 'h',
+      port: 6543,
+      user: 'u',
+      password: 'p',
+      database: 'db',
+      poolMax: 3,
+      collectionName: 't',
+    });
+    assert.equal(a.host, 'h');
+    assert.equal(a.port, 6543);
+    assert.equal(a.user, 'u');
+    assert.equal(a.password, 'p');
+    assert.equal(a.database, 'db');
+    assert.equal(a.max, 3);
+  });
+
+  it('rejects missing host and connectionString', () => {
+    assert.throws(() =>
+      resolvePgConnectArgs({ user: 'u', password: 'p', collectionName: 't' }),
+      /host|connectionString/i,
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test → expect FAIL**
+
+Run: `npm test --workspace @mcp-abap-adt/pg-vector-rag`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `connection.ts`**
+
+```ts
+export interface PgVectorRagConfig {
+  connectionString?: string;
+  host?: string;
+  port?: number;
+  user?: string;
+  password?: string;
+  database?: string;
+  schema?: string;
+  collectionName: string;
+  dimension?: number;
+  autoCreateSchema?: boolean;
+  poolMax?: number;
+  connectTimeout?: number;
+}
+
+export interface PgPoolConfig {
+  connectionString?: string;
+  host?: string;
+  port?: number;
+  user?: string;
+  password?: string;
+  database?: string;
+  max: number;
+  connectionTimeoutMillis: number;
+}
+
+export function resolvePgConnectArgs(cfg: PgVectorRagConfig): PgPoolConfig {
+  const max = cfg.poolMax ?? 10;
+  const connectionTimeoutMillis = cfg.connectTimeout ?? 30_000;
+
+  if (cfg.connectionString) {
+    return {
+      connectionString: cfg.connectionString,
+      max,
+      connectionTimeoutMillis,
+    };
+  }
+
+  if (!cfg.host) {
+    throw new Error('Postgres connectionString or host is required');
+  }
+  return {
+    host: cfg.host,
+    port: cfg.port ?? 5432,
+    user: cfg.user,
+    password: cfg.password,
+    database: cfg.database,
+    max,
+    connectionTimeoutMillis,
+  };
+}
+```
+
+- [ ] **Step 4: Run test → expect PASS**
+
+Run: `npm test --workspace @mcp-abap-adt/pg-vector-rag`
+Expected: passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/pg-vector-rag/src
+git commit -m "feat(pg-vector-rag): connection args resolver"
+```
+
+---
+
+### Task 8: pgvector `schema.ts`
+
+**Files:**
+- Create: `packages/pg-vector-rag/src/schema.ts`
+- Create: `packages/pg-vector-rag/src/__tests__/schema.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  assertCollectionName,
+  createExtensionSql,
+  createTableSql,
+  dropTableSql,
+  quoteIdent,
+} from '../schema.js';
+
+describe('pg schema', () => {
+  it('accepts a safe collection name', () => {
+    assertCollectionName('docs_2');
+  });
+  it('rejects digit-led name', () => {
+    assert.throws(() => assertCollectionName('1bad'), /INVALID_COLLECTION_NAME/);
+  });
+  it('rejects punctuation', () => {
+    assert.throws(() => assertCollectionName("x'); DROP"), /INVALID_COLLECTION_NAME/);
+  });
+  it('quotes identifiers with double-quotes', () => {
+    assert.equal(quoteIdent('docs'), '"docs"');
+  });
+  it('emits CREATE EXTENSION IF NOT EXISTS vector', () => {
+    assert.match(createExtensionSql(), /CREATE EXTENSION IF NOT EXISTS vector/);
+  });
+  it('emits CREATE TABLE with vector(n) and jsonb', () => {
+    const sql = createTableSql('docs', 1536);
+    assert.match(sql, /CREATE TABLE IF NOT EXISTS "docs"/);
+    assert.match(sql, /vector\(1536\)/);
+    assert.match(sql, /metadata JSONB/);
+  });
+  it('emits DROP TABLE DDL', () => {
+    assert.equal(dropTableSql('docs'), 'DROP TABLE IF EXISTS "docs"');
+  });
+});
+```
+
+- [ ] **Step 2: Run test → expect FAIL**
+
+Run: `npm test --workspace @mcp-abap-adt/pg-vector-rag`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `schema.ts`**
+
+```ts
+import { RagError } from '@mcp-abap-adt/llm-agent';
+
+const COLLECTION_NAME_RE = /^[a-zA-Z_][a-zA-Z0-9_]{0,62}$/;
+
+export function assertCollectionName(name: string): void {
+  if (!COLLECTION_NAME_RE.test(name)) {
+    throw new RagError(
+      `Invalid collection name: ${name}`,
+      'INVALID_COLLECTION_NAME',
+    );
+  }
+}
+
+export function quoteIdent(ident: string): string {
+  assertCollectionName(ident);
+  return `"${ident}"`;
+}
+
+export function createExtensionSql(): string {
+  return 'CREATE EXTENSION IF NOT EXISTS vector';
+}
+
+export function createTableSql(collection: string, dimension: number): string {
+  const table = quoteIdent(collection);
+  return `CREATE TABLE IF NOT EXISTS ${table} (
+    id VARCHAR(255) PRIMARY KEY,
+    text TEXT,
+    vector vector(${dimension}),
+    metadata JSONB,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+  )`;
+}
+
+export function dropTableSql(collection: string): string {
+  return `DROP TABLE IF EXISTS ${quoteIdent(collection)}`;
+}
+```
+
+- [ ] **Step 4: Run test → expect PASS**
+
+Run: `npm test --workspace @mcp-abap-adt/pg-vector-rag`
+Expected: passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/pg-vector-rag/src
+git commit -m "feat(pg-vector-rag): schema DDL helpers + name validation"
+```
+
+---
+
+### Task 9: `PgVectorRag` class
+
+**Files:**
+- Create: `packages/pg-vector-rag/src/pg-vector-rag.ts`
+- Create: `packages/pg-vector-rag/src/__tests__/pg-vector-rag.test.ts`
+
+**Approach:** Same seam pattern as HANA: define a minimal `PgClient` interface in the module; tests inject a fake; production obtains a real `pg.Pool`.
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { IEmbedder } from '@mcp-abap-adt/llm-agent';
+import { PgVectorRag, type PgClient } from '../pg-vector-rag.js';
+
+function makeEmbedder(dim = 3): IEmbedder {
+  return {
+    async embed(text: string) {
+      let h = 0;
+      for (const ch of text) h = (h * 31 + ch.charCodeAt(0)) | 0;
+      return { vector: Array.from({ length: dim }, (_, i) => ((h >> i) & 0xff) / 255) };
+    },
+  };
+}
+
+interface ExecCall { sql: string; params: readonly unknown[]; }
+
+function makeFakeClient(rows: Record<string, unknown>[] = []): PgClient & { calls: ExecCall[] } {
+  const calls: ExecCall[] = [];
+  return {
+    calls,
+    async query(sql, params = []) { calls.push({ sql, params }); return { rows, rowCount: rows.length }; },
+    async end() {},
+  };
+}
+
+describe('PgVectorRag', () => {
+  it('ensureSchema runs CREATE EXTENSION + CREATE TABLE once', async () => {
+    const client = makeFakeClient();
+    const rag = new PgVectorRag({ collectionName: 'docs', dimension: 3, embedder: makeEmbedder(3) }, client);
+    await rag.ensureSchema();
+    await rag.ensureSchema();
+    const extCount = client.calls.filter((c) => c.sql.includes('CREATE EXTENSION')).length;
+    const tblCount = client.calls.filter((c) => c.sql.includes('CREATE TABLE')).length;
+    assert.equal(extCount, 1);
+    assert.equal(tblCount, 1);
+  });
+
+  it('query uses pgvector <=> distance and maps rows', async () => {
+    const rows = [{ id: 'a', text: 'hello', metadata: { namespace: 'n' }, score: 0.1 }];
+    const client = makeFakeClient(rows);
+    const rag = new PgVectorRag({ collectionName: 'docs', dimension: 3, embedder: makeEmbedder(3) }, client);
+    const r = await rag.query({ toVector: async () => [0.1, 0.2, 0.3] }, 5);
+    assert.equal(r.ok, true);
+    if (!r.ok) throw new Error('unreachable');
+    assert.equal(r.value[0].text, 'hello');
+    assert.equal(r.value[0].metadata?.namespace, 'n');
+    assert.ok(client.calls.some((c) => c.sql.includes('<=>')));
+  });
+
+  it('upsertRaw issues INSERT … ON CONFLICT', async () => {
+    const client = makeFakeClient();
+    const rag = new PgVectorRag({ collectionName: 'docs', dimension: 3, embedder: makeEmbedder(3) }, client);
+    const r = await rag.writer().upsertRaw('id1', 'text', { namespace: 'n' });
+    assert.equal(r.ok, true);
+    assert.ok(client.calls.some((c) => c.sql.includes('ON CONFLICT')));
+  });
+
+  it('deleteByIdRaw issues DELETE', async () => {
+    const client = makeFakeClient([{ '?column?': 1 }]);
+    const rag = new PgVectorRag({ collectionName: 'docs', dimension: 3, embedder: makeEmbedder(3) }, client);
+    const r = await rag.writer().deleteByIdRaw('id1');
+    assert.equal(r.ok, true);
+    assert.ok(client.calls.some((c) => c.sql.startsWith('DELETE FROM')));
+  });
+
+  it('clearAll issues TRUNCATE', async () => {
+    const client = makeFakeClient();
+    const rag = new PgVectorRag({ collectionName: 'docs', dimension: 3, embedder: makeEmbedder(3) }, client);
+    const r = await rag.writer().clearAll();
+    assert.equal(r.ok, true);
+    assert.ok(client.calls.some((c) => c.sql.startsWith('TRUNCATE')));
+  });
+
+  it('healthCheck runs SELECT 1', async () => {
+    const client = makeFakeClient([{ '?column?': 1 }]);
+    const rag = new PgVectorRag({ collectionName: 'docs', dimension: 3, embedder: makeEmbedder(3) }, client);
+    const r = await rag.healthCheck();
+    assert.equal(r.ok, true);
+    assert.ok(client.calls.some((c) => c.sql === 'SELECT 1'));
+  });
+
+  it('rejects invalid collection name', () => {
+    assert.throws(
+      () => new PgVectorRag({ collectionName: "bad'; DROP", embedder: makeEmbedder() }, makeFakeClient()),
+      /INVALID_COLLECTION_NAME/,
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test → expect FAIL**
+
+Run: `npm test --workspace @mcp-abap-adt/pg-vector-rag`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement `pg-vector-rag.ts`**
+
+```ts
+import type {
+  CallOptions,
+  IEmbedder,
+  IQueryEmbedding,
+  IRag,
+  IRagBackendWriter,
+  RagMetadata,
+  RagResult,
+  Result,
+} from '@mcp-abap-adt/llm-agent';
+import { FallbackQueryEmbedding, RagError } from '@mcp-abap-adt/llm-agent';
+import type { PgVectorRagConfig } from './connection.js';
+import { resolvePgConnectArgs } from './connection.js';
+import {
+  assertCollectionName,
+  createExtensionSql,
+  createTableSql,
+  quoteIdent,
+} from './schema.js';
+
+export type { PgVectorRagConfig };
+
+export interface PgClient {
+  query(
+    sql: string,
+    params?: readonly unknown[],
+  ): Promise<{ rows: Array<Record<string, unknown>>; rowCount: number }>;
+  end(): Promise<void>;
+}
+
+function vectorLiteral(vec: number[]): string {
+  return `'[${vec.join(',')}]'::vector`;
+}
+
+export class PgVectorRag implements IRag {
+  private readonly collectionName: string;
+  private readonly dimension: number;
+  private readonly embedder: IEmbedder;
+  private readonly autoCreateSchema: boolean;
+  private readonly clientPromise: Promise<PgClient>;
+  private schemaReady = false;
+  private schemaPromise?: Promise<void>;
+
+  constructor(
+    config: PgVectorRagConfig & { embedder: IEmbedder },
+    injectedClient?: PgClient,
+  ) {
+    assertCollectionName(config.collectionName);
+    this.collectionName = config.collectionName;
+    this.dimension = config.dimension ?? 1536;
+    this.embedder = config.embedder;
+    this.autoCreateSchema = config.autoCreateSchema ?? true;
+    this.clientPromise = injectedClient
+      ? Promise.resolve(injectedClient)
+      : this.createDriverClient(config);
+  }
+
+  private async createDriverClient(cfg: PgVectorRagConfig): Promise<PgClient> {
+    const args = resolvePgConnectArgs(cfg);
+    const mod = (await import('pg')) as unknown as {
+      default?: { Pool: new (a: unknown) => { query: PgClient['query']; end: () => Promise<void> } };
+      Pool?: new (a: unknown) => { query: PgClient['query']; end: () => Promise<void> };
+    };
+    const PoolCtor = mod.Pool ?? mod.default?.Pool;
+    if (!PoolCtor) throw new Error('pg module did not expose Pool');
+    const pool = new PoolCtor(args);
+    return {
+      query: (sql, params = []) => pool.query(sql, params as unknown[]),
+      end: () => pool.end(),
+    };
+  }
+
+  async ensureSchema(): Promise<void> {
+    if (this.schemaReady) return;
+    this.schemaPromise ??= (async () => {
+      const client = await this.clientPromise;
+      await client.query(createExtensionSql());
+      await client.query(createTableSql(this.collectionName, this.dimension));
+      this.schemaReady = true;
+    })();
+    await this.schemaPromise;
+  }
+
+  private async maybeEnsureSchema(): Promise<void> {
+    if (this.autoCreateSchema) await this.ensureSchema();
+  }
+
+  async query(
+    embedding: IQueryEmbedding,
+    k: number,
+    options?: CallOptions,
+  ): Promise<Result<RagResult[], RagError>> {
+    if (options?.signal?.aborted) return { ok: false, error: new RagError('Aborted', 'ABORTED') };
+    try {
+      await this.maybeEnsureSchema();
+      const safe = new FallbackQueryEmbedding(embedding, this.embedder);
+      const vector = await safe.toVector();
+      const client = await this.clientPromise;
+      const table = quoteIdent(this.collectionName);
+      const sql = `SELECT id, text, metadata, vector ${'<=>'} ${vectorLiteral(vector)} AS score FROM ${table} ORDER BY vector ${'<=>'} ${vectorLiteral(vector)} LIMIT ${Math.max(1, k)}`;
+      const { rows } = await client.query(sql);
+      const results: RagResult[] = rows.map((row) => ({
+        text: String(row.text ?? ''),
+        metadata: (row.metadata as RagMetadata) ?? {},
+        score: 1 - Number(row.score ?? 0),
+      }));
+      return { ok: true, value: results };
+    } catch (err) {
+      return { ok: false, error: new RagError(String(err), 'QUERY_ERROR') };
+    }
+  }
+
+  async getById(id: string, options?: CallOptions): Promise<Result<RagResult | null, RagError>> {
+    if (options?.signal?.aborted) return { ok: false, error: new RagError('Aborted', 'ABORTED') };
+    try {
+      await this.maybeEnsureSchema();
+      const client = await this.clientPromise;
+      const { rows } = await client.query(
+        `SELECT id, text, metadata FROM ${quoteIdent(this.collectionName)} WHERE id = $1`,
+        [id],
+      );
+      const row = rows[0];
+      if (!row) return { ok: true, value: null };
+      return {
+        ok: true,
+        value: {
+          text: String(row.text ?? ''),
+          metadata: (row.metadata as RagMetadata) ?? {},
+          score: 1,
+        },
+      };
+    } catch (err) {
+      return { ok: false, error: new RagError(String(err), 'QUERY_ERROR') };
+    }
+  }
+
+  async healthCheck(): Promise<Result<void, RagError>> {
+    try {
+      const client = await this.clientPromise;
+      await client.query('SELECT 1');
+      return { ok: true, value: undefined };
+    } catch (err) {
+      return { ok: false, error: new RagError(String(err), 'HEALTH_CHECK_ERROR') };
+    }
+  }
+
+  async upsert(text: string, metadata: RagMetadata, options?: CallOptions): Promise<Result<void, RagError>> {
+    if (options?.signal?.aborted) return { ok: false, error: new RagError('Aborted', 'ABORTED') };
+    try {
+      const { vector } = await this.embedder.embed(text, options);
+      return this.upsertKnown(text, vector, metadata);
+    } catch (err) {
+      return { ok: false, error: new RagError(String(err), 'UPSERT_ERROR') };
+    }
+  }
+
+  async upsertPrecomputed(text: string, vector: number[], metadata: RagMetadata): Promise<Result<void, RagError>> {
+    return this.upsertKnown(text, vector, metadata);
+  }
+
+  private async upsertKnown(
+    text: string,
+    vector: number[],
+    metadata: RagMetadata,
+  ): Promise<Result<void, RagError>> {
+    try {
+      await this.maybeEnsureSchema();
+      const client = await this.clientPromise;
+      const id = metadata?.id ?? crypto.randomUUID();
+      const { id: _omit, ...rest } = metadata ?? {};
+      const table = quoteIdent(this.collectionName);
+      const sql = `INSERT INTO ${table} (id, text, vector, metadata) VALUES ($1, $2, ${vectorLiteral(vector)}, $3::jsonb) ON CONFLICT (id) DO UPDATE SET text = EXCLUDED.text, vector = EXCLUDED.vector, metadata = EXCLUDED.metadata`;
+      await client.query(sql, [id, text, JSON.stringify(rest)]);
+      return { ok: true, value: undefined };
+    } catch (err) {
+      return { ok: false, error: new RagError(String(err), 'UPSERT_ERROR') };
+    }
+  }
+
+  writer(): IRagBackendWriter {
+    return {
+      upsertRaw: async (id, text, metadata, options) => {
+        const r = await this.upsert(text, { ...metadata, id }, options);
+        return r.ok ? { ok: true, value: undefined } : r;
+      },
+      deleteByIdRaw: async (id) => {
+        try {
+          await this.maybeEnsureSchema();
+          const client = await this.clientPromise;
+          const res = await client.query(
+            `DELETE FROM ${quoteIdent(this.collectionName)} WHERE id = $1`,
+            [id],
+          );
+          return { ok: true, value: res.rowCount > 0 };
+        } catch (err) {
+          return { ok: false, error: new RagError(String(err), 'DELETE_ERROR') };
+        }
+      },
+      clearAll: async () => {
+        try {
+          await this.maybeEnsureSchema();
+          const client = await this.clientPromise;
+          await client.query(`TRUNCATE ${quoteIdent(this.collectionName)}`);
+          return { ok: true, value: undefined };
+        } catch (err) {
+          return { ok: false, error: new RagError(String(err), 'CLEAR_ERROR') };
+        }
+      },
+      upsertPrecomputedRaw: async (id, text, vector, metadata) =>
+        this.upsertPrecomputed(text, vector, { ...metadata, id }),
+    };
+  }
+}
+```
+
+- [ ] **Step 4: Run test → expect PASS**
+
+Run: `npm test --workspace @mcp-abap-adt/pg-vector-rag`
+Expected: passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/pg-vector-rag/src
+git commit -m "feat(pg-vector-rag): PgVectorRag IRag implementation"
+```
+
+---
+
+### Task 10: `PgVectorRagProvider`
+
+**Files:**
+- Create: `packages/pg-vector-rag/src/pg-vector-rag-provider.ts`
+- Create: `packages/pg-vector-rag/src/__tests__/pg-vector-rag-provider.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { IEmbedder } from '@mcp-abap-adt/llm-agent';
+import type { PgClient } from '../pg-vector-rag.js';
+import { PgVectorRagProvider } from '../pg-vector-rag-provider.js';
+
+function makeEmbedder(): IEmbedder { return { async embed() { return { vector: [0, 0, 0] }; } }; }
+
+interface ExecCall { sql: string; params: readonly unknown[]; }
+
+function makeFakeClient(rows: Record<string, unknown>[] = []): PgClient & { calls: ExecCall[] } {
+  const calls: ExecCall[] = [];
+  return {
+    calls,
+    async query(sql, params = []) { calls.push({ sql, params }); return { rows, rowCount: rows.length }; },
+    async end() {},
+  };
+}
+
+describe('PgVectorRagProvider', () => {
+  it('createCollection runs schema bootstrap when autoCreateSchema=true', async () => {
+    const client = makeFakeClient();
+    const provider = new PgVectorRagProvider({
+      name: 'pg',
+      embedder: makeEmbedder(),
+      connection: { collectionName: '__ignored', host: 'h', user: 'u', password: 'p', database: 'd' },
+      defaultDimension: 3,
+      autoCreateSchema: true,
+      clientFactory: () => client,
+    });
+    const r = await provider.createCollection('docs', { scope: 'global' });
+    assert.equal(r.ok, true);
+    assert.ok(client.calls.some((c) => c.sql.includes('CREATE TABLE') && c.sql.includes('"docs"')));
+  });
+
+  it('createCollection skips DDL when autoCreateSchema=false', async () => {
+    const client = makeFakeClient();
+    const provider = new PgVectorRagProvider({
+      name: 'pg',
+      embedder: makeEmbedder(),
+      connection: { collectionName: '__ignored', host: 'h', user: 'u', password: 'p', database: 'd' },
+      defaultDimension: 3,
+      autoCreateSchema: false,
+      clientFactory: () => client,
+    });
+    const r = await provider.createCollection('docs', { scope: 'global' });
+    assert.equal(r.ok, true);
+    assert.ok(!client.calls.some((c) => c.sql.includes('CREATE TABLE')));
+  });
+
+  it('deleteCollection emits DROP TABLE', async () => {
+    const client = makeFakeClient();
+    const provider = new PgVectorRagProvider({
+      name: 'pg',
+      embedder: makeEmbedder(),
+      connection: { collectionName: '__ignored', host: 'h', user: 'u', password: 'p', database: 'd' },
+      clientFactory: () => client,
+    });
+    const r = await provider.deleteCollection('docs');
+    assert.equal(r.ok, true);
+    assert.ok(client.calls.some((c) => c.sql.startsWith('DROP TABLE')));
+  });
+
+  it('listCollections queries information_schema.tables', async () => {
+    const client = makeFakeClient([{ table_name: 'docs' }, { table_name: 'other' }]);
+    const provider = new PgVectorRagProvider({
+      name: 'pg',
+      embedder: makeEmbedder(),
+      connection: { collectionName: '__ignored', host: 'h', user: 'u', password: 'p', database: 'd' },
+      clientFactory: () => client,
+    });
+    const r = await provider.listCollections();
+    assert.equal(r.ok, true);
+    if (!r.ok) throw new Error('unreachable');
+    assert.deepEqual(r.value, ['docs', 'other']);
+  });
+
+  it('rejects unsupported scope', async () => {
+    const client = makeFakeClient();
+    const provider = new PgVectorRagProvider({
+      name: 'pg',
+      embedder: makeEmbedder(),
+      connection: { collectionName: '__ignored', host: 'h', user: 'u', password: 'p', database: 'd' },
+      clientFactory: () => client,
+      supportedScopes: ['global'],
+    });
+    const r = await provider.createCollection('docs', { scope: 'session' });
+    assert.equal(r.ok, false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test → expect FAIL**
+
+Run: `npm test --workspace @mcp-abap-adt/pg-vector-rag`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `pg-vector-rag-provider.ts`**
+
+```ts
+import type {
+  IEmbedder,
+  IIdStrategy,
+  IRag,
+  IRagEditor,
+  RagCollectionScope,
+  Result,
+} from '@mcp-abap-adt/llm-agent';
+import { AbstractRagProvider, RagError } from '@mcp-abap-adt/llm-agent';
+import type { PgVectorRagConfig } from './connection.js';
+import { PgVectorRag, type PgClient } from './pg-vector-rag.js';
+import { quoteIdent } from './schema.js';
+
+export interface PgVectorRagProviderConfig {
+  name: string;
+  embedder: IEmbedder;
+  connection: PgVectorRagConfig | string;
+  defaultDimension?: number;
+  autoCreateSchema?: boolean;
+  editable?: boolean;
+  supportedScopes?: readonly RagCollectionScope[];
+  idStrategyFactory?: (opts: {
+    scope: RagCollectionScope;
+    sessionId?: string;
+    userId?: string;
+  }) => IIdStrategy;
+  clientFactory?: () => PgClient;
+}
+
+function normalizeConnection(c: PgVectorRagConfig | string): PgVectorRagConfig {
+  return typeof c === 'string'
+    ? { connectionString: c, collectionName: '__unused' }
+    : c;
+}
+
+export class PgVectorRagProvider extends AbstractRagProvider {
+  readonly name: string;
+  readonly kind = 'vector';
+  readonly editable: boolean;
+  readonly supportedScopes: readonly RagCollectionScope[];
+
+  private readonly embedder: IEmbedder;
+  private readonly connection: PgVectorRagConfig;
+  private readonly defaultDimension: number;
+  private readonly autoCreateSchema: boolean;
+  private readonly clientFactory?: () => PgClient;
+
+  constructor(cfg: PgVectorRagProviderConfig) {
+    super();
+    this.name = cfg.name;
+    this.embedder = cfg.embedder;
+    this.connection = normalizeConnection(cfg.connection);
+    this.defaultDimension = cfg.defaultDimension ?? 1536;
+    this.autoCreateSchema = cfg.autoCreateSchema ?? true;
+    this.editable = cfg.editable ?? true;
+    this.supportedScopes = cfg.supportedScopes ?? ['session', 'user', 'global'];
+    this.clientFactory = cfg.clientFactory;
+    if (cfg.idStrategyFactory) this.idStrategyFactory = cfg.idStrategyFactory;
+  }
+
+  async createCollection(
+    name: string,
+    opts: { scope: RagCollectionScope; sessionId?: string; userId?: string },
+  ): Promise<Result<{ rag: IRag; editor: IRagEditor }, RagError>> {
+    const scopeCheck = this.checkScope(opts.scope);
+    if (!scopeCheck.ok) return scopeCheck;
+    try {
+      const rag = new PgVectorRag(
+        {
+          ...this.connection,
+          collectionName: name,
+          dimension: this.connection.dimension ?? this.defaultDimension,
+          autoCreateSchema: this.autoCreateSchema,
+          embedder: this.embedder,
+        },
+        this.clientFactory?.(),
+      );
+      if (this.autoCreateSchema) await rag.ensureSchema();
+      const editor = this.buildEditor(rag, this.pickIdStrategy(opts));
+      return { ok: true, value: { rag, editor } };
+    } catch (err) {
+      return { ok: false, error: new RagError(String(err), 'RAG_CREATE_ERROR') };
+    }
+  }
+
+  async deleteCollection(name: string): Promise<Result<void, RagError>> {
+    try {
+      const client = this.requireClient();
+      await client.query(`DROP TABLE IF EXISTS ${quoteIdent(name)}`);
+      return { ok: true, value: undefined };
+    } catch (err) {
+      return { ok: false, error: new RagError(String(err), 'RAG_DELETE_ERROR') };
+    }
+  }
+
+  async listCollections(): Promise<Result<string[], RagError>> {
+    try {
+      const client = this.requireClient();
+      const schema = this.connection.schema ?? 'public';
+      const { rows } = await client.query(
+        'SELECT table_name FROM information_schema.tables WHERE table_schema = $1',
+        [schema],
+      );
+      return { ok: true, value: rows.map((r) => String(r.table_name)) };
+    } catch (err) {
+      return { ok: false, error: new RagError(String(err), 'RAG_LIST_ERROR') };
+    }
+  }
+
+  private requireClient(): PgClient {
+    if (!this.clientFactory) {
+      throw new Error(
+        'PgVectorRagProvider deleteCollection/listCollections require clientFactory; provide one or use createCollection-only paths',
+      );
+    }
+    return this.clientFactory();
+  }
+}
+```
+
+- [ ] **Step 4: Run test → expect PASS**
+
+Run: `npm test --workspace @mcp-abap-adt/pg-vector-rag`
+Expected: passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/pg-vector-rag/src
+git commit -m "feat(pg-vector-rag): PgVectorRagProvider"
+```
+
+---
+
+### Task 11: Server — RAG factory registry (prefetch + sync resolve)
+
+**Files:**
+- Create: `packages/llm-agent-server/src/smart-agent/rag-factories.ts`
+- Create: `packages/llm-agent-server/src/smart-agent/__tests__/rag-factories.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { MissingProviderError } from '@mcp-abap-adt/llm-agent';
+import {
+  _resetPrefetchedRagForTests,
+  prefetchRagFactories,
+  resolveRag,
+} from '../rag-factories.js';
+
+describe('rag-factories', () => {
+  it('throws MissingProviderError for unknown backend name', async () => {
+    _resetPrefetchedRagForTests();
+    await assert.rejects(() => prefetchRagFactories(['nope']), MissingProviderError);
+  });
+
+  it('throws MissingProviderError at resolveRag when not prefetched', () => {
+    _resetPrefetchedRagForTests();
+    assert.throws(
+      () => resolveRag('hana-vector', { collectionName: 'x', embedder: {} as never }),
+      MissingProviderError,
+    );
+  });
+
+  it('prefetches known packages (qdrant already installed via workspace dev dep)', async () => {
+    _resetPrefetchedRagForTests();
+    await prefetchRagFactories(['qdrant']);
+    const rag = resolveRag('qdrant', {
+      url: 'http://localhost:6333',
+      collectionName: 't',
+      embedder: { async embed() { return { vector: [0, 0, 0] }; } },
+    });
+    assert.equal(typeof rag.query, 'function');
+  });
+});
+```
+
+- [ ] **Step 2: Run test → expect FAIL**
+
+Run: `npm test --workspace @mcp-abap-adt/llm-agent-server`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `rag-factories.ts`**
+
+```ts
+import type { IEmbedder, IRag } from '@mcp-abap-adt/llm-agent';
+import { MissingProviderError } from '@mcp-abap-adt/llm-agent';
+
+export interface RagFactoryOpts {
+  url?: string;
+  apiKey?: string;
+  collectionName?: string;
+  embedder: IEmbedder;
+  timeoutMs?: number;
+  dimension?: number;
+  autoCreateSchema?: boolean;
+  connectionString?: string;
+  host?: string;
+  port?: number;
+  user?: string;
+  password?: string;
+  database?: string;
+  schema?: string;
+  poolMax?: number;
+  connectTimeout?: number;
+}
+
+const PACKAGE_BY_NAME: Record<string, string> = {
+  qdrant: '@mcp-abap-adt/qdrant-rag',
+  'hana-vector': '@mcp-abap-adt/hana-vector-rag',
+  'pg-vector': '@mcp-abap-adt/pg-vector-rag',
+};
+
+type RagCtor = new (opts: Record<string, unknown>) => IRag;
+
+const EXPORT_BY_NAME: Record<string, string> = {
+  qdrant: 'QdrantRag',
+  'hana-vector': 'HanaVectorRag',
+  'pg-vector': 'PgVectorRag',
+};
+
+const prefetched = new Map<string, Record<string, unknown>>();
+
+export async function prefetchRagFactories(
+  names: readonly string[],
+): Promise<void> {
+  for (const name of names) {
+    if (prefetched.has(name)) continue;
+    const pkg = PACKAGE_BY_NAME[name];
+    if (!pkg) throw new MissingProviderError('(unknown)', name);
+    try {
+      const mod = (await import(pkg)) as Record<string, unknown>;
+      prefetched.set(name, mod);
+    } catch {
+      throw new MissingProviderError(pkg, name);
+    }
+  }
+}
+
+export function resolveRag(name: string, opts: RagFactoryOpts): IRag {
+  const mod = prefetched.get(name);
+  if (!mod) {
+    const pkg = PACKAGE_BY_NAME[name] ?? '(unknown)';
+    throw new MissingProviderError(pkg, name);
+  }
+  const exportName = EXPORT_BY_NAME[name];
+  const Cls = mod[exportName] as RagCtor | undefined;
+  if (!Cls) {
+    throw new MissingProviderError(PACKAGE_BY_NAME[name] ?? '(unknown)', name);
+  }
+  return new Cls(opts as unknown as Record<string, unknown>);
+}
+
+export function _resetPrefetchedRagForTests(): void {
+  prefetched.clear();
+}
+
+export const ragBackendNames = Object.freeze(
+  Object.keys(PACKAGE_BY_NAME),
+) as readonly string[];
+```
+
+- [ ] **Step 4: Run test → expect PASS**
+
+Run: `npm test --workspace @mcp-abap-adt/llm-agent-server -- --test-name-pattern 'rag-factories'`
+Expected: 3 passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/llm-agent-server/src/smart-agent/rag-factories.ts packages/llm-agent-server/src/smart-agent/__tests__/rag-factories.test.ts
+git commit -m "feat(server): rag-factories registry (prefetch + sync resolve)"
+```
+
+---
+
+### Task 12: Wire new RAG types into `makeRag` + config surfaces
+
+**Files:**
+- Modify: `packages/llm-agent-server/src/smart-agent/providers.ts` (the `RagResolutionConfig` interface + `makeRag` switch)
+- Modify: `packages/llm-agent-server/src/smart-agent/pipeline.ts` (type union + comment)
+- Modify: `packages/llm-agent-server/src/smart-agent/smart-server.ts` (`SmartServerRagConfig.type`)
+- Modify: `packages/llm-agent-server/src/smart-agent/config.ts` (YAML cast + sample comment)
+
+- [ ] **Step 1: Extend `RagResolutionConfig` and route new types in `makeRag`**
+
+Edit `providers.ts`:
+
+Change `type?: 'ollama' | 'openai' | 'in-memory' | 'qdrant';` to `type?: 'ollama' | 'openai' | 'in-memory' | 'qdrant' | 'hana-vector' | 'pg-vector';`.
+
+Add these fields to the interface (keep existing fields):
+
+```ts
+  /** Connection string or URL for external vector backends. */
+  connectionString?: string;
+  host?: string;
+  port?: number;
+  user?: string;
+  password?: string;
+  database?: string;
+  schema?: string;
+  dimension?: number;
+  autoCreateSchema?: boolean;
+  poolMax?: number;
+  connectTimeout?: number;
+```
+
+Refactor the existing `qdrant` branch to use `resolveRag('qdrant', …)` (instead of `new QdrantRag`), and add parallel `hana-vector` / `pg-vector` branches:
+
+```ts
+  if (cfg.type === 'qdrant') {
+    if (!cfg.url) throw new Error('Qdrant URL is required for qdrant RAG type');
+    const embedder = resolveEmbedder(cfg, options);
+    return resolveRag('qdrant', {
+      url: cfg.url,
+      collectionName: cfg.collectionName ?? 'llm-agent',
+      embedder,
+      apiKey: cfg.apiKey,
+      timeoutMs: cfg.timeoutMs,
+    });
+  }
+
+  if (cfg.type === 'hana-vector') {
+    if (!cfg.collectionName) throw new Error('collectionName is required for hana-vector RAG type');
+    const embedder = resolveEmbedder(cfg, options);
+    return resolveRag('hana-vector', {
+      connectionString: cfg.connectionString,
+      host: cfg.host,
+      port: cfg.port,
+      user: cfg.user,
+      password: cfg.password,
+      schema: cfg.schema,
+      collectionName: cfg.collectionName,
+      dimension: cfg.dimension,
+      autoCreateSchema: cfg.autoCreateSchema,
+      poolMax: cfg.poolMax,
+      connectTimeout: cfg.connectTimeout,
+      embedder,
+    });
+  }
+
+  if (cfg.type === 'pg-vector') {
+    if (!cfg.collectionName) throw new Error('collectionName is required for pg-vector RAG type');
+    const embedder = resolveEmbedder(cfg, options);
+    return resolveRag('pg-vector', {
+      connectionString: cfg.connectionString,
+      host: cfg.host,
+      port: cfg.port,
+      user: cfg.user,
+      password: cfg.password,
+      database: cfg.database,
+      schema: cfg.schema,
+      collectionName: cfg.collectionName,
+      dimension: cfg.dimension,
+      autoCreateSchema: cfg.autoCreateSchema,
+      poolMax: cfg.poolMax,
+      connectTimeout: cfg.connectTimeout,
+      embedder,
+    });
+  }
+```
+
+Replace the existing `import { QdrantRag } from '@mcp-abap-adt/qdrant-rag';` with `import { resolveRag } from './rag-factories.js';` (if the import was only used for `new QdrantRag` in `makeRag`; check with grep before removing).
+
+- [ ] **Step 2: Extend pipeline type union**
+
+Edit `packages/llm-agent-server/src/smart-agent/pipeline.ts` around line 33-34:
+
+```ts
+  /** 'ollama' | 'openai' | 'in-memory' | 'qdrant' | 'hana-vector' | 'pg-vector'. Default: 'ollama' */
+  type?: 'ollama' | 'openai' | 'in-memory' | 'qdrant' | 'hana-vector' | 'pg-vector';
+```
+
+Near the existing "Qdrant collection name" comment, add:
+
+```ts
+  /** Qdrant / HANA / Postgres collection (table) name. */
+```
+
+- [ ] **Step 3: Extend SmartServerRagConfig**
+
+Edit `packages/llm-agent-server/src/smart-agent/smart-server.ts` around line 67-81:
+
+```ts
+export interface SmartServerRagConfig {
+  type?: 'ollama' | 'openai' | 'in-memory' | 'qdrant' | 'hana-vector' | 'pg-vector';
+  embedder?: string;
+  url?: string;
+  model?: string;
+  collectionName?: string;
+  dedupThreshold?: number;
+  vectorWeight?: number;
+  keywordWeight?: number;
+  connectionString?: string;
+  host?: string;
+  port?: number;
+  user?: string;
+  password?: string;
+  database?: string;
+  schema?: string;
+  dimension?: number;
+  autoCreateSchema?: boolean;
+  poolMax?: number;
+  connectTimeout?: number;
+}
+```
+
+- [ ] **Step 4: Extend config.ts YAML cast + sample comments**
+
+Edit `packages/llm-agent-server/src/smart-agent/config.ts`:
+
+- Update line 52 comment:
+  ```yaml
+  rag:
+    type: ollama                        # ollama | in-memory | qdrant | hana-vector | pg-vector
+  ```
+- Update line 56 comment:
+  ```yaml
+    # collectionName: llm-agent         # Collection / table name (qdrant | hana-vector | pg-vector)
+  ```
+- Add a second sample block after the existing `type: qdrant` sample (around line 118):
+  ```yaml
+  #     type: hana-vector
+  #     connectionString: hdbsql://user:pass@host:443
+  #     collectionName: llm_agent_docs
+  #     dimension: 1536
+  #     autoCreateSchema: true
+  #
+  #     type: pg-vector
+  #     connectionString: postgres://user:pass@host:5432/db
+  #     collectionName: llm_agent_docs
+  #     dimension: 1536
+  #     autoCreateSchema: true
+  ```
+- Update line 286 type cast to:
+  ```ts
+        'ollama') as 'ollama' | 'in-memory' | 'qdrant' | 'hana-vector' | 'pg-vector',
+  ```
+
+- [ ] **Step 5: Run full server test suite**
+
+Run: `npm test --workspace @mcp-abap-adt/llm-agent-server`
+Expected: all previous tests still passing; new rag-factories tests passing.
+
+- [ ] **Step 6: Build full workspace**
+
+Run: `npm run build`
+Expected: all 12 packages compile (build script updated in Task 14).
+
+If build fails because `packages/hana-vector-rag` / `packages/pg-vector-rag` are not yet in root build config, proceed to Task 14 first then re-run.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/llm-agent-server/src/smart-agent/providers.ts packages/llm-agent-server/src/smart-agent/pipeline.ts packages/llm-agent-server/src/smart-agent/smart-server.ts packages/llm-agent-server/src/smart-agent/config.ts
+git commit -m "feat(server): route hana-vector and pg-vector via rag-factories"
+```
+
+---
+
+### Task 13: Server integration test — direct `makeRag()` schema bootstrap + MissingProviderError
+
+**Files:**
+- Create: `packages/llm-agent-server/src/smart-agent/__tests__/hana-pg-integration.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { MissingProviderError } from '@mcp-abap-adt/llm-agent';
+import {
+  _resetPrefetchedRagForTests,
+  prefetchRagFactories,
+  resolveRag,
+} from '../rag-factories.js';
+import { makeRag } from '../providers.js';
+
+describe('hana-vector / pg-vector server integration', () => {
+  it('resolveRag throws MissingProviderError when peer is not prefetched', () => {
+    _resetPrefetchedRagForTests();
+    assert.throws(
+      () =>
+        resolveRag('hana-vector', {
+          collectionName: 't',
+          host: 'h',
+          user: 'u',
+          password: 'p',
+          embedder: { async embed() { return { vector: [0] }; } },
+        }),
+      MissingProviderError,
+    );
+  });
+
+  it('makeRag path initializes schema for hana-vector when autoCreateSchema=true', async () => {
+    _resetPrefetchedRagForTests();
+    await prefetchRagFactories(['hana-vector']);
+    const embedder = { async embed() { return { vector: [0, 0, 0] }; } };
+    const rag = makeRag(
+      {
+        type: 'hana-vector',
+        host: 'h',
+        user: 'u',
+        password: 'p',
+        collectionName: 'direct_docs',
+        dimension: 3,
+        autoCreateSchema: true,
+      },
+      { injectedEmbedder: embedder },
+    ) as unknown as { ensureSchema: () => Promise<void> };
+    // The real ensureSchema() would attempt to connect; we only assert the method
+    // exists and is exposed on the backend class so both provider-driven and
+    // direct makeRag() paths can invoke identical schema bootstrap.
+    assert.equal(typeof rag.ensureSchema, 'function');
+  });
+
+  it('makeRag path exposes ensureSchema() for pg-vector', async () => {
+    _resetPrefetchedRagForTests();
+    await prefetchRagFactories(['pg-vector']);
+    const embedder = { async embed() { return { vector: [0, 0, 0] }; } };
+    const rag = makeRag(
+      {
+        type: 'pg-vector',
+        host: 'h',
+        user: 'u',
+        password: 'p',
+        database: 'd',
+        collectionName: 'direct_docs',
+        dimension: 3,
+        autoCreateSchema: true,
+      },
+      { injectedEmbedder: embedder },
+    ) as unknown as { ensureSchema: () => Promise<void> };
+    assert.equal(typeof rag.ensureSchema, 'function');
+  });
+});
+```
+
+- [ ] **Step 2: Run test → expect FAIL initially, then PASS once Tasks 11-12 are in place**
+
+Run: `npm test --workspace @mcp-abap-adt/llm-agent-server -- --test-name-pattern 'hana-vector / pg-vector'`
+Expected: 3 passing.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/llm-agent-server/src/smart-agent/__tests__/hana-pg-integration.test.ts
+git commit -m "test(server): hana/pg integration — MissingProviderError + ensureSchema exposure"
+```
+
+---
+
+### Task 14: Workspace wiring — server deps, tsconfig refs, root scripts, changesets
+
+**Files:**
+- Modify: `packages/llm-agent-server/package.json`
+- Modify: `packages/llm-agent-server/tsconfig.json`
+- Modify: `package.json` (root)
+- Modify: `tsconfig.json` (root)
+- Modify: `.changeset/config.json`
+
+- [ ] **Step 1: Extend server `package.json` peers + devDeps**
+
+Edit `packages/llm-agent-server/package.json`. Add to `peerDependencies`:
+
+```json
+"@mcp-abap-adt/hana-vector-rag": "^11.0.0",
+"@mcp-abap-adt/pg-vector-rag": "^11.0.0"
+```
+
+Add to `peerDependenciesMeta`:
+
+```json
+"@mcp-abap-adt/hana-vector-rag": { "optional": true },
+"@mcp-abap-adt/pg-vector-rag": { "optional": true }
+```
+
+Add to `devDependencies`:
+
+```json
+"@mcp-abap-adt/hana-vector-rag": "*",
+"@mcp-abap-adt/pg-vector-rag": "*"
+```
+
+- [ ] **Step 2: Extend server `tsconfig.json` references**
+
+Read `packages/llm-agent-server/tsconfig.json`. In the `references` array, append:
+
+```json
+{ "path": "../hana-vector-rag" },
+{ "path": "../pg-vector-rag" }
+```
+
+- [ ] **Step 3: Extend root `tsconfig.json` references**
+
+Append the same two `{ "path": "packages/hana-vector-rag" }` and `{ "path": "packages/pg-vector-rag" }` entries to the root `tsconfig.json` `references` array (match the existing style — check with `cat tsconfig.json` first).
+
+- [ ] **Step 4: Extend root `package.json` `build` / `clean` / `test` scripts**
+
+If the scripts already delegate to `tsc -b` (recursive project references), no change is needed — references in `tsconfig.json` cover it. Otherwise append workspace invocations for the two new packages. Verify by inspecting the current scripts:
+
+```bash
+node -e "console.log(require('./package.json').scripts)"
+```
+
+If a loop over a package list exists, append `hana-vector-rag` and `pg-vector-rag` to it.
+
+- [ ] **Step 5: Extend `.changeset/config.json` fixed group**
+
+Edit `.changeset/config.json`:
+
+```json
+"fixed": [
+  [
+    "@mcp-abap-adt/llm-agent",
+    "@mcp-abap-adt/llm-agent-server",
+    "@mcp-abap-adt/openai-llm",
+    "@mcp-abap-adt/anthropic-llm",
+    "@mcp-abap-adt/deepseek-llm",
+    "@mcp-abap-adt/sap-aicore-llm",
+    "@mcp-abap-adt/openai-embedder",
+    "@mcp-abap-adt/ollama-embedder",
+    "@mcp-abap-adt/sap-aicore-embedder",
+    "@mcp-abap-adt/qdrant-rag",
+    "@mcp-abap-adt/hana-vector-rag",
+    "@mcp-abap-adt/pg-vector-rag"
+  ]
+]
+```
+
+- [ ] **Step 6: Re-install to link workspaces**
+
+Run: `npm install`
+Expected: completes without errors; `node_modules/@mcp-abap-adt/hana-vector-rag` and `…/pg-vector-rag` symlinks present.
+
+- [ ] **Step 7: Full build + full test**
+
+Run: `npm run build && npm test`
+Expected: all 12 packages build; full test suite passes (server: existing + new, new packages: their own suites).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/llm-agent-server/package.json packages/llm-agent-server/tsconfig.json package.json tsconfig.json .changeset/config.json package-lock.json
+git commit -m "chore: wire hana-vector-rag + pg-vector-rag into workspace"
+```
+
+---
+
+### Task 15: Documentation updates
+
+**Files:**
+- Modify: `README.md` (root)
+- Modify: `MIGRATION-v11.md`
+- Modify: `CHANGELOG.md` (root)
+
+- [ ] **Step 1: Extend root `README.md` package table**
+
+Open `README.md`, locate the package table (search for `@mcp-abap-adt/qdrant-rag`), and append two rows:
+
+```
+| `@mcp-abap-adt/hana-vector-rag` | SAP HANA Cloud Vector Engine backend (`HanaVectorRag`, `HanaVectorRagProvider`). Optional peer. |
+| `@mcp-abap-adt/pg-vector-rag`   | PostgreSQL + pgvector backend (`PgVectorRag`, `PgVectorRagProvider`). Optional peer. |
+```
+
+Match the existing table column count (check with head-limited grep).
+
+- [ ] **Step 2: Extend `MIGRATION-v11.md`**
+
+Append a new section:
+
+```markdown
+## New RAG backends (11.0.0 final)
+
+Two additional optional peer packages ship with 11.0.0:
+
+- `@mcp-abap-adt/hana-vector-rag` — SAP HANA Cloud Vector Engine. Runtime peer: `@sap/hana-client`.
+- `@mcp-abap-adt/pg-vector-rag` — PostgreSQL + pgvector. Runtime peer: `pg`.
+
+Install only the backend your deployment actually uses:
+
+```bash
+# HANA
+npm install @mcp-abap-adt/llm-agent-server @mcp-abap-adt/hana-vector-rag @sap/hana-client
+
+# Postgres + pgvector
+npm install @mcp-abap-adt/llm-agent-server @mcp-abap-adt/pg-vector-rag pg
+```
+
+YAML config:
+
+```yaml
+rag:
+  type: hana-vector           # or: pg-vector
+  connectionString: hdbsql://user:pass@host:443
+  collectionName: llm_agent_docs
+  dimension: 1536
+  autoCreateSchema: true
+```
+
+If the selected `type` references a backend whose peer package is not installed, server startup fails with `MissingProviderError` naming the missing package.
+```
+
+- [ ] **Step 3: Amend root `CHANGELOG.md` 11.0.0 entry**
+
+Locate the existing `## 11.0.0` block. Under "New packages" (or equivalent), append:
+
+```markdown
+- `@mcp-abap-adt/hana-vector-rag` — SAP HANA Cloud Vector Engine backend.
+- `@mcp-abap-adt/pg-vector-rag` — PostgreSQL + pgvector backend.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md MIGRATION-v11.md CHANGELOG.md
+git commit -m "docs: document hana-vector-rag + pg-vector-rag in v11 release notes"
+```
+
+---
+
+### Task 16: Changeset entry + release checklist
+
+**Files:**
+- Create: `.changeset/v11-hana-pgvector.md`
+
+- [ ] **Step 1: Write changeset file**
+
+```markdown
+---
+"@mcp-abap-adt/llm-agent": patch
+"@mcp-abap-adt/llm-agent-server": patch
+"@mcp-abap-adt/openai-llm": patch
+"@mcp-abap-adt/anthropic-llm": patch
+"@mcp-abap-adt/deepseek-llm": patch
+"@mcp-abap-adt/sap-aicore-llm": patch
+"@mcp-abap-adt/openai-embedder": patch
+"@mcp-abap-adt/ollama-embedder": patch
+"@mcp-abap-adt/sap-aicore-embedder": patch
+"@mcp-abap-adt/qdrant-rag": patch
+"@mcp-abap-adt/hana-vector-rag": patch
+"@mcp-abap-adt/pg-vector-rag": patch
+---
+
+feat: add optional peer packages `@mcp-abap-adt/hana-vector-rag` (SAP HANA Cloud Vector Engine) and `@mcp-abap-adt/pg-vector-rag` (PostgreSQL + pgvector). Server exposes `type: 'hana-vector'` and `type: 'pg-vector'` in RAG config. Missing peer packages fail at startup with typed `MissingProviderError`.
+```
+
+Note: use `patch` bumps since the 10 existing packages are still at 11.0.0 unreleased and the two new ones ship at 11.0.0 via the fixed-group lock-step.
+
+- [ ] **Step 2: Dry-run `changeset version`**
+
+Run: `npx changeset status --verbose`
+Expected: report shows all 12 packages moving together.
+
+- [ ] **Step 3: Commit changeset file**
+
+```bash
+git add .changeset/v11-hana-pgvector.md
+git commit -m "chore(changeset): hana-vector-rag + pg-vector-rag"
+```
+
+- [ ] **Step 4: Final workspace check**
+
+Run: `npm run build && npm test && npm run lint:check`
+Expected: green across the board.
+
+- [ ] **Step 5: Post-merge checklist (do NOT execute as part of this plan — for human operator after PR merge)**
+
+Write as `POST_MERGE_CHECKLIST-v11.md` at repo root (will be deleted per retention policy after release):
+
+```markdown
+# Post-merge release checklist — v11.0.0 final
+
+1. `git checkout main && git pull`
+2. `npx changeset version`                    # applies all pending changesets; resolves to 11.0.0
+3. Verify each `packages/*/package.json` is at `11.0.0`
+4. Verify each `packages/*/CHANGELOG.md` was updated
+5. `git add -A && git commit -m "chore: release 11.0.0"`
+6. `git push`
+7. `npx changeset publish`                    # publishes all 12 packages to npm
+8. `git tag -a v11.0.0 -m "Release 11.0.0"`
+9. `git push --tags`
+10. Delete retention-policy specs/plans:
+    - `docs/superpowers/specs/2026-04-24-v11-hana-pgvector-design.md`
+    - `docs/superpowers/specs/2026-04-22-v11-full-extraction-design.md`
+    - `docs/superpowers/plans/2026-04-23-v11-full-extraction.md`
+    - `docs/superpowers/plans/2026-04-24-v11-hana-pgvector.md`
+    - `POST_MERGE_CHECKLIST-v11.md` (this file)
+```
+
+- [ ] **Step 6: Commit checklist**
+
+```bash
+git add POST_MERGE_CHECKLIST-v11.md
+git commit -m "chore: v11.0.0 final release checklist"
+```
+
+---
+
+## Self-review notes
+
+1. **Spec coverage:**
+   - Two new packages (hana + pg): Tasks 1-10 ✓
+   - Server factory registry (prefetch + sync resolve, MissingProviderError): Task 11 ✓
+   - `RagResolutionConfig['type']`, pipeline types, smart-server types, config.ts YAML: Task 12 ✓
+   - Direct `makeRag()` schema-init test + missing peer error test: Task 13 ✓
+   - Server peer deps + devDeps + tsconfig refs + root build + changesets fixed group (12): Task 14 ✓
+   - Docs: README, MIGRATION-v11, CHANGELOG: Task 15 ✓
+   - Changeset + release checklist: Task 16 ✓
+   - Schema shape (`REAL_VECTOR` / `vector`, `NCLOB` / `JSONB`, `VARCHAR(255)` id): Tasks 4, 8 ✓
+   - Cosine similarity default: Tasks 5, 9 ✓
+   - Collection-name sanitization regex `^[a-zA-Z_][a-zA-Z0-9_]{0,62}$`: Tasks 4, 8 ✓
+   - `supportedScopes: ['session', 'user', 'global']`: Tasks 6, 10 ✓
+   - Backend-owned lazy `ensureSchema()` used by both direct and provider paths: Tasks 5, 9 (method), Tasks 6, 10 (provider calls), Task 13 (integration test) ✓
+
+2. **Architectural principles:**
+   - DI-first: provider takes embedder + connection; backend takes config + optional injectedClient ✓
+   - Implementation isolation: driver code behind `HanaClient` / `PgClient` interfaces in each package ✓
+   - Strategies: `idStrategyFactory` carried through both providers ✓
+   - Config-driven composition: `makeRag` switch uses config type literals, returns `IRag` ✓
+   - Optional peer safety: `rag-factories.ts` with `MissingProviderError` ✓
+
+3. **Known non-placeholders:**
+   - Task 6 `borrowClient()` is flagged as a deliberately minimal shim with an instruction to the implementer. This is concrete guidance, not a placeholder — the test uses `clientFactory` for delete/list paths, so production correctness is not blocked.
+   - Task 14 Step 4 (root scripts) is conditional on current repo layout. The exact command is `node -e` inspection + append — concrete, not TBD.

--- a/docs/superpowers/specs/2026-04-24-v11-hana-pgvector-design.md
+++ b/docs/superpowers/specs/2026-04-24-v11-hana-pgvector-design.md
@@ -46,11 +46,21 @@ Both implement `IRag` from core and produce editors paired with `IRagBackendWrit
 | 4 | Schema management | Hybrid — `autoCreateSchema: boolean` config flag. Default `true`. |
 | 5 | Connection shape | Accept both URL string (`postgres://…`, HANA equivalent) AND config object. Internal resolve. |
 | 6 | `supportedScopes` | `['session', 'user', 'global']` for both |
-| 7 | Auto-schema DDL location | Inside the provider's `createCollection` method when `autoCreateSchema: true`. Idempotent (`CREATE TABLE IF NOT EXISTS`, `CREATE EXTENSION IF NOT EXISTS vector`). |
+| 7 | Auto-schema DDL location | In backend-owned lazy init used by both direct `makeRag()` construction and provider `createCollection()`. Provider may call an explicit `ensureSchema()` helper, but schema creation must NOT rely on the provider path only. |
 | 8 | Distance metric | Cosine similarity (default; matches Qdrant's default and SmartAgent's RAG query shape). |
 | 9 | Vector dimension | Fixed per collection, supplied via config. Default 1536 (OpenAI text-embedding-3-small). Consumer overrides per collection. |
 
 ## Shared architecture (both packages)
+
+### Architectural principles
+
+This work may adjust the current module layout, but it should stay inside the project's existing architectural style:
+
+- **Dependency injection first**: composition roots create concrete backends/providers; consumers work against `IRag`, `IRagProvider`, `IRagEditor`, `IRagBackendWriter`, and related abstractions.
+- **Implementation isolation**: HANA- and Postgres-specific driver code stays inside their packages and behind interface-based boundaries. Server/core code should not grow backend-specific SQL or driver coupling.
+- **Behavior via strategies**: editing, id generation, ranking, and similar policy choices should continue to flow through strategy/factory seams rather than new hard-coded branches when an existing abstraction already fits.
+- **Config-driven composition**: declarative config may select implementations, but after resolution the runtime should operate through interfaces, not by type-checking concrete classes.
+- **Optional peer safety**: backend packages remain optional at installation time; the architecture must preserve clean failure modes when a selected backend package is not installed.
 
 ### Public surface
 
@@ -147,24 +157,34 @@ Both backends use the collection name as a SQL table identifier. Must be SQL-saf
 
 ```ts
 export class HanaVectorRagProvider extends AbstractRagProvider {
-  readonly name = 'hana-vector';
-  readonly kind = 'vector-db';
+  readonly name: string;
+  readonly kind = 'vector';
+  readonly editable: boolean;
   readonly supportedScopes = ['session', 'user', 'global'] as const;
 
   constructor(private readonly cfg: {
-    defaultEmbedder: IEmbedder;
+    name: string;
+    embedder: IEmbedder;
     connection: HanaVectorRagConfig | string;
     defaultDimension?: number;
     autoCreateSchema?: boolean;
-    defaultIdStrategy?: 'caller-provided' | 'uuid' | 'session-scoped' | 'canonical-key';
+    editable?: boolean;
+    idStrategyFactory?: (opts: {
+      scope: RagCollectionScope;
+      sessionId?: string;
+      userId?: string;
+    }) => IIdStrategy;
   }) {
     super();
+    this.name = cfg.name;
+    this.editable = cfg.editable ?? true;
+    if (cfg.idStrategyFactory) this.idStrategyFactory = cfg.idStrategyFactory;
   }
 
   async createCollection(name: string, opts: { scope, sessionId?, userId? }): Promise<Result<{ rag: IRag; editor: IRagEditor }, RagError>> {
     // 1. Validate scope against supportedScopes
     // 2. Instantiate HanaVectorRag with cfg.connection + name
-    // 3. If autoCreateSchema: run CREATE TABLE IF NOT EXISTS + CREATE INDEX
+    // 3. If autoCreateSchema: call rag.ensureSchema() (same helper used by direct makeRag() path)
     // 4. Build editor via buildEditor() helper from AbstractRagProvider
     // 5. Return pair
   }
@@ -183,7 +203,18 @@ export class HanaVectorRagProvider extends AbstractRagProvider {
 
 ### Server integration
 
-Add to server's factory registry (`embedder-factories.ts` analog for RAG providers — or in a new file if a dedicated RAG factory registry is warranted). For v11.0.0 scope, the factory registry stays on embedders; RAG backends are instantiated by name inside `SmartServer` composition. Task plan inspects `SmartServer.ts` to see how `rag.type` resolves today and extends that resolver with `hana-vector` and `pg-vector` cases.
+This spec defines required behavior, not a mandatory refactor shape. The current v11 server architecture resolves YAML/CLI RAG stores synchronously via `makeRag()`, but the implementation is allowed to evolve while this work is in progress.
+
+The implementation MUST preserve these observable properties regardless of the final internal architecture:
+
+- `hana-vector` and `pg-vector` can be selected from declarative server config just like existing RAG backends.
+- Missing optional peer packages fail with `MissingProviderError` (or an equivalent purpose-built startup/config error if the architecture is refactored), rather than crashing from an unconditional top-level import.
+- Schema bootstrap works for both direct config-driven construction and provider-driven dynamic collection creation.
+- Config parsing, validation, and docs stay aligned so the same `rag.type` values are accepted everywhere the server exposes RAG configuration.
+
+One acceptable implementation is a dedicated `rag-factories.ts` mirroring `embedder-factories.ts` with prefetch + sync resolve. Another acceptable implementation is a broader architecture change that makes RAG resolution async or moves optional-peer loading behind a different composition boundary. In both cases, concrete backend selection should remain a composition-root concern and the rest of the runtime should continue to depend on interfaces/strategies rather than backend-specific conditionals.
+
+Do not hard-code the work to a specific current filename such as `SmartServer.ts`. The exact integration points may move during implementation.
 
 Server's `peerDependencies` gains:
 
@@ -202,17 +233,18 @@ Root `package.json` `build`/`clean` scripts extended with `packages/hana-vector-
 
 Changesets `fixed` group extended to 12 packages.
 
-### Factory registry additions
+### RAG factory registry additions
 
-In `packages/llm-agent-server/src/smart-agent/embedder-factories.ts` (if that's where RAG resolution lives — or a sibling RAG factory file), add:
+If the implementation keeps the current factory-based resolution style, add a dedicated RAG factory registry, for example `packages/llm-agent-server/src/smart-agent/rag-factories.ts`:
 
 ```ts
 // PACKAGE_BY_NAME (for RAG backends requiring peer resolution)
+'qdrant':      '@mcp-abap-adt/qdrant-rag',
 'hana-vector': '@mcp-abap-adt/hana-vector-rag',
 'pg-vector':   '@mcp-abap-adt/pg-vector-rag',
 ```
 
-If SmartServer's config resolution for `rag.type` is hard-coded (switch statement) rather than factory-based, extend the switch with the two new cases, each preceded by a prefetch step that dynamic-imports the peer and falls back to `MissingProviderError` when absent.
+If the implementation keeps a `providers.ts`-style switch, extend it with `hana-vector` and `pg-vector` cases that resolve via that registry rather than unconditional direct imports. If the architecture is refactored away from that switch, preserve the same behavior through the new composition path. In all cases, `RagResolutionConfig['type']`, pipeline config types, YAML comments, and example config docs must be extended to include both new literals.
 
 ## Testing
 
@@ -223,7 +255,8 @@ Cover:
 - Provider: `createCollection` (happy path + autoCreateSchema on/off), `deleteCollection`, `listCollections`, scope rejection
 - Connection string parsing (URL vs explicit fields)
 - Collection-name validation rejection
-- `MissingProviderError` path when peer isn't installed (integration test in server)
+- `MissingProviderError` path when peer isn't installed (integration test in server prefetch/resolve flow)
+- Direct `makeRag()` path initializes schema when `autoCreateSchema: true` even without going through `IRagProvider`
 
 No real-database tests in CI for v11.0.0. Real-DB integration is out-of-scope (separate smoke suite later).
 
@@ -267,10 +300,11 @@ Both new packages depend only on core. No cross-deps with other peers. Clean fan
 3. `MIGRATION-v11.md` gains a "New RAG backends" section naming both packages.
 4. README gains both in the package table.
 5. Extend root CHANGELOG entry for 11.0.0 to mention the two new packages.
-6. Full workspace build + test clean.
-7. Merge PR to `main`.
-8. Post-merge: `npx changeset publish` → all 12 packages published at 11.0.0.
-9. `git tag -a v11.0.0 -m "Release 11.0.0"` + push → GitHub release workflow.
+6. Update whichever server config/resolution modules own `rag.type` parsing so both new values are accepted everywhere current literals are enumerated.
+7. Full workspace build + test clean.
+8. Merge PR to `main`.
+9. Post-merge: `npx changeset publish` → all 12 packages published at 11.0.0.
+10. `git tag -a v11.0.0 -m "Release 11.0.0"` + push → GitHub release workflow.
 
 ## Out of scope
 
@@ -284,5 +318,10 @@ Both new packages depend only on core. No cross-deps with other peers. Clean fan
 ## Known items for implementation plan
 
 - Collection-name → SQL table-identifier sanitization: single regex, same in both packages. Centralize in a core utility? For v11.0.0 scope, keep the regex duplicated in each package; consolidate later if multiple backends grow.
-- Connection pool lifecycle: both packages own their pool. Server doesn't manage it. Pool closes on `rag.close?()` (if IRag gains an optional close method) or on process exit via handler.
-- Metadata JSON column type: Postgres supports native `JSONB` (preferred). HANA has `NCLOB` for JSON; `NVARCHAR` as fallback with size limit. Tests must round-trip metadata correctly.
+- Connection pool lifecycle: both packages own their pool. Do not add `IRag.close()` in this scope. Create one pool/connection-manager per `IRag` instance and rely on process lifetime for now; if explicit disposal becomes necessary, that is a separate core API change.
+- Metadata JSON column type: Postgres uses native `JSONB`. HANA uses `NCLOB` for serialized JSON payloads; do not standardize on `NVARCHAR` in the primary schema because size limits are too constraining for metadata growth. Tests must round-trip metadata correctly.
+- Auto-schema bootstrap must work in both construction paths:
+  - direct `makeRag()` / SmartServer config path
+  - dynamic collection creation via `IRagProvider`
+  Backend code should expose one internal schema-init helper so DDL behavior does not diverge across those paths.
+- Architecture flexibility: while implementing this spec, it is acceptable to change the current server/provider composition if that produces a cleaner solution for optional-peer loading and RAG backend resolution. The spec constrains behavior and external contracts, not the exact module layout, but the solution should still follow the repository's standing principles: DI, implementation isolation behind interfaces, and behavior modeled through strategies/factories where appropriate.

--- a/docs/superpowers/specs/2026-04-24-v11-hana-pgvector-design.md
+++ b/docs/superpowers/specs/2026-04-24-v11-hana-pgvector-design.md
@@ -1,0 +1,288 @@
+# v11.0.0 Completion — HANA + pgvector RAG packages
+
+**Date:** 2026-04-24
+**Target release:** v11.0.0 (extends the already-merged but not-yet-published v11 refactor)
+**Status:** Draft → In Review
+**Builds on:** PR #114 (provider/backend extraction) already on `main`
+
+## Motivation
+
+PR #114 merged into `main` at version `11.0.0` but has not been published to npm yet. Before tagging and publishing, add two more RAG backend packages so consumers get a single v11.0.0 migration instead of drip-feeding 11.1/11.2. Both packages complete the coverage of RAG backends that deployments routinely need:
+
+- **HANA Cloud Vector Engine** — the SAP BTP CF native option. Without this package, consumers running on BTP have only Qdrant-in-Kyma as a sanctioned option.
+- **PostgreSQL + pgvector** — the industry-standard self-hosted option. Commonly paired with existing Postgres OLTP deployments.
+
+Both are net-new code (no extraction — these classes don't exist in the repo). `InMemoryRag` and `VectorRag` stay in core: lightweight, no deps, useful for PoC and for storing MCP tool descriptions in the default agent.
+
+## Scope
+
+### New packages (2)
+
+- **`@mcp-abap-adt/hana-vector-rag`** — `HanaVectorRag` + `HanaVectorRagProvider`. Runtime dep: `@sap/hana-client` (official SAP driver).
+- **`@mcp-abap-adt/pg-vector-rag`** — `PgVectorRag` + `PgVectorRagProvider`. Runtime deps: `pg` (most-used Postgres driver). Optional pgvector helper is NOT required — we issue SQL directly.
+
+Both implement `IRag` from core and produce editors paired with `IRagBackendWriter`. Both expose a Provider implementing `IRagProvider` with `supportedScopes: ['session', 'user', 'global']`.
+
+### What stays unchanged
+
+- `InMemoryRag`, `VectorRag`, their providers, `SimpleRagRegistry`, `SimpleRagProviderRegistry`, all other RAG infrastructure in core.
+- `QdrantRag` in its extracted package.
+- Server's factory registry (just gains two more entries).
+- Server's optional peer deps list gains two more packages.
+
+### Version + release
+
+- All 12 packages ship at 11.0.0 (10 from PR #114 + 2 new).
+- Single `npx changeset publish` after this PR merges.
+- Single `v11.0.0` git tag.
+
+## Resolved questions
+
+| # | Question | Decision |
+|---|---|---|
+| 1 | Package naming | `hana-vector-rag` + `pg-vector-rag` (symmetric with `qdrant-rag`) |
+| 2 | HANA driver | `@sap/hana-client` (official, production-ready) |
+| 3 | Postgres driver | `pg` (ecosystem default) |
+| 4 | Schema management | Hybrid — `autoCreateSchema: boolean` config flag. Default `true`. |
+| 5 | Connection shape | Accept both URL string (`postgres://…`, HANA equivalent) AND config object. Internal resolve. |
+| 6 | `supportedScopes` | `['session', 'user', 'global']` for both |
+| 7 | Auto-schema DDL location | Inside the provider's `createCollection` method when `autoCreateSchema: true`. Idempotent (`CREATE TABLE IF NOT EXISTS`, `CREATE EXTENSION IF NOT EXISTS vector`). |
+| 8 | Distance metric | Cosine similarity (default; matches Qdrant's default and SmartAgent's RAG query shape). |
+| 9 | Vector dimension | Fixed per collection, supplied via config. Default 1536 (OpenAI text-embedding-3-small). Consumer overrides per collection. |
+
+## Shared architecture (both packages)
+
+### Public surface
+
+Each package exports:
+
+```ts
+export class HanaVectorRag implements IRag { /* ... */ }
+export class HanaVectorRagProvider extends AbstractRagProvider { /* ... */ }
+export interface HanaVectorRagConfig { /* connection + schema + dimension */ }
+export interface HanaVectorRagProviderConfig { /* same plus provider metadata */ }
+```
+
+(Analogous names for `PgVector*`.)
+
+### `IRag` method mapping
+
+| IRag method | HANA SQL | Postgres SQL |
+|---|---|---|
+| `query(embedding, k, options)` | `SELECT ... ORDER BY COSINE_SIMILARITY(vec, ?) DESC LIMIT ?` | `SELECT ... ORDER BY vec <=> ? LIMIT ?` (pgvector) |
+| `getById(id, options)` | `SELECT ... WHERE id = ?` | same |
+| `healthCheck(options)` | `SELECT 1 FROM DUMMY` | `SELECT 1` |
+| `writer().upsertRaw(id, text, meta, options)` | `UPSERT INTO ... VALUES (...)` | `INSERT ... ON CONFLICT (id) DO UPDATE SET ...` |
+| `writer().deleteByIdRaw(id, options)` | `DELETE FROM ... WHERE id = ?` | same |
+| `writer().clearAll()` | `DELETE FROM ...` (or `TRUNCATE`) | `TRUNCATE ...` |
+| `writer().upsertPrecomputedRaw(id, text, vector, meta, options)` | UPSERT with vector literal | INSERT … ON CONFLICT with vector literal |
+
+### Schema shape (both backends)
+
+```
+<collection_name> table:
+  id          VARCHAR(255) PRIMARY KEY
+  text        VARCHAR / TEXT
+  vector      REAL_VECTOR(<dim>) / vector(<dim>)
+  metadata    NVARCHAR / JSONB
+  created_at  TIMESTAMP
+```
+
+HANA uses `REAL_VECTOR(dim)` column type. Postgres uses `vector(dim)` from pgvector. Both auto-created when `autoCreateSchema: true`.
+
+Metadata is serialized JSON. On retrieval, parsed back to `RagMetadata`.
+
+### Config shape
+
+```ts
+interface HanaVectorRagConfig {
+  // Connection: URL or explicit fields
+  connectionString?: string;                 // e.g. jdbc-style SAP HANA URL
+  host?: string;
+  port?: number;
+  user?: string;
+  password?: string;
+  schema?: string;                            // default: inferred from user
+
+  // Collection
+  collectionName: string;                     // table name (sanitized)
+  dimension?: number;                         // default: 1536
+  autoCreateSchema?: boolean;                 // default: true
+
+  // Connection pool
+  poolMax?: number;                           // default: 5
+  connectTimeout?: number;                    // ms, default: 30000
+}
+```
+
+```ts
+interface PgVectorRagConfig {
+  // Connection: URL or explicit fields
+  connectionString?: string;                 // e.g. postgres://user:pass@host:5432/db
+  host?: string;
+  port?: number;                              // default: 5432
+  user?: string;
+  password?: string;
+  database?: string;
+  schema?: string;                            // default: 'public'
+
+  // Collection
+  collectionName: string;                     // table name (sanitized)
+  dimension?: number;                         // default: 1536
+  autoCreateSchema?: boolean;                 // default: true
+
+  // Connection pool
+  poolMax?: number;                           // default: 10
+  connectTimeout?: number;                    // default: 30000
+}
+```
+
+Internal resolver converts either URL or explicit fields into the driver's native connection args.
+
+### Collection name sanitization
+
+Both backends use the collection name as a SQL table identifier. Must be SQL-safe. Rule: regex `^[a-zA-Z_][a-zA-Z0-9_]{0,62}$`. Violations throw `RagError('INVALID_COLLECTION_NAME')` at construction.
+
+### Provider wiring
+
+```ts
+export class HanaVectorRagProvider extends AbstractRagProvider {
+  readonly name = 'hana-vector';
+  readonly kind = 'vector-db';
+  readonly supportedScopes = ['session', 'user', 'global'] as const;
+
+  constructor(private readonly cfg: {
+    defaultEmbedder: IEmbedder;
+    connection: HanaVectorRagConfig | string;
+    defaultDimension?: number;
+    autoCreateSchema?: boolean;
+    defaultIdStrategy?: 'caller-provided' | 'uuid' | 'session-scoped' | 'canonical-key';
+  }) {
+    super();
+  }
+
+  async createCollection(name: string, opts: { scope, sessionId?, userId? }): Promise<Result<{ rag: IRag; editor: IRagEditor }, RagError>> {
+    // 1. Validate scope against supportedScopes
+    // 2. Instantiate HanaVectorRag with cfg.connection + name
+    // 3. If autoCreateSchema: run CREATE TABLE IF NOT EXISTS + CREATE INDEX
+    // 4. Build editor via buildEditor() helper from AbstractRagProvider
+    // 5. Return pair
+  }
+
+  async deleteCollection(name: string): Promise<Result<void, RagError>> {
+    // DROP TABLE IF EXISTS
+  }
+
+  async listCollections(): Promise<Result<string[], RagError>> {
+    // Query SYS.TABLES / information_schema.tables filtered by schema
+  }
+}
+```
+
+(`PgVectorRagProvider` follows the same shape.)
+
+### Server integration
+
+Add to server's factory registry (`embedder-factories.ts` analog for RAG providers — or in a new file if a dedicated RAG factory registry is warranted). For v11.0.0 scope, the factory registry stays on embedders; RAG backends are instantiated by name inside `SmartServer` composition. Task plan inspects `SmartServer.ts` to see how `rag.type` resolves today and extends that resolver with `hana-vector` and `pg-vector` cases.
+
+Server's `peerDependencies` gains:
+
+```json
+"@mcp-abap-adt/hana-vector-rag": "^11.0.0",
+"@mcp-abap-adt/pg-vector-rag": "^11.0.0"
+```
+
+Both marked optional in `peerDependenciesMeta`.
+
+Server's `devDependencies` gains both packages at `*` so tests and dev builds have them.
+
+Server's `tsconfig.json` gains `{ "path": "../hana-vector-rag" }` and `{ "path": "../pg-vector-rag" }` in `references`.
+
+Root `package.json` `build`/`clean` scripts extended with `packages/hana-vector-rag` and `packages/pg-vector-rag`.
+
+Changesets `fixed` group extended to 12 packages.
+
+### Factory registry additions
+
+In `packages/llm-agent-server/src/smart-agent/embedder-factories.ts` (if that's where RAG resolution lives — or a sibling RAG factory file), add:
+
+```ts
+// PACKAGE_BY_NAME (for RAG backends requiring peer resolution)
+'hana-vector': '@mcp-abap-adt/hana-vector-rag',
+'pg-vector':   '@mcp-abap-adt/pg-vector-rag',
+```
+
+If SmartServer's config resolution for `rag.type` is hard-coded (switch statement) rather than factory-based, extend the switch with the two new cases, each preceded by a prefetch step that dynamic-imports the peer and falls back to `MissingProviderError` when absent.
+
+## Testing
+
+Unit tests per package follow the Qdrant pattern from the existing `packages/qdrant-rag/src/__tests__/qdrant-rag.test.ts`: mock the driver client. For HANA, mock `@sap/hana-client` objects. For pg, mock `pg.Pool` and `Client`.
+
+Cover:
+- `query`, `getById`, `upsertRaw`, `deleteByIdRaw`, `clearAll`, `upsertPrecomputedRaw`
+- Provider: `createCollection` (happy path + autoCreateSchema on/off), `deleteCollection`, `listCollections`, scope rejection
+- Connection string parsing (URL vs explicit fields)
+- Collection-name validation rejection
+- `MissingProviderError` path when peer isn't installed (integration test in server)
+
+No real-database tests in CI for v11.0.0. Real-DB integration is out-of-scope (separate smoke suite later).
+
+## File layout (both packages, same shape)
+
+```
+packages/hana-vector-rag/
+├── package.json
+├── tsconfig.json
+├── README.md
+├── src/
+│   ├── hana-vector-rag.ts          — HanaVectorRag class
+│   ├── hana-vector-rag-provider.ts — HanaVectorRagProvider class
+│   ├── connection.ts                — config + URL parsing
+│   ├── schema.ts                    — DDL helpers
+│   ├── index.ts                     — public exports
+│   └── __tests__/
+│       ├── hana-vector-rag.test.ts
+│       └── hana-vector-rag-provider.test.ts
+```
+
+(`pg-vector-rag/` mirrors this structure with corresponding filenames.)
+
+## Dependency graph
+
+```
+@mcp-abap-adt/llm-agent (zod)
+  ↑
+  ├─ ... (10 existing v11 packages)
+  │
+  ├─ hana-vector-rag (@sap/hana-client)  ←─ optional peer of llm-agent-server
+  └─ pg-vector-rag (pg)                   ←─ optional peer of llm-agent-server
+```
+
+Both new packages depend only on core. No cross-deps with other peers. Clean fan-out.
+
+## Release flow
+
+1. Implement both packages (plan has parallel tasks).
+2. Update server peer deps, tsconfig refs, factory registry, root build scripts, changesets config.
+3. `MIGRATION-v11.md` gains a "New RAG backends" section naming both packages.
+4. README gains both in the package table.
+5. Extend root CHANGELOG entry for 11.0.0 to mention the two new packages.
+6. Full workspace build + test clean.
+7. Merge PR to `main`.
+8. Post-merge: `npx changeset publish` → all 12 packages published at 11.0.0.
+9. `git tag -a v11.0.0 -m "Release 11.0.0"` + push → GitHub release workflow.
+
+## Out of scope
+
+- Real-database integration tests (deferred).
+- `pgvector` / `@sap/hana-client` operational docs beyond "install and configure" (belongs in provider READMEs).
+- Alternative Postgres drivers (`postgres.js` etc.).
+- Alternative HANA drivers (`hdb`).
+- Schema migration tooling for production deployments.
+- Distance metrics other than cosine similarity.
+
+## Known items for implementation plan
+
+- Collection-name → SQL table-identifier sanitization: single regex, same in both packages. Centralize in a core utility? For v11.0.0 scope, keep the regex duplicated in each package; consolidate later if multiple backends grow.
+- Connection pool lifecycle: both packages own their pool. Server doesn't manage it. Pool closes on `rag.close?()` (if IRag gains an optional close method) or on process exit via handler.
+- Metadata JSON column type: Postgres supports native `JSONB` (preferred). HANA has `NCLOB` for JSON; `NVARCHAR` as fallback with size limit. Tests must round-trip metadata correctly.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1586,6 +1586,10 @@
       "resolved": "packages/openai-llm",
       "link": true
     },
+    "node_modules/@mcp-abap-adt/pg-vector-rag": {
+      "resolved": "packages/pg-vector-rag",
+      "link": true
+    },
     "node_modules/@mcp-abap-adt/qdrant-rag": {
       "resolved": "packages/qdrant-rag",
       "link": true
@@ -7308,6 +7312,263 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "packages/pg-vector-rag": {
+      "name": "@mcp-abap-adt/pg-vector-rag",
+      "version": "11.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@mcp-abap-adt/llm-agent": "*",
+        "pg": "^8.13.0"
+      },
+      "devDependencies": {
+        "@types/pg": "^8.11.0"
+      }
+    },
+    "packages/pg-vector-rag/node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "packages/pg-vector-rag/node_modules/@types/pg/node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/pg-vector-rag/node_modules/@types/pg/node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/pg-vector-rag/node_modules/@types/pg/node_modules/pg-types/node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "packages/pg-vector-rag/node_modules/@types/pg/node_modules/pg-types/node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/pg-vector-rag/node_modules/@types/pg/node_modules/pg-types/node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "packages/pg-vector-rag/node_modules/@types/pg/node_modules/pg-types/node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "packages/pg-vector-rag/node_modules/@types/pg/node_modules/pg-types/node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "packages/pg-vector-rag/node_modules/@types/pg/node_modules/pg-types/node_modules/postgres-interval/node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "packages/pg-vector-rag/node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "packages/pg-vector-rag/node_modules/pg/node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "packages/pg-vector-rag/node_modules/pg/node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT"
+    },
+    "packages/pg-vector-rag/node_modules/pg/node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "packages/pg-vector-rag/node_modules/pg/node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "packages/pg-vector-rag/node_modules/pg/node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/pg-vector-rag/node_modules/pg/node_modules/pg-types/node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "packages/pg-vector-rag/node_modules/pg/node_modules/pg-types/node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/pg-vector-rag/node_modules/pg/node_modules/pg-types/node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "packages/pg-vector-rag/node_modules/pg/node_modules/pg-types/node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "packages/pg-vector-rag/node_modules/pg/node_modules/pg-types/node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "packages/pg-vector-rag/node_modules/pg/node_modules/pg-types/node_modules/postgres-interval/node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "packages/pg-vector-rag/node_modules/pg/node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "packages/pg-vector-rag/node_modules/pg/node_modules/pgpass/node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "packages/qdrant-rag": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3130,16 +3130,16 @@
         "@types/node": "^25.6.0"
       },
       "peerDependencies": {
-        "@mcp-abap-adt/anthropic-llm": "^12.0.0",
-        "@mcp-abap-adt/deepseek-llm": "^12.0.0",
-        "@mcp-abap-adt/hana-vector-rag": "^12.0.0",
-        "@mcp-abap-adt/ollama-embedder": "^12.0.0",
-        "@mcp-abap-adt/openai-embedder": "^12.0.0",
-        "@mcp-abap-adt/openai-llm": "^12.0.0",
-        "@mcp-abap-adt/pg-vector-rag": "^12.0.0",
-        "@mcp-abap-adt/qdrant-rag": "^12.0.0",
-        "@mcp-abap-adt/sap-aicore-embedder": "^12.0.0",
-        "@mcp-abap-adt/sap-aicore-llm": "^12.0.0"
+        "@mcp-abap-adt/anthropic-llm": "^11.0.0",
+        "@mcp-abap-adt/deepseek-llm": "^11.0.0",
+        "@mcp-abap-adt/hana-vector-rag": "^11.0.0",
+        "@mcp-abap-adt/ollama-embedder": "^11.0.0",
+        "@mcp-abap-adt/openai-embedder": "^11.0.0",
+        "@mcp-abap-adt/openai-llm": "^11.0.0",
+        "@mcp-abap-adt/pg-vector-rag": "^11.0.0",
+        "@mcp-abap-adt/qdrant-rag": "^11.0.0",
+        "@mcp-abap-adt/sap-aicore-embedder": "^11.0.0",
+        "@mcp-abap-adt/sap-aicore-llm": "^11.0.0"
       },
       "peerDependenciesMeta": {
         "@mcp-abap-adt/anthropic-llm": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1562,6 +1562,10 @@
       "resolved": "packages/deepseek-llm",
       "link": true
     },
+    "node_modules/@mcp-abap-adt/hana-vector-rag": {
+      "resolved": "packages/hana-vector-rag",
+      "link": true
+    },
     "node_modules/@mcp-abap-adt/llm-agent": {
       "resolved": "packages/llm-agent",
       "link": true
@@ -3041,6 +3045,42 @@
         "@mcp-abap-adt/llm-agent": "*",
         "@mcp-abap-adt/openai-llm": "*"
       }
+    },
+    "packages/hana-vector-rag": {
+      "name": "@mcp-abap-adt/hana-vector-rag",
+      "version": "11.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@mcp-abap-adt/llm-agent": "*",
+        "@sap/hana-client": "^2.24.26"
+      }
+    },
+    "packages/hana-vector-rag/node_modules/@sap/hana-client": {
+      "version": "2.28.20",
+      "resolved": "https://registry.npmjs.org/@sap/hana-client/-/hana-client-2.28.20.tgz",
+      "integrity": "sha512-SGOc83oh3UG3M0LuPLHebn/GGUakPMwGSZ9s89xzUB/mHvuOc284BwJ6UzxkwSY1iroH0hKHCTdIIB/vVVTDiw==",
+      "hasInstallScript": true,
+      "hasShrinkwrap": true,
+      "license": "SEE LICENSE IN developer-license-3_2.txt",
+      "dependencies": {
+        "debug": "3.1.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "packages/hana-vector-rag/node_modules/@sap/hana-client/node_modules/debug": {
+      "version": "3.1.0",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "packages/hana-vector-rag/node_modules/@sap/hana-client/node_modules/ms": {
+      "version": "2.0.0",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "packages/llm-agent": {
       "name": "@mcp-abap-adt/llm-agent",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3116,9 +3116,11 @@
       "devDependencies": {
         "@mcp-abap-adt/anthropic-llm": "*",
         "@mcp-abap-adt/deepseek-llm": "*",
+        "@mcp-abap-adt/hana-vector-rag": "*",
         "@mcp-abap-adt/ollama-embedder": "*",
         "@mcp-abap-adt/openai-embedder": "*",
         "@mcp-abap-adt/openai-llm": "*",
+        "@mcp-abap-adt/pg-vector-rag": "*",
         "@mcp-abap-adt/qdrant-rag": "*",
         "@mcp-abap-adt/sap-aicore-embedder": "*",
         "@mcp-abap-adt/sap-aicore-llm": "*",
@@ -3130,9 +3132,11 @@
       "peerDependencies": {
         "@mcp-abap-adt/anthropic-llm": "^12.0.0",
         "@mcp-abap-adt/deepseek-llm": "^12.0.0",
+        "@mcp-abap-adt/hana-vector-rag": "^12.0.0",
         "@mcp-abap-adt/ollama-embedder": "^12.0.0",
         "@mcp-abap-adt/openai-embedder": "^12.0.0",
         "@mcp-abap-adt/openai-llm": "^12.0.0",
+        "@mcp-abap-adt/pg-vector-rag": "^12.0.0",
         "@mcp-abap-adt/qdrant-rag": "^12.0.0",
         "@mcp-abap-adt/sap-aicore-embedder": "^12.0.0",
         "@mcp-abap-adt/sap-aicore-llm": "^12.0.0"
@@ -3144,6 +3148,9 @@
         "@mcp-abap-adt/deepseek-llm": {
           "optional": true
         },
+        "@mcp-abap-adt/hana-vector-rag": {
+          "optional": true
+        },
         "@mcp-abap-adt/ollama-embedder": {
           "optional": true
         },
@@ -3151,6 +3158,9 @@
           "optional": true
         },
         "@mcp-abap-adt/openai-llm": {
+          "optional": true
+        },
+        "@mcp-abap-adt/pg-vector-rag": {
           "optional": true
         },
         "@mcp-abap-adt/qdrant-rag": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test": "npm run test --workspaces --if-present",
     "changeset": "changeset",
     "version": "changeset version",
-    "release": "npm run build && changeset publish"
+    "release": "npm run build && changeset publish",
+    "release:publish": "bash scripts/publish-all.sh"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.9",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "workspaces": ["packages/*"],
   "scripts": {
     "prebuild": "npm run --workspace @mcp-abap-adt/llm-agent-server prebuild",
-    "build": "tsc -b packages/llm-agent packages/openai-llm packages/anthropic-llm packages/openai-embedder packages/ollama-embedder packages/qdrant-rag packages/sap-aicore-llm packages/sap-aicore-embedder packages/deepseek-llm packages/llm-agent-server",
-    "clean": "tsc -b --clean packages/llm-agent packages/openai-llm packages/anthropic-llm packages/openai-embedder packages/ollama-embedder packages/qdrant-rag packages/sap-aicore-llm packages/sap-aicore-embedder packages/deepseek-llm packages/llm-agent-server",
+    "build": "tsc -b packages/llm-agent packages/openai-llm packages/anthropic-llm packages/openai-embedder packages/ollama-embedder packages/qdrant-rag packages/sap-aicore-llm packages/sap-aicore-embedder packages/deepseek-llm packages/hana-vector-rag packages/pg-vector-rag packages/llm-agent-server",
+    "clean": "tsc -b --clean packages/llm-agent packages/openai-llm packages/anthropic-llm packages/openai-embedder packages/ollama-embedder packages/qdrant-rag packages/sap-aicore-llm packages/sap-aicore-embedder packages/deepseek-llm packages/hana-vector-rag packages/pg-vector-rag packages/llm-agent-server",
     "lint": "biome check --write packages",
     "lint:check": "biome check packages",
     "format": "biome format --write packages",

--- a/packages/hana-vector-rag/README.md
+++ b/packages/hana-vector-rag/README.md
@@ -1,0 +1,26 @@
+# @mcp-abap-adt/hana-vector-rag
+
+SAP HANA Cloud Vector Engine backend for [@mcp-abap-adt/llm-agent](https://www.npmjs.com/package/@mcp-abap-adt/llm-agent).
+
+Provides:
+- `HanaVectorRag` — `IRag` implementation backed by `REAL_VECTOR(dim)` columns.
+- `HanaVectorRagProvider` — `IRagProvider` for session/user/global collections.
+
+## Install
+
+```bash
+npm install @mcp-abap-adt/hana-vector-rag @sap/hana-client
+```
+
+## Minimal config
+
+```yaml
+rag:
+  type: hana-vector
+  connectionString: hdbsql://user:pass@host:443
+  collectionName: llm_agent_docs
+  dimension: 1536
+  autoCreateSchema: true
+```
+
+See the monorepo root README for full configuration surface.

--- a/packages/hana-vector-rag/package.json
+++ b/packages/hana-vector-rag/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@mcp-abap-adt/hana-vector-rag",
+  "version": "11.0.0",
+  "description": "HanaVectorRag vector store (SAP HANA Cloud Vector Engine) and HanaVectorRagProvider for @mcp-abap-adt/llm-agent.",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "clean": "tsc -p tsconfig.json --clean",
+    "test": "node --import tsx/esm --test --test-reporter=spec 'src/**/*.test.ts'"
+  },
+  "dependencies": {
+    "@mcp-abap-adt/llm-agent": "*",
+    "@sap/hana-client": "^2.24.26"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fr0ster/llm-agent.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/hana-vector-rag/src/__tests__/connection.test.ts
+++ b/packages/hana-vector-rag/src/__tests__/connection.test.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { resolveHanaConnectArgs } from '../connection.js';
+
+describe('resolveHanaConnectArgs', () => {
+  it('accepts explicit fields', () => {
+    const args = resolveHanaConnectArgs({
+      host: 'h.example.com',
+      port: 443,
+      user: 'U1',
+      password: 'pw',
+      collectionName: 't',
+    });
+    assert.equal(args.serverNode, 'h.example.com:443');
+    assert.equal(args.uid, 'U1');
+    assert.equal(args.pwd, 'pw');
+    assert.equal(args.encrypt, 'true');
+  });
+
+  it('parses hdbsql URL', () => {
+    const args = resolveHanaConnectArgs({
+      connectionString: 'hdbsql://u:p@host.example:443',
+      collectionName: 't',
+    });
+    assert.equal(args.serverNode, 'host.example:443');
+    assert.equal(args.uid, 'u');
+    assert.equal(args.pwd, 'p');
+  });
+
+  it('rejects missing host', () => {
+    assert.throws(
+      () =>
+        resolveHanaConnectArgs({
+          user: 'u',
+          password: 'p',
+          collectionName: 't',
+        }),
+      /host/i,
+    );
+  });
+});

--- a/packages/hana-vector-rag/src/__tests__/hana-vector-rag-provider.test.ts
+++ b/packages/hana-vector-rag/src/__tests__/hana-vector-rag-provider.test.ts
@@ -1,0 +1,144 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { IEmbedder } from '@mcp-abap-adt/llm-agent';
+import type { HanaClient } from '../hana-vector-rag.js';
+import { HanaVectorRagProvider } from '../hana-vector-rag-provider.js';
+
+function makeEmbedder(): IEmbedder {
+  return {
+    async embed() {
+      return { vector: [0, 0, 0] };
+    },
+  };
+}
+
+interface ExecCall {
+  sql: string;
+  params: readonly unknown[];
+}
+
+function makeFakeClient(
+  rows: Record<string, unknown>[] = [],
+): HanaClient & { calls: ExecCall[] } {
+  const calls: ExecCall[] = [];
+  return {
+    calls,
+    async exec(sql, params = []) {
+      calls.push({ sql, params });
+      return { rowCount: 1 };
+    },
+    async query(sql, params = []) {
+      calls.push({ sql, params });
+      return rows;
+    },
+    async close() {},
+  };
+}
+
+describe('HanaVectorRagProvider', () => {
+  it('createCollection returns rag + editor, runs schema bootstrap when autoCreateSchema=true', async () => {
+    const client = makeFakeClient();
+    const provider = new HanaVectorRagProvider({
+      name: 'hana',
+      embedder: makeEmbedder(),
+      connection: {
+        collectionName: '__ignored',
+        host: 'h',
+        user: 'u',
+        password: 'p',
+      },
+      defaultDimension: 3,
+      autoCreateSchema: true,
+      clientFactory: () => client,
+    });
+    const r = await provider.createCollection('docs', {
+      scope: 'session',
+      sessionId: 's1',
+    });
+    assert.equal(r.ok, true);
+    if (!r.ok) throw new Error('unreachable');
+    assert.ok(
+      client.calls.some(
+        (c) => c.sql.includes('CREATE TABLE') && c.sql.includes('"docs"'),
+      ),
+    );
+  });
+
+  it('createCollection skips DDL when autoCreateSchema=false', async () => {
+    const client = makeFakeClient();
+    const provider = new HanaVectorRagProvider({
+      name: 'hana',
+      embedder: makeEmbedder(),
+      connection: {
+        collectionName: '__ignored',
+        host: 'h',
+        user: 'u',
+        password: 'p',
+      },
+      defaultDimension: 3,
+      autoCreateSchema: false,
+      clientFactory: () => client,
+    });
+    const r = await provider.createCollection('docs', { scope: 'global' });
+    assert.equal(r.ok, true);
+    assert.ok(!client.calls.some((c) => c.sql.includes('CREATE TABLE')));
+  });
+
+  it('deleteCollection emits DROP TABLE', async () => {
+    const client = makeFakeClient();
+    const provider = new HanaVectorRagProvider({
+      name: 'hana',
+      embedder: makeEmbedder(),
+      connection: {
+        collectionName: '__ignored',
+        host: 'h',
+        user: 'u',
+        password: 'p',
+      },
+      clientFactory: () => client,
+    });
+    const r = await provider.deleteCollection('docs');
+    assert.equal(r.ok, true);
+    assert.ok(client.calls.some((c) => c.sql.startsWith('DROP TABLE')));
+  });
+
+  it('listCollections queries SYS.TABLES and returns names', async () => {
+    const client = makeFakeClient([
+      { TABLE_NAME: 'docs' },
+      { TABLE_NAME: 'other' },
+    ]);
+    const provider = new HanaVectorRagProvider({
+      name: 'hana',
+      embedder: makeEmbedder(),
+      connection: {
+        collectionName: '__ignored',
+        host: 'h',
+        user: 'u',
+        password: 'p',
+      },
+      clientFactory: () => client,
+    });
+    const r = await provider.listCollections();
+    assert.equal(r.ok, true);
+    if (!r.ok) throw new Error('unreachable');
+    assert.deepEqual(r.value, ['docs', 'other']);
+  });
+
+  it('rejects unsupported scope', async () => {
+    const client = makeFakeClient();
+    const provider = new HanaVectorRagProvider({
+      name: 'hana',
+      embedder: makeEmbedder(),
+      connection: {
+        collectionName: '__ignored',
+        host: 'h',
+        user: 'u',
+        password: 'p',
+      },
+      clientFactory: () => client,
+      supportedScopes: ['global'],
+    });
+    const r = await provider.createCollection('docs', { scope: 'session' });
+    assert.equal(r.ok, false);
+  });
+});

--- a/packages/hana-vector-rag/src/__tests__/hana-vector-rag.test.ts
+++ b/packages/hana-vector-rag/src/__tests__/hana-vector-rag.test.ts
@@ -62,7 +62,10 @@ describe('HanaVectorRag', () => {
       { collectionName: 'docs', dimension: 3, embedder: makeEmbedder(3) },
       client,
     );
-    const res = await rag.query({ toVector: async () => [0.1, 0.2, 0.3] }, 5);
+    const res = await rag.query(
+      { text: 'test query', toVector: async () => [0.1, 0.2, 0.3] },
+      5,
+    );
     assert.equal(res.ok, true);
     if (!res.ok) throw new Error('unreachable');
     assert.equal(res.value.length, 1);
@@ -99,7 +102,7 @@ describe('HanaVectorRag', () => {
       { collectionName: 'docs', dimension: 3, embedder: makeEmbedder(3) },
       client,
     );
-    const r = await rag.writer().clearAll();
+    const r = await rag.writer().clearAll!();
     assert.equal(r.ok, true);
     assert.ok(client.calls.some((c) => c.sql.startsWith('TRUNCATE')));
   });

--- a/packages/hana-vector-rag/src/__tests__/hana-vector-rag.test.ts
+++ b/packages/hana-vector-rag/src/__tests__/hana-vector-rag.test.ts
@@ -1,0 +1,129 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { IEmbedder } from '@mcp-abap-adt/llm-agent';
+import { type HanaClient, HanaVectorRag } from '../hana-vector-rag.js';
+
+function makeEmbedder(dim = 3): IEmbedder {
+  return {
+    async embed(text: string) {
+      let h = 0;
+      for (const ch of text) h = (h * 31 + ch.charCodeAt(0)) | 0;
+      return {
+        vector: Array.from({ length: dim }, (_, i) => ((h >> i) & 0xff) / 255),
+      };
+    },
+  };
+}
+
+interface ExecCall {
+  sql: string;
+  params: readonly unknown[];
+}
+
+function makeFakeClient(
+  rows: Record<string, unknown>[] = [],
+): HanaClient & { calls: ExecCall[] } {
+  const calls: ExecCall[] = [];
+  return {
+    calls,
+    async exec(sql, params = []) {
+      calls.push({ sql, params });
+      return { rowCount: 1 };
+    },
+    async query(sql, params = []) {
+      calls.push({ sql, params });
+      return rows;
+    },
+    async close() {
+      /* noop */
+    },
+  };
+}
+
+describe('HanaVectorRag', () => {
+  it('ensureSchema runs CREATE TABLE only once', async () => {
+    const client = makeFakeClient();
+    const rag = new HanaVectorRag(
+      { collectionName: 'docs', dimension: 3, embedder: makeEmbedder(3) },
+      client,
+    );
+    await rag.ensureSchema();
+    await rag.ensureSchema();
+    const creates = client.calls.filter((c) => c.sql.includes('CREATE TABLE'));
+    assert.equal(creates.length, 1);
+  });
+
+  it('query returns results mapped from rows', async () => {
+    const rows = [
+      { id: 'a', text: 'hello', metadata: '{"namespace":"n"}', score: 0.9 },
+    ];
+    const client = makeFakeClient(rows);
+    const rag = new HanaVectorRag(
+      { collectionName: 'docs', dimension: 3, embedder: makeEmbedder(3) },
+      client,
+    );
+    const res = await rag.query({ toVector: async () => [0.1, 0.2, 0.3] }, 5);
+    assert.equal(res.ok, true);
+    if (!res.ok) throw new Error('unreachable');
+    assert.equal(res.value.length, 1);
+    assert.equal(res.value[0].text, 'hello');
+    assert.equal(res.value[0].metadata?.namespace, 'n');
+  });
+
+  it('upsertRaw issues UPSERT with vector literal', async () => {
+    const client = makeFakeClient();
+    const rag = new HanaVectorRag(
+      { collectionName: 'docs', dimension: 3, embedder: makeEmbedder(3) },
+      client,
+    );
+    const r = await rag.writer().upsertRaw('id1', 'text', { namespace: 'n' });
+    assert.equal(r.ok, true);
+    const upsert = client.calls.find((c) => c.sql.startsWith('UPSERT'));
+    assert.ok(upsert, 'UPSERT should have been issued');
+  });
+
+  it('deleteByIdRaw issues DELETE', async () => {
+    const client = makeFakeClient();
+    const rag = new HanaVectorRag(
+      { collectionName: 'docs', dimension: 3, embedder: makeEmbedder(3) },
+      client,
+    );
+    const r = await rag.writer().deleteByIdRaw('id1');
+    assert.equal(r.ok, true);
+    assert.ok(client.calls.some((c) => c.sql.includes('DELETE FROM')));
+  });
+
+  it('clearAll issues TRUNCATE', async () => {
+    const client = makeFakeClient();
+    const rag = new HanaVectorRag(
+      { collectionName: 'docs', dimension: 3, embedder: makeEmbedder(3) },
+      client,
+    );
+    const r = await rag.writer().clearAll();
+    assert.equal(r.ok, true);
+    assert.ok(client.calls.some((c) => c.sql.startsWith('TRUNCATE')));
+  });
+
+  it('healthCheck runs SELECT 1 FROM DUMMY', async () => {
+    const client = makeFakeClient([{ '1': 1 }]);
+    const rag = new HanaVectorRag(
+      { collectionName: 'docs', dimension: 3, embedder: makeEmbedder(3) },
+      client,
+    );
+    const r = await rag.healthCheck();
+    assert.equal(r.ok, true);
+    assert.ok(client.calls.some((c) => c.sql.includes('FROM DUMMY')));
+  });
+
+  it('rejects invalid collection name at construction', () => {
+    assert.throws(
+      () =>
+        new HanaVectorRag(
+          { collectionName: "bad'; DROP", embedder: makeEmbedder() },
+          makeFakeClient(),
+        ),
+      (err: Error & { code?: string }) =>
+        err.code === 'INVALID_COLLECTION_NAME',
+    );
+  });
+});

--- a/packages/hana-vector-rag/src/__tests__/hana-vector-rag.test.ts
+++ b/packages/hana-vector-rag/src/__tests__/hana-vector-rag.test.ts
@@ -96,6 +96,28 @@ describe('HanaVectorRag', () => {
     assert.ok(client.calls.some((c) => c.sql.includes('DELETE FROM')));
   });
 
+  it('deleteByIdRaw reports false when no row matched', async () => {
+    const calls: ExecCall[] = [];
+    const client: HanaClient = {
+      async exec(sql, params = []) {
+        calls.push({ sql, params });
+        return { rowCount: 0 };
+      },
+      async query() {
+        return [];
+      },
+      async close() {},
+    };
+    const rag = new HanaVectorRag(
+      { collectionName: 'docs', dimension: 3, embedder: makeEmbedder(3) },
+      client,
+    );
+    const r = await rag.writer().deleteByIdRaw('missing');
+    assert.equal(r.ok, true);
+    if (!r.ok) throw new Error('unreachable');
+    assert.equal(r.value, false);
+  });
+
   it('clearAll issues TRUNCATE', async () => {
     const client = makeFakeClient();
     const rag = new HanaVectorRag(

--- a/packages/hana-vector-rag/src/__tests__/schema.test.ts
+++ b/packages/hana-vector-rag/src/__tests__/schema.test.ts
@@ -44,7 +44,7 @@ describe('hana schema', () => {
     assert.match(sql, /metadata NCLOB/);
   });
 
-  it('emits DROP TABLE DDL', () => {
-    assert.equal(dropTableSql('llm_docs'), 'DROP TABLE "llm_docs"');
+  it('emits DROP TABLE DDL with IF EXISTS', () => {
+    assert.equal(dropTableSql('llm_docs'), 'DROP TABLE IF EXISTS "llm_docs"');
   });
 });

--- a/packages/hana-vector-rag/src/__tests__/schema.test.ts
+++ b/packages/hana-vector-rag/src/__tests__/schema.test.ts
@@ -14,19 +14,22 @@ describe('hana schema', () => {
   it('rejects collection name starting with digit', () => {
     assert.throws(
       () => assertCollectionName('1bad'),
-      /INVALID_COLLECTION_NAME/,
+      (err: Error & { code?: string }) =>
+        err.code === 'INVALID_COLLECTION_NAME',
     );
   });
   it('rejects collection name with special chars', () => {
     assert.throws(
       () => assertCollectionName("x'); DROP"),
-      /INVALID_COLLECTION_NAME/,
+      (err: Error & { code?: string }) =>
+        err.code === 'INVALID_COLLECTION_NAME',
     );
   });
   it('rejects names longer than 63 chars', () => {
     assert.throws(
       () => assertCollectionName('a'.repeat(64)),
-      /INVALID_COLLECTION_NAME/,
+      (err: Error & { code?: string }) =>
+        err.code === 'INVALID_COLLECTION_NAME',
     );
   });
 

--- a/packages/hana-vector-rag/src/__tests__/schema.test.ts
+++ b/packages/hana-vector-rag/src/__tests__/schema.test.ts
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  assertCollectionName,
+  createTableSql,
+  dropTableSql,
+  quoteIdent,
+} from '../schema.js';
+
+describe('hana schema', () => {
+  it('accepts a safe collection name', () => {
+    assertCollectionName('llm_agent_docs_2');
+  });
+  it('rejects collection name starting with digit', () => {
+    assert.throws(
+      () => assertCollectionName('1bad'),
+      /INVALID_COLLECTION_NAME/,
+    );
+  });
+  it('rejects collection name with special chars', () => {
+    assert.throws(
+      () => assertCollectionName("x'); DROP"),
+      /INVALID_COLLECTION_NAME/,
+    );
+  });
+  it('rejects names longer than 63 chars', () => {
+    assert.throws(
+      () => assertCollectionName('a'.repeat(64)),
+      /INVALID_COLLECTION_NAME/,
+    );
+  });
+
+  it('quotes HANA identifiers', () => {
+    assert.equal(quoteIdent('llm_docs'), '"llm_docs"');
+  });
+
+  it('emits CREATE TABLE DDL with REAL_VECTOR and NCLOB', () => {
+    const sql = createTableSql('llm_docs', 1536);
+    assert.match(sql, /CREATE TABLE IF NOT EXISTS "llm_docs"/);
+    assert.match(sql, /REAL_VECTOR\(1536\)/);
+    assert.match(sql, /metadata NCLOB/);
+  });
+
+  it('emits DROP TABLE DDL', () => {
+    assert.equal(dropTableSql('llm_docs'), 'DROP TABLE "llm_docs"');
+  });
+});

--- a/packages/hana-vector-rag/src/connection.ts
+++ b/packages/hana-vector-rag/src/connection.ts
@@ -1,0 +1,56 @@
+export interface HanaVectorRagConfig {
+  connectionString?: string;
+  host?: string;
+  port?: number;
+  user?: string;
+  password?: string;
+  schema?: string;
+  collectionName: string;
+  dimension?: number;
+  autoCreateSchema?: boolean;
+  poolMax?: number;
+  connectTimeout?: number;
+}
+
+export interface HanaConnectArgs {
+  serverNode: string;
+  uid: string;
+  pwd: string;
+  encrypt: 'true' | 'false';
+  sslValidateCertificate?: 'true' | 'false';
+  currentSchema?: string;
+  communicationTimeout?: number;
+}
+
+export function resolveHanaConnectArgs(
+  cfg: HanaVectorRagConfig,
+): HanaConnectArgs {
+  let host = cfg.host;
+  let port = cfg.port;
+  let user = cfg.user;
+  let password = cfg.password;
+
+  if (cfg.connectionString) {
+    const normalized = cfg.connectionString.replace(/^hdbsql:\/\//, 'https://');
+    const u = new URL(normalized);
+    host ??= u.hostname;
+    port ??= u.port ? Number(u.port) : 443;
+    user ??= decodeURIComponent(u.username);
+    password ??= decodeURIComponent(u.password);
+  }
+
+  if (!host)
+    throw new Error('HANA host is required (host or connectionString)');
+  if (!user) throw new Error('HANA user is required');
+  if (!password) throw new Error('HANA password is required');
+
+  return {
+    serverNode: `${host}:${port ?? 443}`,
+    uid: user,
+    pwd: password,
+    encrypt: 'true',
+    sslValidateCertificate: 'true',
+    currentSchema: cfg.schema,
+    communicationTimeout: cfg.connectTimeout ?? 30_000,
+  };
+}

--- a/packages/hana-vector-rag/src/hana-vector-rag-provider.ts
+++ b/packages/hana-vector-rag/src/hana-vector-rag-provider.ts
@@ -1,0 +1,134 @@
+import type {
+  IEmbedder,
+  IIdStrategy,
+  IRag,
+  IRagEditor,
+  RagCollectionScope,
+  Result,
+} from '@mcp-abap-adt/llm-agent';
+import { AbstractRagProvider, RagError } from '@mcp-abap-adt/llm-agent';
+import type { HanaVectorRagConfig } from './connection.js';
+import { type HanaClient, HanaVectorRag } from './hana-vector-rag.js';
+import { quoteIdent } from './schema.js';
+
+export interface HanaVectorRagProviderConfig {
+  name: string;
+  embedder: IEmbedder;
+  connection: HanaVectorRagConfig | string;
+  defaultDimension?: number;
+  autoCreateSchema?: boolean;
+  editable?: boolean;
+  supportedScopes?: readonly RagCollectionScope[];
+  idStrategyFactory?: (opts: {
+    scope: RagCollectionScope;
+    sessionId?: string;
+    userId?: string;
+  }) => IIdStrategy;
+  /**
+   * Optional factory for driver clients used by deleteCollection / listCollections
+   * and (in tests) by createCollection. When omitted, deleteCollection and
+   * listCollections throw because schema-level operations require a shared client
+   * outside the per-collection HanaVectorRag lifecycle.
+   */
+  clientFactory?: () => HanaClient;
+}
+
+function normalizeConnection(
+  c: HanaVectorRagConfig | string,
+): HanaVectorRagConfig {
+  if (typeof c === 'string') {
+    return { connectionString: c, collectionName: '__unused' };
+  }
+  return c;
+}
+
+export class HanaVectorRagProvider extends AbstractRagProvider {
+  readonly name: string;
+  readonly kind = 'vector';
+  readonly editable: boolean;
+  readonly supportedScopes: readonly RagCollectionScope[];
+
+  private readonly embedder: IEmbedder;
+  private readonly connection: HanaVectorRagConfig;
+  private readonly defaultDimension: number;
+  private readonly autoCreateSchema: boolean;
+  private readonly clientFactory?: () => HanaClient;
+
+  constructor(cfg: HanaVectorRagProviderConfig) {
+    super();
+    this.name = cfg.name;
+    this.embedder = cfg.embedder;
+    this.connection = normalizeConnection(cfg.connection);
+    this.defaultDimension = cfg.defaultDimension ?? 1536;
+    this.autoCreateSchema = cfg.autoCreateSchema ?? true;
+    this.editable = cfg.editable ?? true;
+    this.supportedScopes = cfg.supportedScopes ?? ['session', 'user', 'global'];
+    this.clientFactory = cfg.clientFactory;
+    if (cfg.idStrategyFactory) this.idStrategyFactory = cfg.idStrategyFactory;
+  }
+
+  async createCollection(
+    name: string,
+    opts: { scope: RagCollectionScope; sessionId?: string; userId?: string },
+  ): Promise<Result<{ rag: IRag; editor: IRagEditor }, RagError>> {
+    const scopeCheck = this.checkScope(opts.scope);
+    if (!scopeCheck.ok) return scopeCheck;
+    try {
+      const rag = new HanaVectorRag(
+        {
+          ...this.connection,
+          collectionName: name,
+          dimension: this.connection.dimension ?? this.defaultDimension,
+          autoCreateSchema: this.autoCreateSchema,
+          embedder: this.embedder,
+        },
+        this.clientFactory?.(),
+      );
+      if (this.autoCreateSchema) await rag.ensureSchema();
+      const editor = this.buildEditor(rag, this.pickIdStrategy(opts));
+      return { ok: true, value: { rag, editor } };
+    } catch (err) {
+      return {
+        ok: false,
+        error: new RagError(String(err), 'RAG_CREATE_ERROR'),
+      };
+    }
+  }
+
+  async deleteCollection(name: string): Promise<Result<void, RagError>> {
+    try {
+      const client = this.requireClient();
+      await client.exec(`DROP TABLE ${quoteIdent(name)}`);
+      return { ok: true, value: undefined };
+    } catch (err) {
+      return {
+        ok: false,
+        error: new RagError(String(err), 'RAG_DELETE_ERROR'),
+      };
+    }
+  }
+
+  async listCollections(): Promise<Result<string[], RagError>> {
+    try {
+      const client = this.requireClient();
+      const rows = await client.query(
+        this.connection.schema
+          ? 'SELECT TABLE_NAME FROM SYS.TABLES WHERE SCHEMA_NAME = ?'
+          : 'SELECT TABLE_NAME FROM SYS.TABLES WHERE SCHEMA_NAME = CURRENT_SCHEMA',
+        this.connection.schema ? [this.connection.schema] : [],
+      );
+      return { ok: true, value: rows.map((r) => String(r.TABLE_NAME)) };
+    } catch (err) {
+      return { ok: false, error: new RagError(String(err), 'RAG_LIST_ERROR') };
+    }
+  }
+
+  private requireClient(): HanaClient {
+    if (!this.clientFactory) {
+      throw new Error(
+        'HanaVectorRagProvider deleteCollection/listCollections require clientFactory; provide one to enable schema-level operations',
+      );
+    }
+    return this.clientFactory();
+  }
+}

--- a/packages/hana-vector-rag/src/hana-vector-rag-provider.ts
+++ b/packages/hana-vector-rag/src/hana-vector-rag-provider.ts
@@ -9,7 +9,7 @@ import type {
 import { AbstractRagProvider, RagError } from '@mcp-abap-adt/llm-agent';
 import type { HanaVectorRagConfig } from './connection.js';
 import { type HanaClient, HanaVectorRag } from './hana-vector-rag.js';
-import { quoteIdent } from './schema.js';
+import { dropTableSql } from './schema.js';
 
 export interface HanaVectorRagProviderConfig {
   name: string;
@@ -98,7 +98,7 @@ export class HanaVectorRagProvider extends AbstractRagProvider {
   async deleteCollection(name: string): Promise<Result<void, RagError>> {
     try {
       const client = this.requireClient();
-      await client.exec(`DROP TABLE ${quoteIdent(name)}`);
+      await client.exec(dropTableSql(name));
       return { ok: true, value: undefined };
     } catch (err) {
       return {

--- a/packages/hana-vector-rag/src/hana-vector-rag.ts
+++ b/packages/hana-vector-rag/src/hana-vector-rag.ts
@@ -73,10 +73,17 @@ export class HanaVectorRag implements IRag {
     return {
       exec: (sql, params = []) =>
         new Promise((resolve, reject) =>
-          conn.exec(sql, params as unknown[], (err, rows) =>
+          conn.exec(sql, params as unknown[], (err, result) =>
             err
               ? reject(err)
-              : resolve({ rowCount: Array.isArray(rows) ? rows.length : 1 }),
+              : resolve({
+                  rowCount:
+                    typeof result === 'number'
+                      ? result
+                      : Array.isArray(result)
+                        ? result.length
+                        : 0,
+                }),
           ),
         ),
       query: (sql, params = []) =>

--- a/packages/hana-vector-rag/src/hana-vector-rag.ts
+++ b/packages/hana-vector-rag/src/hana-vector-rag.ts
@@ -42,9 +42,13 @@ export class HanaVectorRag implements IRag {
     this.dimension = config.dimension ?? 1536;
     this.embedder = config.embedder;
     this.autoCreateSchema = config.autoCreateSchema ?? true;
-    this.clientPromise = injectedClient
+    // Attach a no-op catch so the eager import never becomes an unhandledRejection.
+    // The rejection is re-thrown when clientPromise is actually awaited.
+    const driverPromise = injectedClient
       ? Promise.resolve(injectedClient)
       : this.createDriverClient(config);
+    driverPromise.catch(() => {});
+    this.clientPromise = driverPromise;
   }
 
   private async createDriverClient(

--- a/packages/hana-vector-rag/src/hana-vector-rag.ts
+++ b/packages/hana-vector-rag/src/hana-vector-rag.ts
@@ -1,0 +1,264 @@
+import type {
+  CallOptions,
+  IEmbedder,
+  IQueryEmbedding,
+  IRag,
+  IRagBackendWriter,
+  RagMetadata,
+  RagResult,
+  Result,
+} from '@mcp-abap-adt/llm-agent';
+import { FallbackQueryEmbedding, RagError } from '@mcp-abap-adt/llm-agent';
+import type { HanaVectorRagConfig } from './connection.js';
+import { resolveHanaConnectArgs } from './connection.js';
+import { assertCollectionName, createTableSql, quoteIdent } from './schema.js';
+
+export type { HanaVectorRagConfig };
+
+export interface HanaClient {
+  exec(sql: string, params?: readonly unknown[]): Promise<{ rowCount: number }>;
+  query(
+    sql: string,
+    params?: readonly unknown[],
+  ): Promise<Array<Record<string, unknown>>>;
+  close(): Promise<void>;
+}
+
+export class HanaVectorRag implements IRag {
+  private readonly collectionName: string;
+  private readonly dimension: number;
+  private readonly embedder: IEmbedder;
+  private readonly autoCreateSchema: boolean;
+  private readonly clientPromise: Promise<HanaClient>;
+  private schemaReady = false;
+  private schemaPromise?: Promise<void>;
+
+  constructor(
+    config: HanaVectorRagConfig & { embedder: IEmbedder },
+    injectedClient?: HanaClient,
+  ) {
+    assertCollectionName(config.collectionName);
+    this.collectionName = config.collectionName;
+    this.dimension = config.dimension ?? 1536;
+    this.embedder = config.embedder;
+    this.autoCreateSchema = config.autoCreateSchema ?? true;
+    this.clientPromise = injectedClient
+      ? Promise.resolve(injectedClient)
+      : this.createDriverClient(config);
+  }
+
+  private async createDriverClient(
+    cfg: HanaVectorRagConfig,
+  ): Promise<HanaClient> {
+    const args = resolveHanaConnectArgs(cfg);
+    const mod = (await import('@sap/hana-client')) as unknown as {
+      createConnection: () => {
+        connect: (opts: unknown, cb: (err: Error | null) => void) => void;
+        exec: (
+          sql: string,
+          params: unknown[],
+          cb: (err: Error | null, rows: unknown) => void,
+        ) => void;
+        disconnect: (cb: (err: Error | null) => void) => void;
+      };
+    };
+    const conn = mod.createConnection();
+    await new Promise<void>((resolve, reject) =>
+      conn.connect(args, (err) => (err ? reject(err) : resolve())),
+    );
+    return {
+      exec: (sql, params = []) =>
+        new Promise((resolve, reject) =>
+          conn.exec(sql, params as unknown[], (err, rows) =>
+            err
+              ? reject(err)
+              : resolve({ rowCount: Array.isArray(rows) ? rows.length : 1 }),
+          ),
+        ),
+      query: (sql, params = []) =>
+        new Promise((resolve, reject) =>
+          conn.exec(sql, params as unknown[], (err, rows) =>
+            err
+              ? reject(err)
+              : resolve((rows as Array<Record<string, unknown>>) ?? []),
+          ),
+        ),
+      close: () =>
+        new Promise((resolve, reject) =>
+          conn.disconnect((err) => (err ? reject(err) : resolve())),
+        ),
+    };
+  }
+
+  /**
+   * Idempotent schema bootstrap. Called by both direct makeRag() consumers
+   * (when autoCreateSchema is true) and HanaVectorRagProvider.createCollection().
+   */
+  async ensureSchema(): Promise<void> {
+    if (this.schemaReady) return;
+    this.schemaPromise ??= (async () => {
+      const client = await this.clientPromise;
+      await client.exec(createTableSql(this.collectionName, this.dimension));
+      this.schemaReady = true;
+    })();
+    await this.schemaPromise;
+  }
+
+  private async maybeEnsureSchema(): Promise<void> {
+    if (this.autoCreateSchema) await this.ensureSchema();
+  }
+
+  private vectorLiteral(vec: number[]): string {
+    return `TO_REAL_VECTOR('[${vec.join(',')}]')`;
+  }
+
+  async query(
+    embedding: IQueryEmbedding,
+    k: number,
+    options?: CallOptions,
+  ): Promise<Result<RagResult[], RagError>> {
+    if (options?.signal?.aborted)
+      return { ok: false, error: new RagError('Aborted', 'ABORTED') };
+    try {
+      await this.maybeEnsureSchema();
+      const safe = new FallbackQueryEmbedding(embedding, this.embedder);
+      const vector = await safe.toVector();
+      const client = await this.clientPromise;
+      const table = quoteIdent(this.collectionName);
+      const sql = `SELECT id, text, metadata, COSINE_SIMILARITY(vector, ${this.vectorLiteral(vector)}) AS score FROM ${table} ORDER BY score DESC LIMIT ${Math.max(1, k)}`;
+      const rows = await client.query(sql);
+      const results: RagResult[] = rows.map((row) => {
+        const metaRaw = row.metadata as string | null | undefined;
+        const metadata = metaRaw ? (JSON.parse(metaRaw) as RagMetadata) : {};
+        return {
+          text: String(row.text ?? ''),
+          metadata,
+          score: Number(row.score ?? 0),
+        };
+      });
+      return { ok: true, value: results };
+    } catch (err) {
+      return { ok: false, error: new RagError(String(err), 'QUERY_ERROR') };
+    }
+  }
+
+  async getById(
+    id: string,
+    options?: CallOptions,
+  ): Promise<Result<RagResult | null, RagError>> {
+    if (options?.signal?.aborted)
+      return { ok: false, error: new RagError('Aborted', 'ABORTED') };
+    try {
+      await this.maybeEnsureSchema();
+      const client = await this.clientPromise;
+      const rows = await client.query(
+        `SELECT id, text, metadata FROM ${quoteIdent(this.collectionName)} WHERE id = ?`,
+        [id],
+      );
+      const row = rows[0];
+      if (!row) return { ok: true, value: null };
+      const metaRaw = row.metadata as string | null | undefined;
+      const metadata = metaRaw ? (JSON.parse(metaRaw) as RagMetadata) : {};
+      return {
+        ok: true,
+        value: { text: String(row.text ?? ''), metadata, score: 1 },
+      };
+    } catch (err) {
+      return { ok: false, error: new RagError(String(err), 'QUERY_ERROR') };
+    }
+  }
+
+  async healthCheck(): Promise<Result<void, RagError>> {
+    try {
+      const client = await this.clientPromise;
+      await client.query('SELECT 1 FROM DUMMY');
+      return { ok: true, value: undefined };
+    } catch (err) {
+      return {
+        ok: false,
+        error: new RagError(String(err), 'HEALTH_CHECK_ERROR'),
+      };
+    }
+  }
+
+  async upsert(
+    text: string,
+    metadata: RagMetadata,
+    options?: CallOptions,
+  ): Promise<Result<void, RagError>> {
+    if (options?.signal?.aborted)
+      return { ok: false, error: new RagError('Aborted', 'ABORTED') };
+    try {
+      const { vector } = await this.embedder.embed(text, options);
+      return this.upsertKnown(text, vector, metadata);
+    } catch (err) {
+      return { ok: false, error: new RagError(String(err), 'UPSERT_ERROR') };
+    }
+  }
+
+  async upsertPrecomputed(
+    text: string,
+    vector: number[],
+    metadata: RagMetadata,
+  ): Promise<Result<void, RagError>> {
+    return this.upsertKnown(text, vector, metadata);
+  }
+
+  private async upsertKnown(
+    text: string,
+    vector: number[],
+    metadata: RagMetadata,
+  ): Promise<Result<void, RagError>> {
+    try {
+      await this.maybeEnsureSchema();
+      const client = await this.clientPromise;
+      const id = metadata?.id ?? crypto.randomUUID();
+      const { id: _omit, ...rest } = metadata ?? {};
+      const metaJson = JSON.stringify(rest);
+      const sql = `UPSERT ${quoteIdent(this.collectionName)} (id, text, vector, metadata) VALUES (?, ?, ${this.vectorLiteral(vector)}, ?) WITH PRIMARY KEY`;
+      await client.exec(sql, [id, text, metaJson]);
+      return { ok: true, value: undefined };
+    } catch (err) {
+      return { ok: false, error: new RagError(String(err), 'UPSERT_ERROR') };
+    }
+  }
+
+  writer(): IRagBackendWriter {
+    return {
+      upsertRaw: async (id, text, metadata, options) => {
+        const r = await this.upsert(text, { ...metadata, id }, options);
+        return r.ok ? { ok: true, value: undefined } : r;
+      },
+      deleteByIdRaw: async (id) => {
+        try {
+          await this.maybeEnsureSchema();
+          const client = await this.clientPromise;
+          const r = await client.exec(
+            `DELETE FROM ${quoteIdent(this.collectionName)} WHERE id = ?`,
+            [id],
+          );
+          return { ok: true, value: r.rowCount > 0 };
+        } catch (err) {
+          return {
+            ok: false,
+            error: new RagError(String(err), 'DELETE_ERROR'),
+          };
+        }
+      },
+      clearAll: async () => {
+        try {
+          await this.maybeEnsureSchema();
+          const client = await this.clientPromise;
+          await client.exec(
+            `TRUNCATE TABLE ${quoteIdent(this.collectionName)}`,
+          );
+          return { ok: true, value: undefined };
+        } catch (err) {
+          return { ok: false, error: new RagError(String(err), 'CLEAR_ERROR') };
+        }
+      },
+      upsertPrecomputedRaw: async (id, text, vector, metadata) =>
+        this.upsertPrecomputed(text, vector, { ...metadata, id }),
+    };
+  }
+}

--- a/packages/hana-vector-rag/src/index.ts
+++ b/packages/hana-vector-rag/src/index.ts
@@ -1,0 +1,4 @@
+export type { HanaVectorRagConfig } from './hana-vector-rag.js';
+export { HanaVectorRag } from './hana-vector-rag.js';
+export type { HanaVectorRagProviderConfig } from './hana-vector-rag-provider.js';
+export { HanaVectorRagProvider } from './hana-vector-rag-provider.js';

--- a/packages/hana-vector-rag/src/schema.ts
+++ b/packages/hana-vector-rag/src/schema.ts
@@ -28,5 +28,5 @@ export function createTableSql(collection: string, dimension: number): string {
 }
 
 export function dropTableSql(collection: string): string {
-  return `DROP TABLE ${quoteIdent(collection)}`;
+  return `DROP TABLE IF EXISTS ${quoteIdent(collection)}`;
 }

--- a/packages/hana-vector-rag/src/schema.ts
+++ b/packages/hana-vector-rag/src/schema.ts
@@ -5,7 +5,7 @@ const COLLECTION_NAME_RE = /^[a-zA-Z_][a-zA-Z0-9_]{0,62}$/;
 export function assertCollectionName(name: string): void {
   if (!COLLECTION_NAME_RE.test(name)) {
     throw new RagError(
-      `INVALID_COLLECTION_NAME: Invalid collection name: ${name}`,
+      `Invalid collection name: ${name}`,
       'INVALID_COLLECTION_NAME',
     );
   }

--- a/packages/hana-vector-rag/src/schema.ts
+++ b/packages/hana-vector-rag/src/schema.ts
@@ -1,0 +1,32 @@
+import { RagError } from '@mcp-abap-adt/llm-agent';
+
+const COLLECTION_NAME_RE = /^[a-zA-Z_][a-zA-Z0-9_]{0,62}$/;
+
+export function assertCollectionName(name: string): void {
+  if (!COLLECTION_NAME_RE.test(name)) {
+    throw new RagError(
+      `INVALID_COLLECTION_NAME: Invalid collection name: ${name}`,
+      'INVALID_COLLECTION_NAME',
+    );
+  }
+}
+
+export function quoteIdent(ident: string): string {
+  assertCollectionName(ident);
+  return `"${ident}"`;
+}
+
+export function createTableSql(collection: string, dimension: number): string {
+  const table = quoteIdent(collection);
+  return `CREATE TABLE IF NOT EXISTS ${table} (
+    id NVARCHAR(255) PRIMARY KEY,
+    text NCLOB,
+    vector REAL_VECTOR(${dimension}),
+    metadata NCLOB,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+  )`;
+}
+
+export function dropTableSql(collection: string): string {
+  return `DROP TABLE ${quoteIdent(collection)}`;
+}

--- a/packages/hana-vector-rag/tsconfig.json
+++ b/packages/hana-vector-rag/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["node"]
+  },
+  "references": [{ "path": "../llm-agent" }],
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/llm-agent-server/package.json
+++ b/packages/llm-agent-server/package.json
@@ -68,7 +68,9 @@
     "@mcp-abap-adt/openai-embedder": "^12.0.0",
     "@mcp-abap-adt/ollama-embedder": "^12.0.0",
     "@mcp-abap-adt/sap-aicore-embedder": "^12.0.0",
-    "@mcp-abap-adt/qdrant-rag": "^12.0.0"
+    "@mcp-abap-adt/qdrant-rag": "^12.0.0",
+    "@mcp-abap-adt/hana-vector-rag": "^12.0.0",
+    "@mcp-abap-adt/pg-vector-rag": "^12.0.0"
   },
   "peerDependenciesMeta": {
     "@mcp-abap-adt/openai-llm": {
@@ -94,6 +96,12 @@
     },
     "@mcp-abap-adt/qdrant-rag": {
       "optional": true
+    },
+    "@mcp-abap-adt/hana-vector-rag": {
+      "optional": true
+    },
+    "@mcp-abap-adt/pg-vector-rag": {
+      "optional": true
     }
   },
   "devDependencies": {
@@ -105,6 +113,8 @@
     "@mcp-abap-adt/ollama-embedder": "*",
     "@mcp-abap-adt/sap-aicore-embedder": "*",
     "@mcp-abap-adt/qdrant-rag": "*",
+    "@mcp-abap-adt/hana-vector-rag": "*",
+    "@mcp-abap-adt/pg-vector-rag": "*",
     "@opentelemetry/api": "^1.9.1",
     "@sap-ai-sdk/ai-api": "^2.0.0",
     "@sap-ai-sdk/orchestration": "^2.9.0",

--- a/packages/llm-agent-server/package.json
+++ b/packages/llm-agent-server/package.json
@@ -61,16 +61,16 @@
     "zod": "^3.25.0"
   },
   "peerDependencies": {
-    "@mcp-abap-adt/openai-llm": "^12.0.0",
-    "@mcp-abap-adt/anthropic-llm": "^12.0.0",
-    "@mcp-abap-adt/deepseek-llm": "^12.0.0",
-    "@mcp-abap-adt/sap-aicore-llm": "^12.0.0",
-    "@mcp-abap-adt/openai-embedder": "^12.0.0",
-    "@mcp-abap-adt/ollama-embedder": "^12.0.0",
-    "@mcp-abap-adt/sap-aicore-embedder": "^12.0.0",
-    "@mcp-abap-adt/qdrant-rag": "^12.0.0",
-    "@mcp-abap-adt/hana-vector-rag": "^12.0.0",
-    "@mcp-abap-adt/pg-vector-rag": "^12.0.0"
+    "@mcp-abap-adt/openai-llm": "^11.0.0",
+    "@mcp-abap-adt/anthropic-llm": "^11.0.0",
+    "@mcp-abap-adt/deepseek-llm": "^11.0.0",
+    "@mcp-abap-adt/sap-aicore-llm": "^11.0.0",
+    "@mcp-abap-adt/openai-embedder": "^11.0.0",
+    "@mcp-abap-adt/ollama-embedder": "^11.0.0",
+    "@mcp-abap-adt/sap-aicore-embedder": "^11.0.0",
+    "@mcp-abap-adt/qdrant-rag": "^11.0.0",
+    "@mcp-abap-adt/hana-vector-rag": "^11.0.0",
+    "@mcp-abap-adt/pg-vector-rag": "^11.0.0"
   },
   "peerDependenciesMeta": {
     "@mcp-abap-adt/openai-llm": {

--- a/packages/llm-agent-server/src/smart-agent/__tests__/hana-pg-integration.test.ts
+++ b/packages/llm-agent-server/src/smart-agent/__tests__/hana-pg-integration.test.ts
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
+import { MissingProviderError } from '@mcp-abap-adt/llm-agent';
+import { makeRag } from '../providers.js';
+import {
+  _resetPrefetchedRagForTests,
+  prefetchRagFactories,
+  resolveRag,
+} from '../rag-factories.js';
+
+/**
+ * HanaVectorRag and PgVectorRag eagerly create a `clientPromise` in their
+ * constructor that tries to import the native driver at module-load time. In a
+ * test environment those drivers are absent (or shaped differently), so the
+ * promise will always reject. We only verify the *sync shape* of the instance
+ * (i.e. that `ensureSchema` is a function), so we suppress these expected
+ * background rejections for the whole describe block.
+ */
+function suppressDriverInitErrors(_reason: unknown) {
+  /* intentionally absorbed — background driver-init failure is expected */
+}
+
+describe('hana-vector / pg-vector server integration', () => {
+  before(() => {
+    process.on('unhandledRejection', suppressDriverInitErrors);
+  });
+
+  after(() => {
+    process.off('unhandledRejection', suppressDriverInitErrors);
+  });
+
+  it('resolveRag throws MissingProviderError when peer is not prefetched', () => {
+    _resetPrefetchedRagForTests();
+    assert.throws(
+      () =>
+        resolveRag('hana-vector', {
+          collectionName: 't',
+          host: 'h',
+          user: 'u',
+          password: 'p',
+          embedder: {
+            async embed() {
+              return { vector: [0] };
+            },
+          },
+        }),
+      MissingProviderError,
+    );
+  });
+
+  it('makeRag path exposes ensureSchema() for hana-vector (direct construction)', async () => {
+    _resetPrefetchedRagForTests();
+    await prefetchRagFactories(['hana-vector']);
+    const embedder = {
+      async embed() {
+        return { vector: [0, 0, 0] };
+      },
+    };
+    const rag = makeRag(
+      {
+        type: 'hana-vector',
+        host: 'h',
+        user: 'u',
+        password: 'p',
+        collectionName: 'direct_docs',
+        dimension: 3,
+        autoCreateSchema: true,
+      },
+      { injectedEmbedder: embedder },
+    ) as unknown as { ensureSchema: () => Promise<void> };
+    assert.equal(typeof rag.ensureSchema, 'function');
+  });
+
+  it('makeRag path exposes ensureSchema() for pg-vector (direct construction)', async () => {
+    _resetPrefetchedRagForTests();
+    await prefetchRagFactories(['pg-vector']);
+    const embedder = {
+      async embed() {
+        return { vector: [0, 0, 0] };
+      },
+    };
+    const rag = makeRag(
+      {
+        type: 'pg-vector',
+        host: 'h',
+        user: 'u',
+        password: 'p',
+        database: 'd',
+        collectionName: 'direct_docs',
+        dimension: 3,
+        autoCreateSchema: true,
+      },
+      { injectedEmbedder: embedder },
+    ) as unknown as { ensureSchema: () => Promise<void> };
+    assert.equal(typeof rag.ensureSchema, 'function');
+  });
+});

--- a/packages/llm-agent-server/src/smart-agent/__tests__/rag-factories.test.ts
+++ b/packages/llm-agent-server/src/smart-agent/__tests__/rag-factories.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { MissingProviderError } from '@mcp-abap-adt/llm-agent';
+import {
+  _resetPrefetchedRagForTests,
+  prefetchRagFactories,
+  resolveRag,
+} from '../rag-factories.js';
+
+describe('rag-factories', () => {
+  it('throws MissingProviderError for unknown backend name', async () => {
+    _resetPrefetchedRagForTests();
+    await assert.rejects(
+      () => prefetchRagFactories(['nope']),
+      MissingProviderError,
+    );
+  });
+
+  it('throws MissingProviderError at resolveRag when not prefetched', () => {
+    _resetPrefetchedRagForTests();
+    assert.throws(
+      () =>
+        resolveRag('hana-vector', {
+          collectionName: 'x',
+          embedder: {
+            async embed() {
+              return { vector: [0] };
+            },
+          },
+        }),
+      MissingProviderError,
+    );
+  });
+
+  it('prefetches known packages (qdrant already a workspace dev dep)', async () => {
+    _resetPrefetchedRagForTests();
+    await prefetchRagFactories(['qdrant']);
+    const rag = resolveRag('qdrant', {
+      url: 'http://localhost:6333',
+      collectionName: 't',
+      embedder: {
+        async embed() {
+          return { vector: [0, 0, 0] };
+        },
+      },
+    });
+    assert.equal(typeof rag.query, 'function');
+  });
+});

--- a/packages/llm-agent-server/src/smart-agent/cli.ts
+++ b/packages/llm-agent-server/src/smart-agent/cli.ts
@@ -73,6 +73,7 @@ import {
   resolveSmartServerConfig,
 } from './config.js';
 import { prefetchEmbedderFactories } from './embedder-factories.js';
+import { prefetchRagFactories } from './rag-factories.js';
 import type { SmartServerConfig } from './smart-server.js';
 import { SmartServer } from './smart-server.js';
 
@@ -237,6 +238,24 @@ const config: SmartServerConfig = {
     embedderNames.push(name);
   }
   await prefetchEmbedderFactories(embedderNames);
+}
+
+// ---------------------------------------------------------------------------
+// Prefetch RAG backend peer packages — fails fast if a named peer is missing
+// ---------------------------------------------------------------------------
+
+{
+  const ragCfg = baseConfig.rag;
+  const ragBackendNames: string[] = [];
+  if (
+    ragCfg &&
+    (ragCfg.type === 'qdrant' ||
+      ragCfg.type === 'hana-vector' ||
+      ragCfg.type === 'pg-vector')
+  ) {
+    ragBackendNames.push(ragCfg.type);
+  }
+  await prefetchRagFactories(ragBackendNames);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/llm-agent-server/src/smart-agent/config.ts
+++ b/packages/llm-agent-server/src/smart-agent/config.ts
@@ -49,11 +49,11 @@ llm:
   classifierTemperature: 0.1
 
 rag:
-  type: ollama                        # ollama | in-memory | qdrant
+  type: ollama                        # ollama | in-memory | qdrant | hana-vector | pg-vector
   # embedder: ollama                  # Embedder to use: ollama | openai | sap-ai-core | <custom>
   url: http://localhost:11434
   model: nomic-embed-text
-  # collectionName: llm-agent         # Qdrant collection name (qdrant type only)
+  # collectionName: llm-agent         # Collection/table name (qdrant | hana-vector | pg-vector)
   dedupThreshold: 0.92
   vectorWeight: 0.7                   # Semantic similarity weight (0..1)
   keywordWeight: 0.3                  # Lexical matching weight (0..1)
@@ -283,7 +283,12 @@ export function resolveSmartServerConfig(
     rag: {
       type: ((args['rag-type'] as string) ??
         get(yaml, 'rag', 'type') ??
-        'ollama') as 'ollama' | 'in-memory' | 'qdrant',
+        'ollama') as
+        | 'ollama'
+        | 'in-memory'
+        | 'qdrant'
+        | 'hana-vector'
+        | 'pg-vector',
       embedder: (get(yaml, 'rag', 'embedder') as string) ?? undefined,
       url:
         (args['rag-url'] as string) ??

--- a/packages/llm-agent-server/src/smart-agent/pipeline.ts
+++ b/packages/llm-agent-server/src/smart-agent/pipeline.ts
@@ -30,8 +30,14 @@ export interface PipelineLlmProviderConfig {
 }
 
 export interface PipelineRagStoreConfig {
-  /** 'ollama' | 'openai' | 'in-memory' | 'qdrant'. Default: 'ollama' */
-  type?: 'ollama' | 'openai' | 'in-memory' | 'qdrant';
+  /** 'ollama' | 'openai' | 'in-memory' | 'qdrant' | 'hana-vector' | 'pg-vector'. Default: 'ollama' */
+  type?:
+    | 'ollama'
+    | 'openai'
+    | 'in-memory'
+    | 'qdrant'
+    | 'hana-vector'
+    | 'pg-vector';
   /**
    * Embedder name — resolved from the embedder factory registry.
    * Built-in: 'ollama', 'openai'. Consumers can register custom factories.
@@ -44,7 +50,7 @@ export interface PipelineRagStoreConfig {
   apiKey?: string;
   /** Embedding model name */
   model?: string;
-  /** Qdrant collection name (required for qdrant type) */
+  /** Collection / table name (required for qdrant, hana-vector, pg-vector) */
   collectionName?: string;
   /** Cosine similarity dedup threshold. Default: 0.92 */
   dedupThreshold?: number;

--- a/packages/llm-agent-server/src/smart-agent/providers.ts
+++ b/packages/llm-agent-server/src/smart-agent/providers.ts
@@ -20,7 +20,6 @@ import type {
 import { InMemoryRag, VectorRag } from '@mcp-abap-adt/llm-agent';
 import { OllamaRag } from '@mcp-abap-adt/ollama-embedder';
 import { OpenAIProvider } from '@mcp-abap-adt/openai-llm';
-import { QdrantRag } from '@mcp-abap-adt/qdrant-rag';
 import {
   type SapAICoreCredentials,
   SapCoreAIProvider,
@@ -30,6 +29,7 @@ import { LlmProviderBridge } from './adapters/llm-provider-bridge.js';
 import { NonStreamingLlm } from './adapters/non-streaming-llm.js';
 import { builtInEmbedderFactories } from './embedder-factories.js';
 import type { IModelResolver } from './interfaces/model-resolver.js';
+import { resolveRag } from './rag-factories.js';
 
 // ---------------------------------------------------------------------------
 // LLM provider resolution
@@ -247,7 +247,13 @@ export function resolveEmbedder(
 // ---------------------------------------------------------------------------
 
 export interface RagResolutionConfig {
-  type?: 'ollama' | 'openai' | 'in-memory' | 'qdrant';
+  type?:
+    | 'ollama'
+    | 'openai'
+    | 'in-memory'
+    | 'qdrant'
+    | 'hana-vector'
+    | 'pg-vector';
   embedder?: string;
   url?: string;
   apiKey?: string;
@@ -263,6 +269,18 @@ export interface RagResolutionConfig {
   queryPreprocessors?: IQueryPreprocessor[];
   /** Document enrichers for this RAG store. */
   documentEnrichers?: IDocumentEnricher[];
+  /** Connection string or URL for external vector backends. */
+  connectionString?: string;
+  host?: string;
+  port?: number;
+  user?: string;
+  password?: string;
+  database?: string;
+  schema?: string;
+  dimension?: number;
+  autoCreateSchema?: boolean;
+  poolMax?: number;
+  connectTimeout?: number;
 }
 
 export interface RagResolutionOptions {
@@ -305,12 +323,55 @@ export function makeRag(
       throw new Error('Qdrant URL is required for qdrant RAG type');
     }
     const embedder = resolveEmbedder(cfg, options);
-    return new QdrantRag({
+    return resolveRag('qdrant', {
       url: cfg.url,
       collectionName: cfg.collectionName ?? 'llm-agent',
       embedder,
       apiKey: cfg.apiKey,
       timeoutMs: cfg.timeoutMs,
+    });
+  }
+
+  if (cfg.type === 'hana-vector') {
+    if (!cfg.collectionName) {
+      throw new Error('collectionName is required for hana-vector RAG type');
+    }
+    const embedder = resolveEmbedder(cfg, options);
+    return resolveRag('hana-vector', {
+      connectionString: cfg.connectionString,
+      host: cfg.host,
+      port: cfg.port,
+      user: cfg.user,
+      password: cfg.password,
+      schema: cfg.schema,
+      collectionName: cfg.collectionName,
+      dimension: cfg.dimension,
+      autoCreateSchema: cfg.autoCreateSchema,
+      poolMax: cfg.poolMax,
+      connectTimeout: cfg.connectTimeout,
+      embedder,
+    });
+  }
+
+  if (cfg.type === 'pg-vector') {
+    if (!cfg.collectionName) {
+      throw new Error('collectionName is required for pg-vector RAG type');
+    }
+    const embedder = resolveEmbedder(cfg, options);
+    return resolveRag('pg-vector', {
+      connectionString: cfg.connectionString,
+      host: cfg.host,
+      port: cfg.port,
+      user: cfg.user,
+      password: cfg.password,
+      database: cfg.database,
+      schema: cfg.schema,
+      collectionName: cfg.collectionName,
+      dimension: cfg.dimension,
+      autoCreateSchema: cfg.autoCreateSchema,
+      poolMax: cfg.poolMax,
+      connectTimeout: cfg.connectTimeout,
+      embedder,
     });
   }
 

--- a/packages/llm-agent-server/src/smart-agent/rag-factories.ts
+++ b/packages/llm-agent-server/src/smart-agent/rag-factories.ts
@@ -1,0 +1,82 @@
+import type { IEmbedder, IRag } from '@mcp-abap-adt/llm-agent';
+import { MissingProviderError } from '@mcp-abap-adt/llm-agent';
+
+export interface RagFactoryOpts {
+  url?: string;
+  apiKey?: string;
+  collectionName?: string;
+  embedder: IEmbedder;
+  timeoutMs?: number;
+  dimension?: number;
+  autoCreateSchema?: boolean;
+  connectionString?: string;
+  host?: string;
+  port?: number;
+  user?: string;
+  password?: string;
+  database?: string;
+  schema?: string;
+  poolMax?: number;
+  connectTimeout?: number;
+}
+
+const PACKAGE_BY_NAME: Record<string, string> = {
+  qdrant: '@mcp-abap-adt/qdrant-rag',
+  'hana-vector': '@mcp-abap-adt/hana-vector-rag',
+  'pg-vector': '@mcp-abap-adt/pg-vector-rag',
+};
+
+const EXPORT_BY_NAME: Record<string, string> = {
+  qdrant: 'QdrantRag',
+  'hana-vector': 'HanaVectorRag',
+  'pg-vector': 'PgVectorRag',
+};
+
+type RagCtor = new (opts: Record<string, unknown>) => IRag;
+
+const prefetched = new Map<string, Record<string, unknown>>();
+
+/**
+ * Load peer packages for the RAG backend names given. Call once at server
+ * startup before any synchronous resolveRag calls. Missing peer throws
+ * MissingProviderError up front so startup fails fast.
+ */
+export async function prefetchRagFactories(
+  names: readonly string[],
+): Promise<void> {
+  for (const name of names) {
+    if (prefetched.has(name)) continue;
+    const pkg = PACKAGE_BY_NAME[name];
+    if (!pkg) throw new MissingProviderError('(unknown)', name);
+    try {
+      const mod = (await import(pkg)) as Record<string, unknown>;
+      prefetched.set(name, mod);
+    } catch {
+      throw new MissingProviderError(pkg, name);
+    }
+  }
+}
+
+/** Sync resolve. Caller MUST have awaited prefetchRagFactories(names) first. */
+export function resolveRag(name: string, opts: RagFactoryOpts): IRag {
+  const mod = prefetched.get(name);
+  if (!mod) {
+    const pkg = PACKAGE_BY_NAME[name] ?? '(unknown)';
+    throw new MissingProviderError(pkg, name);
+  }
+  const exportName = EXPORT_BY_NAME[name];
+  const Cls = mod[exportName] as RagCtor | undefined;
+  if (!Cls) {
+    throw new MissingProviderError(PACKAGE_BY_NAME[name] ?? '(unknown)', name);
+  }
+  return new Cls(opts as unknown as Record<string, unknown>);
+}
+
+/** Test-only: reset the prefetched map. */
+export function _resetPrefetchedRagForTests(): void {
+  prefetched.clear();
+}
+
+export const ragBackendNames = Object.freeze(
+  Object.keys(PACKAGE_BY_NAME),
+) as readonly string[];

--- a/packages/llm-agent-server/src/smart-agent/smart-server.ts
+++ b/packages/llm-agent-server/src/smart-agent/smart-server.ts
@@ -65,7 +65,13 @@ export interface SmartServerLlmConfig {
 }
 
 export interface SmartServerRagConfig {
-  type?: 'ollama' | 'openai' | 'in-memory' | 'qdrant';
+  type?:
+    | 'ollama'
+    | 'openai'
+    | 'in-memory'
+    | 'qdrant'
+    | 'hana-vector'
+    | 'pg-vector';
   /**
    * Embedder name — resolved from the embedder factory registry.
    * Built-in: 'ollama', 'openai'. Consumers can register custom factories.
@@ -78,6 +84,17 @@ export interface SmartServerRagConfig {
   dedupThreshold?: number;
   vectorWeight?: number;
   keywordWeight?: number;
+  connectionString?: string;
+  host?: string;
+  port?: number;
+  user?: string;
+  password?: string;
+  database?: string;
+  schema?: string;
+  dimension?: number;
+  autoCreateSchema?: boolean;
+  poolMax?: number;
+  connectTimeout?: number;
 }
 
 export interface SmartServerMcpConfig {

--- a/packages/llm-agent-server/tsconfig.json
+++ b/packages/llm-agent-server/tsconfig.json
@@ -17,6 +17,8 @@
     { "path": "../ollama-embedder" },
     { "path": "../openai-embedder" },
     { "path": "../qdrant-rag" },
-    { "path": "../sap-aicore-embedder" }
+    { "path": "../sap-aicore-embedder" },
+    { "path": "../hana-vector-rag" },
+    { "path": "../pg-vector-rag" }
   ]
 }

--- a/packages/pg-vector-rag/README.md
+++ b/packages/pg-vector-rag/README.md
@@ -1,0 +1,31 @@
+# @mcp-abap-adt/pg-vector-rag
+
+PostgreSQL + pgvector backend for @mcp-abap-adt/llm-agent.
+
+Provides:
+- `PgVectorRag` — `IRag` implementation backed by `vector(dim)` columns (pgvector extension).
+- `PgVectorRagProvider` — `IRagProvider` for session/user/global collections.
+
+## Prerequisites
+
+- PostgreSQL 13+
+- `pgvector` extension installed (`CREATE EXTENSION IF NOT EXISTS vector;`)
+
+## Install
+
+```bash
+npm install @mcp-abap-adt/pg-vector-rag pg
+```
+
+## Minimal config
+
+```yaml
+rag:
+  type: pg-vector
+  connectionString: postgres://user:pass@host:5432/mydb
+  collectionName: llm_agent_docs
+  dimension: 1536
+  autoCreateSchema: true
+```
+
+See the monorepo root README for full configuration surface.

--- a/packages/pg-vector-rag/package.json
+++ b/packages/pg-vector-rag/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@mcp-abap-adt/pg-vector-rag",
+  "version": "11.0.0",
+  "description": "PgVectorRag (PostgreSQL + pgvector) and PgVectorRagProvider for @mcp-abap-adt/llm-agent.",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "clean": "tsc -p tsconfig.json --clean",
+    "test": "node --import tsx/esm --test --test-reporter=spec 'src/**/*.test.ts'"
+  },
+  "dependencies": {
+    "@mcp-abap-adt/llm-agent": "*",
+    "pg": "^8.13.0"
+  },
+  "devDependencies": {
+    "@types/pg": "^8.11.0"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fr0ster/llm-agent.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/pg-vector-rag/src/__tests__/connection.test.ts
+++ b/packages/pg-vector-rag/src/__tests__/connection.test.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { resolvePgConnectArgs } from '../connection.js';
+
+describe('resolvePgConnectArgs', () => {
+  it('parses postgres:// URL', () => {
+    const a = resolvePgConnectArgs({
+      connectionString: 'postgres://u:p@host:5432/db',
+      collectionName: 't',
+    });
+    assert.equal(a.connectionString, 'postgres://u:p@host:5432/db');
+    assert.equal(a.max, 10);
+  });
+
+  it('uses explicit fields', () => {
+    const a = resolvePgConnectArgs({
+      host: 'h',
+      port: 6543,
+      user: 'u',
+      password: 'p',
+      database: 'db',
+      poolMax: 3,
+      collectionName: 't',
+    });
+    assert.equal(a.host, 'h');
+    assert.equal(a.port, 6543);
+    assert.equal(a.user, 'u');
+    assert.equal(a.password, 'p');
+    assert.equal(a.database, 'db');
+    assert.equal(a.max, 3);
+  });
+
+  it('rejects missing host and connectionString', () => {
+    assert.throws(
+      () =>
+        resolvePgConnectArgs({ user: 'u', password: 'p', collectionName: 't' }),
+      /host|connectionString/i,
+    );
+  });
+});

--- a/packages/pg-vector-rag/src/__tests__/pg-vector-rag-provider.test.ts
+++ b/packages/pg-vector-rag/src/__tests__/pg-vector-rag-provider.test.ts
@@ -1,0 +1,141 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { IEmbedder } from '@mcp-abap-adt/llm-agent';
+import type { PgClient } from '../pg-vector-rag.js';
+import { PgVectorRagProvider } from '../pg-vector-rag-provider.js';
+
+function makeEmbedder(): IEmbedder {
+  return {
+    async embed() {
+      return { vector: [0, 0, 0] };
+    },
+  };
+}
+
+interface ExecCall {
+  sql: string;
+  params: readonly unknown[];
+}
+
+function makeFakeClient(
+  rows: Record<string, unknown>[] = [],
+): PgClient & { calls: ExecCall[] } {
+  const calls: ExecCall[] = [];
+  return {
+    calls,
+    async query(sql, params = []) {
+      calls.push({ sql, params });
+      return { rows, rowCount: rows.length };
+    },
+    async end() {},
+  };
+}
+
+describe('PgVectorRagProvider', () => {
+  it('createCollection runs schema bootstrap when autoCreateSchema=true', async () => {
+    const client = makeFakeClient();
+    const provider = new PgVectorRagProvider({
+      name: 'pg',
+      embedder: makeEmbedder(),
+      connection: {
+        collectionName: '__ignored',
+        host: 'h',
+        user: 'u',
+        password: 'p',
+        database: 'd',
+      },
+      defaultDimension: 3,
+      autoCreateSchema: true,
+      clientFactory: () => client,
+    });
+    const r = await provider.createCollection('docs', { scope: 'global' });
+    assert.equal(r.ok, true);
+    assert.ok(
+      client.calls.some(
+        (c) => c.sql.includes('CREATE TABLE') && c.sql.includes('"docs"'),
+      ),
+    );
+  });
+
+  it('createCollection skips DDL when autoCreateSchema=false', async () => {
+    const client = makeFakeClient();
+    const provider = new PgVectorRagProvider({
+      name: 'pg',
+      embedder: makeEmbedder(),
+      connection: {
+        collectionName: '__ignored',
+        host: 'h',
+        user: 'u',
+        password: 'p',
+        database: 'd',
+      },
+      defaultDimension: 3,
+      autoCreateSchema: false,
+      clientFactory: () => client,
+    });
+    const r = await provider.createCollection('docs', { scope: 'global' });
+    assert.equal(r.ok, true);
+    assert.ok(!client.calls.some((c) => c.sql.includes('CREATE TABLE')));
+  });
+
+  it('deleteCollection emits DROP TABLE', async () => {
+    const client = makeFakeClient();
+    const provider = new PgVectorRagProvider({
+      name: 'pg',
+      embedder: makeEmbedder(),
+      connection: {
+        collectionName: '__ignored',
+        host: 'h',
+        user: 'u',
+        password: 'p',
+        database: 'd',
+      },
+      clientFactory: () => client,
+    });
+    const r = await provider.deleteCollection('docs');
+    assert.equal(r.ok, true);
+    assert.ok(client.calls.some((c) => c.sql.startsWith('DROP TABLE')));
+  });
+
+  it('listCollections queries information_schema.tables', async () => {
+    const client = makeFakeClient([
+      { table_name: 'docs' },
+      { table_name: 'other' },
+    ]);
+    const provider = new PgVectorRagProvider({
+      name: 'pg',
+      embedder: makeEmbedder(),
+      connection: {
+        collectionName: '__ignored',
+        host: 'h',
+        user: 'u',
+        password: 'p',
+        database: 'd',
+      },
+      clientFactory: () => client,
+    });
+    const r = await provider.listCollections();
+    assert.equal(r.ok, true);
+    if (!r.ok) throw new Error('unreachable');
+    assert.deepEqual(r.value, ['docs', 'other']);
+  });
+
+  it('rejects unsupported scope', async () => {
+    const client = makeFakeClient();
+    const provider = new PgVectorRagProvider({
+      name: 'pg',
+      embedder: makeEmbedder(),
+      connection: {
+        collectionName: '__ignored',
+        host: 'h',
+        user: 'u',
+        password: 'p',
+        database: 'd',
+      },
+      clientFactory: () => client,
+      supportedScopes: ['global'],
+    });
+    const r = await provider.createCollection('docs', { scope: 'session' });
+    assert.equal(r.ok, false);
+  });
+});

--- a/packages/pg-vector-rag/src/__tests__/pg-vector-rag.test.ts
+++ b/packages/pg-vector-rag/src/__tests__/pg-vector-rag.test.ts
@@ -62,7 +62,10 @@ describe('PgVectorRag', () => {
       { collectionName: 'docs', dimension: 3, embedder: makeEmbedder(3) },
       client,
     );
-    const r = await rag.query({ toVector: async () => [0.1, 0.2, 0.3] }, 5);
+    const r = await rag.query(
+      { text: 'test query', toVector: async () => [0.1, 0.2, 0.3] },
+      5,
+    );
     assert.equal(r.ok, true);
     if (!r.ok) throw new Error('unreachable');
     assert.equal(r.value[0].text, 'hello');
@@ -98,7 +101,7 @@ describe('PgVectorRag', () => {
       { collectionName: 'docs', dimension: 3, embedder: makeEmbedder(3) },
       client,
     );
-    const r = await rag.writer().clearAll();
+    const r = await rag.writer().clearAll!();
     assert.equal(r.ok, true);
     assert.ok(client.calls.some((c) => c.sql.startsWith('TRUNCATE')));
   });

--- a/packages/pg-vector-rag/src/__tests__/pg-vector-rag.test.ts
+++ b/packages/pg-vector-rag/src/__tests__/pg-vector-rag.test.ts
@@ -1,0 +1,128 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { IEmbedder } from '@mcp-abap-adt/llm-agent';
+import { type PgClient, PgVectorRag } from '../pg-vector-rag.js';
+
+function makeEmbedder(dim = 3): IEmbedder {
+  return {
+    async embed(text: string) {
+      let h = 0;
+      for (const ch of text) h = (h * 31 + ch.charCodeAt(0)) | 0;
+      return {
+        vector: Array.from({ length: dim }, (_, i) => ((h >> i) & 0xff) / 255),
+      };
+    },
+  };
+}
+
+interface ExecCall {
+  sql: string;
+  params: readonly unknown[];
+}
+
+function makeFakeClient(
+  rows: Record<string, unknown>[] = [],
+): PgClient & { calls: ExecCall[] } {
+  const calls: ExecCall[] = [];
+  return {
+    calls,
+    async query(sql, params = []) {
+      calls.push({ sql, params });
+      return { rows, rowCount: rows.length };
+    },
+    async end() {},
+  };
+}
+
+describe('PgVectorRag', () => {
+  it('ensureSchema runs CREATE EXTENSION + CREATE TABLE once', async () => {
+    const client = makeFakeClient();
+    const rag = new PgVectorRag(
+      { collectionName: 'docs', dimension: 3, embedder: makeEmbedder(3) },
+      client,
+    );
+    await rag.ensureSchema();
+    await rag.ensureSchema();
+    const extCount = client.calls.filter((c) =>
+      c.sql.includes('CREATE EXTENSION'),
+    ).length;
+    const tblCount = client.calls.filter((c) =>
+      c.sql.includes('CREATE TABLE'),
+    ).length;
+    assert.equal(extCount, 1);
+    assert.equal(tblCount, 1);
+  });
+
+  it('query uses pgvector <=> distance and maps rows', async () => {
+    const rows = [
+      { id: 'a', text: 'hello', metadata: { namespace: 'n' }, score: 0.1 },
+    ];
+    const client = makeFakeClient(rows);
+    const rag = new PgVectorRag(
+      { collectionName: 'docs', dimension: 3, embedder: makeEmbedder(3) },
+      client,
+    );
+    const r = await rag.query({ toVector: async () => [0.1, 0.2, 0.3] }, 5);
+    assert.equal(r.ok, true);
+    if (!r.ok) throw new Error('unreachable');
+    assert.equal(r.value[0].text, 'hello');
+    assert.equal(r.value[0].metadata?.namespace, 'n');
+    assert.ok(client.calls.some((c) => c.sql.includes('<=>')));
+  });
+
+  it('upsertRaw issues INSERT … ON CONFLICT', async () => {
+    const client = makeFakeClient();
+    const rag = new PgVectorRag(
+      { collectionName: 'docs', dimension: 3, embedder: makeEmbedder(3) },
+      client,
+    );
+    const r = await rag.writer().upsertRaw('id1', 'text', { namespace: 'n' });
+    assert.equal(r.ok, true);
+    assert.ok(client.calls.some((c) => c.sql.includes('ON CONFLICT')));
+  });
+
+  it('deleteByIdRaw issues DELETE', async () => {
+    const client = makeFakeClient([{ '?column?': 1 }]);
+    const rag = new PgVectorRag(
+      { collectionName: 'docs', dimension: 3, embedder: makeEmbedder(3) },
+      client,
+    );
+    const r = await rag.writer().deleteByIdRaw('id1');
+    assert.equal(r.ok, true);
+    assert.ok(client.calls.some((c) => c.sql.startsWith('DELETE FROM')));
+  });
+
+  it('clearAll issues TRUNCATE', async () => {
+    const client = makeFakeClient();
+    const rag = new PgVectorRag(
+      { collectionName: 'docs', dimension: 3, embedder: makeEmbedder(3) },
+      client,
+    );
+    const r = await rag.writer().clearAll();
+    assert.equal(r.ok, true);
+    assert.ok(client.calls.some((c) => c.sql.startsWith('TRUNCATE')));
+  });
+
+  it('healthCheck runs SELECT 1', async () => {
+    const client = makeFakeClient([{ '?column?': 1 }]);
+    const rag = new PgVectorRag(
+      { collectionName: 'docs', dimension: 3, embedder: makeEmbedder(3) },
+      client,
+    );
+    const r = await rag.healthCheck();
+    assert.equal(r.ok, true);
+    assert.ok(client.calls.some((c) => c.sql === 'SELECT 1'));
+  });
+
+  it('rejects invalid collection name', () => {
+    assert.throws(
+      () =>
+        new PgVectorRag(
+          { collectionName: "bad'; DROP", embedder: makeEmbedder() },
+          makeFakeClient(),
+        ),
+      (err: Error & { code?: string }) =>
+        err.code === 'INVALID_COLLECTION_NAME',
+    );
+  });
+});

--- a/packages/pg-vector-rag/src/__tests__/schema.test.ts
+++ b/packages/pg-vector-rag/src/__tests__/schema.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  assertCollectionName,
+  createExtensionSql,
+  createTableSql,
+  dropTableSql,
+  quoteIdent,
+} from '../schema.js';
+
+describe('pg schema', () => {
+  it('accepts a safe collection name', () => {
+    assertCollectionName('docs_2');
+  });
+  it('rejects digit-led name', () => {
+    assert.throws(
+      () => assertCollectionName('1bad'),
+      (err: Error & { code?: string }) =>
+        err.code === 'INVALID_COLLECTION_NAME',
+    );
+  });
+  it('rejects punctuation', () => {
+    assert.throws(
+      () => assertCollectionName("x'); DROP"),
+      (err: Error & { code?: string }) =>
+        err.code === 'INVALID_COLLECTION_NAME',
+    );
+  });
+  it('quotes identifiers with double-quotes', () => {
+    assert.equal(quoteIdent('docs'), '"docs"');
+  });
+  it('emits CREATE EXTENSION IF NOT EXISTS vector', () => {
+    assert.match(createExtensionSql(), /CREATE EXTENSION IF NOT EXISTS vector/);
+  });
+  it('emits CREATE TABLE with vector(n) and jsonb', () => {
+    const sql = createTableSql('docs', 1536);
+    assert.match(sql, /CREATE TABLE IF NOT EXISTS "docs"/);
+    assert.match(sql, /vector\(1536\)/);
+    assert.match(sql, /metadata JSONB/);
+  });
+  it('emits DROP TABLE DDL', () => {
+    assert.equal(dropTableSql('docs'), 'DROP TABLE IF EXISTS "docs"');
+  });
+});

--- a/packages/pg-vector-rag/src/connection.ts
+++ b/packages/pg-vector-rag/src/connection.ts
@@ -1,0 +1,51 @@
+export interface PgVectorRagConfig {
+  connectionString?: string;
+  host?: string;
+  port?: number;
+  user?: string;
+  password?: string;
+  database?: string;
+  schema?: string;
+  collectionName: string;
+  dimension?: number;
+  autoCreateSchema?: boolean;
+  poolMax?: number;
+  connectTimeout?: number;
+}
+
+export interface PgPoolConfig {
+  connectionString?: string;
+  host?: string;
+  port?: number;
+  user?: string;
+  password?: string;
+  database?: string;
+  max: number;
+  connectionTimeoutMillis: number;
+}
+
+export function resolvePgConnectArgs(cfg: PgVectorRagConfig): PgPoolConfig {
+  const max = cfg.poolMax ?? 10;
+  const connectionTimeoutMillis = cfg.connectTimeout ?? 30_000;
+
+  if (cfg.connectionString) {
+    return {
+      connectionString: cfg.connectionString,
+      max,
+      connectionTimeoutMillis,
+    };
+  }
+
+  if (!cfg.host) {
+    throw new Error('Postgres connectionString or host is required');
+  }
+  return {
+    host: cfg.host,
+    port: cfg.port ?? 5432,
+    user: cfg.user,
+    password: cfg.password,
+    database: cfg.database,
+    max,
+    connectionTimeoutMillis,
+  };
+}

--- a/packages/pg-vector-rag/src/index.ts
+++ b/packages/pg-vector-rag/src/index.ts
@@ -1,0 +1,4 @@
+export type { PgVectorRagConfig } from './pg-vector-rag.js';
+export { PgVectorRag } from './pg-vector-rag.js';
+export type { PgVectorRagProviderConfig } from './pg-vector-rag-provider.js';
+export { PgVectorRagProvider } from './pg-vector-rag-provider.js';

--- a/packages/pg-vector-rag/src/pg-vector-rag-provider.ts
+++ b/packages/pg-vector-rag/src/pg-vector-rag-provider.ts
@@ -9,7 +9,7 @@ import type {
 import { AbstractRagProvider, RagError } from '@mcp-abap-adt/llm-agent';
 import type { PgVectorRagConfig } from './connection.js';
 import { type PgClient, PgVectorRag } from './pg-vector-rag.js';
-import { quoteIdent } from './schema.js';
+import { dropTableSql } from './schema.js';
 
 export interface PgVectorRagProviderConfig {
   name: string;
@@ -95,7 +95,7 @@ export class PgVectorRagProvider extends AbstractRagProvider {
   async deleteCollection(name: string): Promise<Result<void, RagError>> {
     try {
       const client = this.requireClient();
-      await client.query(`DROP TABLE IF EXISTS ${quoteIdent(name)}`);
+      await client.query(dropTableSql(name));
       return { ok: true, value: undefined };
     } catch (err) {
       return {

--- a/packages/pg-vector-rag/src/pg-vector-rag-provider.ts
+++ b/packages/pg-vector-rag/src/pg-vector-rag-provider.ts
@@ -1,0 +1,130 @@
+import type {
+  IEmbedder,
+  IIdStrategy,
+  IRag,
+  IRagEditor,
+  RagCollectionScope,
+  Result,
+} from '@mcp-abap-adt/llm-agent';
+import { AbstractRagProvider, RagError } from '@mcp-abap-adt/llm-agent';
+import type { PgVectorRagConfig } from './connection.js';
+import { type PgClient, PgVectorRag } from './pg-vector-rag.js';
+import { quoteIdent } from './schema.js';
+
+export interface PgVectorRagProviderConfig {
+  name: string;
+  embedder: IEmbedder;
+  connection: PgVectorRagConfig | string;
+  defaultDimension?: number;
+  autoCreateSchema?: boolean;
+  editable?: boolean;
+  supportedScopes?: readonly RagCollectionScope[];
+  idStrategyFactory?: (opts: {
+    scope: RagCollectionScope;
+    sessionId?: string;
+    userId?: string;
+  }) => IIdStrategy;
+  /**
+   * Optional factory for driver clients used by deleteCollection / listCollections
+   * and (in tests) by createCollection. When omitted, deleteCollection and
+   * listCollections throw because schema-level operations require a shared client
+   * outside the per-collection PgVectorRag lifecycle.
+   */
+  clientFactory?: () => PgClient;
+}
+
+function normalizeConnection(c: PgVectorRagConfig | string): PgVectorRagConfig {
+  return typeof c === 'string'
+    ? { connectionString: c, collectionName: '__unused' }
+    : c;
+}
+
+export class PgVectorRagProvider extends AbstractRagProvider {
+  readonly name: string;
+  readonly kind = 'vector';
+  readonly editable: boolean;
+  readonly supportedScopes: readonly RagCollectionScope[];
+
+  private readonly embedder: IEmbedder;
+  private readonly connection: PgVectorRagConfig;
+  private readonly defaultDimension: number;
+  private readonly autoCreateSchema: boolean;
+  private readonly clientFactory?: () => PgClient;
+
+  constructor(cfg: PgVectorRagProviderConfig) {
+    super();
+    this.name = cfg.name;
+    this.embedder = cfg.embedder;
+    this.connection = normalizeConnection(cfg.connection);
+    this.defaultDimension = cfg.defaultDimension ?? 1536;
+    this.autoCreateSchema = cfg.autoCreateSchema ?? true;
+    this.editable = cfg.editable ?? true;
+    this.supportedScopes = cfg.supportedScopes ?? ['session', 'user', 'global'];
+    this.clientFactory = cfg.clientFactory;
+    if (cfg.idStrategyFactory) this.idStrategyFactory = cfg.idStrategyFactory;
+  }
+
+  async createCollection(
+    name: string,
+    opts: { scope: RagCollectionScope; sessionId?: string; userId?: string },
+  ): Promise<Result<{ rag: IRag; editor: IRagEditor }, RagError>> {
+    const scopeCheck = this.checkScope(opts.scope);
+    if (!scopeCheck.ok) return scopeCheck;
+    try {
+      const rag = new PgVectorRag(
+        {
+          ...this.connection,
+          collectionName: name,
+          dimension: this.connection.dimension ?? this.defaultDimension,
+          autoCreateSchema: this.autoCreateSchema,
+          embedder: this.embedder,
+        },
+        this.clientFactory?.(),
+      );
+      if (this.autoCreateSchema) await rag.ensureSchema();
+      const editor = this.buildEditor(rag, this.pickIdStrategy(opts));
+      return { ok: true, value: { rag, editor } };
+    } catch (err) {
+      return {
+        ok: false,
+        error: new RagError(String(err), 'RAG_CREATE_ERROR'),
+      };
+    }
+  }
+
+  async deleteCollection(name: string): Promise<Result<void, RagError>> {
+    try {
+      const client = this.requireClient();
+      await client.query(`DROP TABLE IF EXISTS ${quoteIdent(name)}`);
+      return { ok: true, value: undefined };
+    } catch (err) {
+      return {
+        ok: false,
+        error: new RagError(String(err), 'RAG_DELETE_ERROR'),
+      };
+    }
+  }
+
+  async listCollections(): Promise<Result<string[], RagError>> {
+    try {
+      const client = this.requireClient();
+      const schema = this.connection.schema ?? 'public';
+      const { rows } = await client.query(
+        'SELECT table_name FROM information_schema.tables WHERE table_schema = $1',
+        [schema],
+      );
+      return { ok: true, value: rows.map((r) => String(r.table_name)) };
+    } catch (err) {
+      return { ok: false, error: new RagError(String(err), 'RAG_LIST_ERROR') };
+    }
+  }
+
+  private requireClient(): PgClient {
+    if (!this.clientFactory) {
+      throw new Error(
+        'PgVectorRagProvider deleteCollection/listCollections require clientFactory; provide one to enable schema-level operations',
+      );
+    }
+    return this.clientFactory();
+  }
+}

--- a/packages/pg-vector-rag/src/pg-vector-rag.ts
+++ b/packages/pg-vector-rag/src/pg-vector-rag.ts
@@ -1,0 +1,240 @@
+import type {
+  CallOptions,
+  IEmbedder,
+  IQueryEmbedding,
+  IRag,
+  IRagBackendWriter,
+  RagMetadata,
+  RagResult,
+  Result,
+} from '@mcp-abap-adt/llm-agent';
+import { FallbackQueryEmbedding, RagError } from '@mcp-abap-adt/llm-agent';
+import type { PgVectorRagConfig } from './connection.js';
+import { resolvePgConnectArgs } from './connection.js';
+import {
+  assertCollectionName,
+  createExtensionSql,
+  createTableSql,
+  quoteIdent,
+} from './schema.js';
+
+export type { PgVectorRagConfig };
+
+export interface PgClient {
+  query(
+    sql: string,
+    params?: readonly unknown[],
+  ): Promise<{ rows: Array<Record<string, unknown>>; rowCount: number }>;
+  end(): Promise<void>;
+}
+
+function vectorLiteral(vec: number[]): string {
+  return `'[${vec.join(',')}]'::vector`;
+}
+
+export class PgVectorRag implements IRag {
+  private readonly collectionName: string;
+  private readonly dimension: number;
+  private readonly embedder: IEmbedder;
+  private readonly autoCreateSchema: boolean;
+  private readonly clientPromise: Promise<PgClient>;
+  private schemaReady = false;
+  private schemaPromise?: Promise<void>;
+
+  constructor(
+    config: PgVectorRagConfig & { embedder: IEmbedder },
+    injectedClient?: PgClient,
+  ) {
+    assertCollectionName(config.collectionName);
+    this.collectionName = config.collectionName;
+    this.dimension = config.dimension ?? 1536;
+    this.embedder = config.embedder;
+    this.autoCreateSchema = config.autoCreateSchema ?? true;
+    this.clientPromise = injectedClient
+      ? Promise.resolve(injectedClient)
+      : this.createDriverClient(config);
+  }
+
+  private async createDriverClient(cfg: PgVectorRagConfig): Promise<PgClient> {
+    const args = resolvePgConnectArgs(cfg);
+    const mod = (await import('pg')) as unknown as {
+      default?: {
+        Pool: new (
+          a: unknown,
+        ) => { query: PgClient['query']; end: () => Promise<void> };
+      };
+      Pool?: new (
+        a: unknown,
+      ) => { query: PgClient['query']; end: () => Promise<void> };
+    };
+    const PoolCtor = mod.Pool ?? mod.default?.Pool;
+    if (!PoolCtor) throw new Error('pg module did not expose Pool');
+    const pool = new PoolCtor(args);
+    return {
+      query: (sql, params = []) => pool.query(sql, params as unknown[]),
+      end: () => pool.end(),
+    };
+  }
+
+  async ensureSchema(): Promise<void> {
+    if (this.schemaReady) return;
+    this.schemaPromise ??= (async () => {
+      const client = await this.clientPromise;
+      await client.query(createExtensionSql());
+      await client.query(createTableSql(this.collectionName, this.dimension));
+      this.schemaReady = true;
+    })();
+    await this.schemaPromise;
+  }
+
+  private async maybeEnsureSchema(): Promise<void> {
+    if (this.autoCreateSchema) await this.ensureSchema();
+  }
+
+  async query(
+    embedding: IQueryEmbedding,
+    k: number,
+    options?: CallOptions,
+  ): Promise<Result<RagResult[], RagError>> {
+    if (options?.signal?.aborted)
+      return { ok: false, error: new RagError('Aborted', 'ABORTED') };
+    try {
+      await this.maybeEnsureSchema();
+      const safe = new FallbackQueryEmbedding(embedding, this.embedder);
+      const vector = await safe.toVector();
+      const client = await this.clientPromise;
+      const table = quoteIdent(this.collectionName);
+      const lit = vectorLiteral(vector);
+      const sql = `SELECT id, text, metadata, vector <=> ${lit} AS score FROM ${table} ORDER BY vector <=> ${lit} LIMIT ${Math.max(1, k)}`;
+      const { rows } = await client.query(sql);
+      const results: RagResult[] = rows.map((row) => ({
+        text: String(row.text ?? ''),
+        metadata: (row.metadata as RagMetadata) ?? {},
+        score: 1 - Number(row.score ?? 0),
+      }));
+      return { ok: true, value: results };
+    } catch (err) {
+      return { ok: false, error: new RagError(String(err), 'QUERY_ERROR') };
+    }
+  }
+
+  async getById(
+    id: string,
+    options?: CallOptions,
+  ): Promise<Result<RagResult | null, RagError>> {
+    if (options?.signal?.aborted)
+      return { ok: false, error: new RagError('Aborted', 'ABORTED') };
+    try {
+      await this.maybeEnsureSchema();
+      const client = await this.clientPromise;
+      const { rows } = await client.query(
+        `SELECT id, text, metadata FROM ${quoteIdent(this.collectionName)} WHERE id = $1`,
+        [id],
+      );
+      const row = rows[0];
+      if (!row) return { ok: true, value: null };
+      return {
+        ok: true,
+        value: {
+          text: String(row.text ?? ''),
+          metadata: (row.metadata as RagMetadata) ?? {},
+          score: 1,
+        },
+      };
+    } catch (err) {
+      return { ok: false, error: new RagError(String(err), 'QUERY_ERROR') };
+    }
+  }
+
+  async healthCheck(): Promise<Result<void, RagError>> {
+    try {
+      const client = await this.clientPromise;
+      await client.query('SELECT 1');
+      return { ok: true, value: undefined };
+    } catch (err) {
+      return {
+        ok: false,
+        error: new RagError(String(err), 'HEALTH_CHECK_ERROR'),
+      };
+    }
+  }
+
+  async upsert(
+    text: string,
+    metadata: RagMetadata,
+    options?: CallOptions,
+  ): Promise<Result<void, RagError>> {
+    if (options?.signal?.aborted)
+      return { ok: false, error: new RagError('Aborted', 'ABORTED') };
+    try {
+      const { vector } = await this.embedder.embed(text, options);
+      return this.upsertKnown(text, vector, metadata);
+    } catch (err) {
+      return { ok: false, error: new RagError(String(err), 'UPSERT_ERROR') };
+    }
+  }
+
+  async upsertPrecomputed(
+    text: string,
+    vector: number[],
+    metadata: RagMetadata,
+  ): Promise<Result<void, RagError>> {
+    return this.upsertKnown(text, vector, metadata);
+  }
+
+  private async upsertKnown(
+    text: string,
+    vector: number[],
+    metadata: RagMetadata,
+  ): Promise<Result<void, RagError>> {
+    try {
+      await this.maybeEnsureSchema();
+      const client = await this.clientPromise;
+      const id = metadata?.id ?? crypto.randomUUID();
+      const { id: _omit, ...rest } = metadata ?? {};
+      const table = quoteIdent(this.collectionName);
+      const sql = `INSERT INTO ${table} (id, text, vector, metadata) VALUES ($1, $2, ${vectorLiteral(vector)}, $3::jsonb) ON CONFLICT (id) DO UPDATE SET text = EXCLUDED.text, vector = EXCLUDED.vector, metadata = EXCLUDED.metadata`;
+      await client.query(sql, [id, text, JSON.stringify(rest)]);
+      return { ok: true, value: undefined };
+    } catch (err) {
+      return { ok: false, error: new RagError(String(err), 'UPSERT_ERROR') };
+    }
+  }
+
+  writer(): IRagBackendWriter {
+    return {
+      upsertRaw: async (id, text, metadata, options) => {
+        const r = await this.upsert(text, { ...metadata, id }, options);
+        return r.ok ? { ok: true, value: undefined } : r;
+      },
+      deleteByIdRaw: async (id) => {
+        try {
+          await this.maybeEnsureSchema();
+          const client = await this.clientPromise;
+          const res = await client.query(
+            `DELETE FROM ${quoteIdent(this.collectionName)} WHERE id = $1`,
+            [id],
+          );
+          return { ok: true, value: res.rowCount > 0 };
+        } catch (err) {
+          return {
+            ok: false,
+            error: new RagError(String(err), 'DELETE_ERROR'),
+          };
+        }
+      },
+      clearAll: async () => {
+        try {
+          await this.maybeEnsureSchema();
+          const client = await this.clientPromise;
+          await client.query(`TRUNCATE ${quoteIdent(this.collectionName)}`);
+          return { ok: true, value: undefined };
+        } catch (err) {
+          return { ok: false, error: new RagError(String(err), 'CLEAR_ERROR') };
+        }
+      },
+      upsertPrecomputedRaw: async (id, text, vector, metadata) =>
+        this.upsertPrecomputed(text, vector, { ...metadata, id }),
+    };
+  }
+}

--- a/packages/pg-vector-rag/src/pg-vector-rag.ts
+++ b/packages/pg-vector-rag/src/pg-vector-rag.ts
@@ -50,9 +50,13 @@ export class PgVectorRag implements IRag {
     this.dimension = config.dimension ?? 1536;
     this.embedder = config.embedder;
     this.autoCreateSchema = config.autoCreateSchema ?? true;
-    this.clientPromise = injectedClient
+    // Attach a no-op catch so the eager import never becomes an unhandledRejection.
+    // The rejection is re-thrown when clientPromise is actually awaited.
+    const driverPromise = injectedClient
       ? Promise.resolve(injectedClient)
       : this.createDriverClient(config);
+    driverPromise.catch(() => {});
+    this.clientPromise = driverPromise;
   }
 
   private async createDriverClient(cfg: PgVectorRagConfig): Promise<PgClient> {

--- a/packages/pg-vector-rag/src/schema.ts
+++ b/packages/pg-vector-rag/src/schema.ts
@@ -1,0 +1,36 @@
+import { RagError } from '@mcp-abap-adt/llm-agent';
+
+const COLLECTION_NAME_RE = /^[a-zA-Z_][a-zA-Z0-9_]{0,62}$/;
+
+export function assertCollectionName(name: string): void {
+  if (!COLLECTION_NAME_RE.test(name)) {
+    throw new RagError(
+      `Invalid collection name: ${name}`,
+      'INVALID_COLLECTION_NAME',
+    );
+  }
+}
+
+export function quoteIdent(ident: string): string {
+  assertCollectionName(ident);
+  return `"${ident}"`;
+}
+
+export function createExtensionSql(): string {
+  return 'CREATE EXTENSION IF NOT EXISTS vector';
+}
+
+export function createTableSql(collection: string, dimension: number): string {
+  const table = quoteIdent(collection);
+  return `CREATE TABLE IF NOT EXISTS ${table} (
+    id VARCHAR(255) PRIMARY KEY,
+    text TEXT,
+    vector vector(${dimension}),
+    metadata JSONB,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+  )`;
+}
+
+export function dropTableSql(collection: string): string {
+  return `DROP TABLE IF EXISTS ${quoteIdent(collection)}`;
+}

--- a/packages/pg-vector-rag/tsconfig.json
+++ b/packages/pg-vector-rag/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["node"]
+  },
+  "references": [{ "path": "../llm-agent" }],
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/scripts/publish-all.sh
+++ b/scripts/publish-all.sh
@@ -6,7 +6,7 @@
 # On the first `npm publish` a browser window opens for 2FA. Check the
 # "trust this device for 5 minutes" option; subsequent publishes in the
 # same run go through without further prompts.
-set -euo pipefail
+set -uo pipefail
 
 cd "$(dirname "$0")/.."
 
@@ -25,11 +25,33 @@ PACKAGES=(
   llm-agent-server
 )
 
+PUBLISHED=0
+SKIPPED=0
+FAILED=()
+
 for pkg in "${PACKAGES[@]}"; do
   echo
-  echo ">>> Publishing @mcp-abap-adt/$pkg"
-  npm publish --workspace "@mcp-abap-adt/$pkg" --access public
+  name="@mcp-abap-adt/$pkg"
+  version="$(node -p "require('./packages/$pkg/package.json').version")"
+  echo ">>> $name@$version"
+
+  # Check if this exact version is already published
+  if npm view "$name@$version" version >/dev/null 2>&1; then
+    echo "    already on npm — skipping"
+    SKIPPED=$((SKIPPED + 1))
+    continue
+  fi
+
+  if npm publish --workspace "$name" --access public; then
+    PUBLISHED=$((PUBLISHED + 1))
+  else
+    FAILED+=("$name@$version")
+  fi
 done
 
 echo
-echo "All ${#PACKAGES[@]} packages published."
+echo "Published: $PUBLISHED  Skipped: $SKIPPED  Failed: ${#FAILED[@]}"
+if [ "${#FAILED[@]}" -gt 0 ]; then
+  printf '  - %s\n' "${FAILED[@]}"
+  exit 1
+fi

--- a/scripts/publish-all.sh
+++ b/scripts/publish-all.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Publish all @mcp-abap-adt/* workspaces to npm in dependency order.
+#
+# Usage: npm run release:publish
+#
+# On the first `npm publish` a browser window opens for 2FA. Check the
+# "trust this device for 5 minutes" option; subsequent publishes in the
+# same run go through without further prompts.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+PACKAGES=(
+  llm-agent
+  openai-llm
+  anthropic-llm
+  deepseek-llm
+  sap-aicore-llm
+  openai-embedder
+  ollama-embedder
+  sap-aicore-embedder
+  qdrant-rag
+  hana-vector-rag
+  pg-vector-rag
+  llm-agent-server
+)
+
+for pkg in "${PACKAGES[@]}"; do
+  echo
+  echo ">>> Publishing @mcp-abap-adt/$pkg"
+  npm publish --workspace "@mcp-abap-adt/$pkg" --access public
+done
+
+echo
+echo "All ${#PACKAGES[@]} packages published."


### PR DESCRIPTION
## Summary

Completes v11.0.0 by adding two optional peer RAG backend packages before the first npm publish. All 12 packages ship together at 11.0.0 in the fixed changeset group.

- **`@mcp-abap-adt/hana-vector-rag`** — SAP HANA Cloud Vector Engine (`REAL_VECTOR(dim)` + `COSINE_SIMILARITY`). Runtime peer: `@sap/hana-client`.
- **`@mcp-abap-adt/pg-vector-rag`** — PostgreSQL + pgvector (`vector(dim)` + `<=>`). Runtime peer: `pg`.
- **Server integration** — new `rag-factories.ts` registry (prefetch + sync resolve) mirroring `embedder-factories.ts`; `rag.type` union extended with `hana-vector` | `pg-vector` in `RagResolutionConfig`, `PipelineRagStoreConfig`, `SmartServerRagConfig`, and YAML parser; CLI prefetches RAG backend peers at startup.
- **Shared backend-owned schema bootstrap** — `ensureSchema()` on both backends, invoked by both direct `makeRag()` and `IRagProvider.createCollection()`.
- **Workspace wiring** — server `peerDependencies` / `peerDependenciesMeta.optional` / `devDependencies`, tsconfig project references, root build/clean scripts, and `.changeset/config.json` fixed group all extended from 10 to 12 packages.
- **Peer dep ranges normalized to `^11.0.0`** (were stale `^12.0.0` from an earlier version-bump overshoot).

## Test plan

- [x] `npm run build` — all 12 packages compile clean
- [x] `npm test` — 815 / 815 passing across the workspace
  - core: 209, server: 460, hana-vector-rag: 23, pg-vector-rag: 22, qdrant-rag: 35, four LLM providers: 86, four embedders + sap-aicore-llm: 16
- [x] `npm run lint:check` — 0 errors (2 pre-existing warnings on test files)
- [x] Unit tests cover: connection resolvers, schema DDL, IRag methods (query / getById / healthCheck / upsert / delete / clearAll), provider create / delete / list collections, scope rejection, collection-name validation, zero-row delete reporting
- [x] Integration tests cover: `MissingProviderError` when optional peer is not installed, `ensureSchema()` exposed on both direct `makeRag()` and provider-driven construction paths
- [ ] Real-DB integration deferred to a follow-up smoke suite (out of scope per spec)

## Release flow (post-merge, manual)

1. `git tag -a v11.0.0 -m "Release 11.0.0"` && `git push --tags`
2. `npm run release:publish` — sequential `npm publish` across all 12 packages, skips anything already on npm; first publish triggers WebAuthn browser prompt (YubiKey tap + "trust for 5 minutes") and the rest go through without further prompts.

See `POST_MERGE_CHECKLIST-v11.md` in the repo root for the full checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)