### PR TITLE
fix(stream,builder): forward streaming tool_calls and surface MCP setup errors

### DIFF
--- a/packages/anthropic-llm/src/anthropic-provider.ts
+++ b/packages/anthropic-llm/src/anthropic-provider.ts
@@ -151,6 +151,14 @@ export class AnthropicProvider extends BaseLLMProvider<AnthropicConfig> {
     const decoder = new TextDecoder();
     let buffer = '';
 
+    // Anthropic streams tool_use as discrete content blocks: a
+    // `content_block_start` with type=tool_use carries id+name, then a series
+    // of `content_block_delta` with type=input_json_delta carries the JSON
+    // arguments in pieces. Map block index → tool-call index to produce
+    // normalized LlmToolCallDelta chunks.
+    const toolBlockIndices = new Map<number, number>();
+    let nextToolIndex = 0;
+
     try {
       while (true) {
         const { done, value } = await reader.read();
@@ -181,6 +189,42 @@ export class AnthropicProvider extends BaseLLMProvider<AnthropicConfig> {
               parsed.delta?.type === 'text_delta'
             ) {
               yield { content: parsed.delta.text || '', raw: parsed };
+            } else if (
+              eventType === 'content_block_start' &&
+              parsed.content_block?.type === 'tool_use'
+            ) {
+              const blockIndex = parsed.index as number;
+              const toolIndex = nextToolIndex++;
+              toolBlockIndices.set(blockIndex, toolIndex);
+              yield {
+                content: '',
+                raw: parsed,
+                toolCalls: [
+                  {
+                    index: toolIndex,
+                    id: parsed.content_block.id,
+                    name: parsed.content_block.name,
+                    arguments: '',
+                  },
+                ],
+              };
+            } else if (
+              eventType === 'content_block_delta' &&
+              parsed.delta?.type === 'input_json_delta'
+            ) {
+              const toolIndex = toolBlockIndices.get(parsed.index as number);
+              if (toolIndex !== undefined) {
+                yield {
+                  content: '',
+                  raw: parsed,
+                  toolCalls: [
+                    {
+                      index: toolIndex,
+                      arguments: parsed.delta.partial_json ?? '',
+                    },
+                  ],
+                };
+              }
             } else if (eventType === 'message_start' && parsed.message?.usage) {
               const u = parsed.message.usage;
               yield {
@@ -194,9 +238,13 @@ export class AnthropicProvider extends BaseLLMProvider<AnthropicConfig> {
               };
             } else if (eventType === 'message_delta') {
               const u = parsed.usage;
+              const stopReason = parsed.delta?.stop_reason;
               yield {
                 content: '',
-                finishReason: parsed.delta?.stop_reason,
+                // Normalize Anthropic's 'tool_use' to 'tool_calls' so the
+                // downstream bridge / agent sees the canonical finish reason.
+                finishReason:
+                  stopReason === 'tool_use' ? 'tool_calls' : stopReason,
                 raw: parsed,
                 usage: u
                   ? {

--- a/packages/llm-agent-server/src/smart-agent/__tests__/builder-mcp-failure-logging.test.ts
+++ b/packages/llm-agent-server/src/smart-agent/__tests__/builder-mcp-failure-logging.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Regression test for issue #118 — SmartAgentBuilder must surface MCP setup
+ * failures via the logger instead of swallowing them silently.
+ */
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type {
+  CallOptions,
+  ILlm,
+  LlmStreamChunk,
+  LlmTool,
+  Result,
+} from '@mcp-abap-adt/llm-agent';
+import type { ILogger, LogEvent } from '../logger/types.js';
+
+function stubLlm(): ILlm {
+  return {
+    async chat(
+      _messages: unknown[],
+      _tools?: LlmTool[],
+      _options?: CallOptions,
+    ) {
+      return {
+        ok: true as const,
+        value: {
+          content: 'ok',
+          toolCalls: [],
+          finishReason: 'stop' as const,
+        },
+      };
+    },
+    async *streamChat(
+      _messages: unknown[],
+      _tools?: LlmTool[],
+      _options?: CallOptions,
+    ): AsyncGenerator<Result<LlmStreamChunk, Error>> {
+      yield {
+        ok: true as const,
+        value: { content: 'ok', finishReason: 'stop' as const },
+      };
+    },
+  };
+}
+
+class CapturingLogger implements ILogger {
+  events: LogEvent[] = [];
+  log(event: LogEvent): void {
+    this.events.push(event);
+  }
+}
+
+describe('SmartAgentBuilder — MCP setup failure logging (#118)', () => {
+  it('logs a warning when an MCP connection fails instead of swallowing it', async () => {
+    const { SmartAgentBuilder } = await import('../builder.js');
+
+    const logger = new CapturingLogger();
+    // Port 1 is reserved/unbound on every sane host → connect must fail.
+    const unreachableUrl = 'http://127.0.0.1:1/mcp/stream/http';
+
+    const handle = await new SmartAgentBuilder({
+      mcp: { type: 'http', url: unreachableUrl },
+    })
+      .withMainLlm(stubLlm())
+      .withLogger(logger)
+      .build();
+
+    try {
+      const warnings = logger.events.filter(
+        (e): e is LogEvent & { type: 'warning' } => e.type === 'warning',
+      );
+      const mcpWarning = warnings.find((w) =>
+        w.message.includes(unreachableUrl),
+      );
+      assert.ok(
+        mcpWarning,
+        `expected a 'warning' log entry mentioning ${unreachableUrl}, got: ${JSON.stringify(warnings)}`,
+      );
+      assert.match(mcpWarning.message, /MCP setup failed/);
+
+      // Agent still builds (graceful degradation contract preserved).
+      const health = await handle.agent.healthCheck();
+      assert.ok(health.ok);
+      assert.equal(health.value.mcp.length, 0);
+    } finally {
+      await handle.close();
+    }
+  });
+});

--- a/packages/llm-agent-server/src/smart-agent/adapters/__tests__/llm-provider-bridge.test.ts
+++ b/packages/llm-agent-server/src/smart-agent/adapters/__tests__/llm-provider-bridge.test.ts
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type {
+  AgentStreamChunk,
+  IModelInfo,
+  LLMProvider,
+  LLMResponse,
+  Message,
+} from '@mcp-abap-adt/llm-agent';
+import { LlmProviderBridge } from '../llm-provider-bridge.js';
+
+class StubProvider implements LLMProvider {
+  readonly model = 'stub';
+  constructor(private readonly chunks: LLMResponse[]) {}
+  async chat(): Promise<LLMResponse> {
+    return { content: '' };
+  }
+  async *streamChat(_m: Message[]): AsyncIterable<LLMResponse> {
+    for (const c of this.chunks) yield c;
+  }
+  async getModels(): Promise<IModelInfo[]> {
+    return [];
+  }
+  async getEmbeddingModels(): Promise<IModelInfo[]> {
+    return [];
+  }
+}
+
+describe('LlmProviderBridge — streaming tool_calls aggregation (#119)', () => {
+  it('aggregates provider-normalized toolCalls deltas across chunks', async () => {
+    // Simulates SAP / Anthropic / OpenAI style: provider yields chunks with
+    // a normalized `toolCalls` field. The bridge must accumulate by index
+    // regardless of provider-specific raw shape.
+    const provider = new StubProvider([
+      {
+        content: '',
+        toolCalls: [
+          { index: 0, id: 'call_abc', name: 'get_weather', arguments: '' },
+        ],
+      },
+      {
+        content: '',
+        toolCalls: [{ index: 0, arguments: '{"city":' }],
+      },
+      {
+        content: '',
+        toolCalls: [{ index: 0, arguments: '"Kyiv"}' }],
+      },
+      { content: '', finishReason: 'tool_calls' },
+    ]);
+    const bridge = new LlmProviderBridge(provider);
+
+    const out: AgentStreamChunk[] = [];
+    for await (const c of bridge.streamWithTools(
+      [{ role: 'user', content: 'hi' }],
+      [],
+    )) {
+      out.push(c as AgentStreamChunk);
+    }
+
+    const toolCallsChunk = out.find((c) => c.type === 'tool_calls');
+    assert.ok(toolCallsChunk, 'expected a tool_calls chunk');
+    assert.equal(toolCallsChunk.type, 'tool_calls');
+    if (toolCallsChunk.type === 'tool_calls') {
+      assert.equal(toolCallsChunk.toolCalls.length, 1);
+      assert.equal(toolCallsChunk.toolCalls[0].id, 'call_abc');
+      assert.equal(toolCallsChunk.toolCalls[0].name, 'get_weather');
+      assert.deepEqual(toolCallsChunk.toolCalls[0].arguments, { city: 'Kyiv' });
+    }
+
+    const done = out.find((c) => c.type === 'done');
+    assert.ok(done && done.type === 'done');
+    if (done && done.type === 'done')
+      assert.equal(done.finishReason, 'tool_calls');
+  });
+
+  it('does not emit tool_calls chunk when provider yields none', async () => {
+    const provider = new StubProvider([
+      { content: 'hello', finishReason: 'stop' },
+    ]);
+    const bridge = new LlmProviderBridge(provider);
+    const out: AgentStreamChunk[] = [];
+    for await (const c of bridge.streamWithTools(
+      [{ role: 'user', content: 'hi' }],
+      [],
+    )) {
+      out.push(c as AgentStreamChunk);
+    }
+    assert.equal(
+      out.find((c) => c.type === 'tool_calls'),
+      undefined,
+    );
+  });
+});

--- a/packages/llm-agent-server/src/smart-agent/adapters/llm-provider-bridge.ts
+++ b/packages/llm-agent-server/src/smart-agent/adapters/llm-provider-bridge.ts
@@ -93,49 +93,34 @@ export class LlmProviderBridge implements BaseAgentLlmBridge {
         yield { type: 'text', delta: chunk.content } as AgentStreamChunk;
       }
 
-      // Extract usage and tool calls from raw
-      const raw = chunk.raw as Record<string, unknown> | undefined;
-      if (raw) {
-        const usage = raw.usage as
-          | { prompt_tokens?: number; completion_tokens?: number }
-          | undefined;
-        if (usage) {
-          yield {
-            type: 'usage',
-            promptTokens: usage.prompt_tokens ?? 0,
-            completionTokens: usage.completion_tokens ?? 0,
-          } as AgentStreamChunk;
-        }
+      // Yield normalized usage from the chunk (provider populates this).
+      if (chunk.usage) {
+        yield {
+          type: 'usage',
+          promptTokens: chunk.usage.prompt_tokens ?? 0,
+          completionTokens: chunk.usage.completion_tokens ?? 0,
+        } as AgentStreamChunk;
+      }
 
-        // Accumulate tool calls from raw delta
-        const choices = raw.choices as
-          | Array<{
-              delta?: {
-                tool_calls?: Array<{
-                  index: number;
-                  id?: string;
-                  function?: { name?: string; arguments?: string };
-                }>;
-              };
-            }>
-          | undefined;
-        const delta = choices?.[0]?.delta;
-        if (delta?.tool_calls) {
-          for (const tc of delta.tool_calls) {
-            const index = tc.index;
-            if (!toolCallMap.has(index)) {
-              toolCallMap.set(index, {
-                id: tc.id ?? '',
-                name: tc.function?.name ?? '',
-                arguments: '',
-              });
-            }
-            if (tc.function?.arguments) {
-              const accumulated = toolCallMap.get(index);
-              if (accumulated) {
-                accumulated.arguments += tc.function.arguments;
-              }
-            }
+      // Accumulate tool-call deltas from the provider-normalized field.
+      // Each provider (OpenAI/DeepSeek, Anthropic, SAP AI SDK) populates
+      // chunk.toolCalls with a uniform LlmToolCallDelta shape, so the bridge
+      // no longer needs to reach into provider-specific raw payloads.
+      if (chunk.toolCalls) {
+        for (const tc of chunk.toolCalls) {
+          const index = tc.index;
+          if (!toolCallMap.has(index)) {
+            toolCallMap.set(index, {
+              id: tc.id ?? '',
+              name: tc.name ?? '',
+              arguments: '',
+            });
+          }
+          const accumulated = toolCallMap.get(index);
+          if (accumulated) {
+            if (tc.id && !accumulated.id) accumulated.id = tc.id;
+            if (tc.name && !accumulated.name) accumulated.name = tc.name;
+            if (tc.arguments) accumulated.arguments += tc.arguments;
           }
         }
       }

--- a/packages/llm-agent-server/src/smart-agent/builder.ts
+++ b/packages/llm-agent-server/src/smart-agent/builder.ts
@@ -978,8 +978,19 @@ export class SmartAgentBuilder {
 
           connected.push(adapter);
           closeFns.push(() => wrapper.disconnect?.() ?? Promise.resolve());
-        } catch {
-          // Skip failed MCP connections — agent continues without that server
+        } catch (err) {
+          // Skip failed MCP setup — agent continues without that server, but
+          // surface why: silently swallowing this leaves operators chasing
+          // "agent has no tools" with no log line to point at the cause
+          // (unreachable host, bad auth, container-network mismatch, etc.).
+          // Note: this try-block also covers tool/skill vectorization, so the
+          // failure could be either connect or post-connect setup.
+          const target = mcpCfg.type === 'stdio' ? mcpCfg.command : mcpCfg.url;
+          log?.log({
+            type: 'warning',
+            traceId: 'builder',
+            message: `MCP setup failed for ${target}: ${err instanceof Error ? err.message : String(err)}`,
+          });
         }
       }
       mcpClients = connected;

--- a/packages/llm-agent/src/types.ts
+++ b/packages/llm-agent/src/types.ts
@@ -45,6 +45,18 @@ export interface LLMResponse {
   content: string;
   raw?: unknown;
   finishReason?: string;
+  /**
+   * Streaming tool-call deltas emitted by the underlying provider, normalized
+   * across providers (SAP AI SDK, OpenAI/DeepSeek, Anthropic). Populated only
+   * by `streamChat()`. Consumers (e.g. LlmProviderBridge) should accumulate
+   * these by `index` to reconstruct full tool calls.
+   */
+  toolCalls?: Array<{
+    index: number;
+    id?: string;
+    name?: string;
+    arguments?: string;
+  }>;
   usage?: {
     prompt_tokens: number;
     completion_tokens: number;

--- a/packages/openai-llm/src/__tests__/openai-provider.test.ts
+++ b/packages/openai-llm/src/__tests__/openai-provider.test.ts
@@ -421,6 +421,45 @@ describe('OpenAIProvider — streamChat() usage', () => {
     assert.deepEqual(capturedBody.stream_options, { include_usage: true });
   });
 
+  it('forwards tool_calls deltas in normalized form (regression: #119)', async () => {
+    const provider = new OpenAIProvider({ apiKey: 'sk-test' });
+    // @ts-expect-error — stub axios for test
+    provider.client.post = async () => ({
+      data: (async function* () {
+        yield Buffer.from(
+          'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"get_weather","arguments":""}}]},"finish_reason":null}]}\n\n',
+        );
+        yield Buffer.from(
+          'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\\"city\\":"}}]},"finish_reason":null}]}\n\n',
+        );
+        yield Buffer.from(
+          'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\\"Kyiv\\"}"}}]},"finish_reason":null}]}\n\n',
+        );
+        yield Buffer.from(
+          'data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}\n\n',
+        );
+        yield Buffer.from('data: [DONE]\n\n');
+      })(),
+    });
+    const chunks: import('@mcp-abap-adt/llm-agent').LLMResponse[] = [];
+    for await (const chunk of provider.streamChat([
+      { role: 'user', content: 'hi' },
+    ])) {
+      chunks.push(chunk);
+    }
+    const toolChunks = chunks.filter((c) => c.toolCalls);
+    assert.equal(toolChunks.length, 3, 'expected 3 chunks carrying toolCalls');
+    assert.deepEqual(toolChunks[0].toolCalls, [
+      { index: 0, id: 'call_1', name: 'get_weather', arguments: '' },
+    ]);
+    assert.deepEqual(toolChunks[1].toolCalls, [
+      { index: 0, id: undefined, name: undefined, arguments: '{"city":' },
+    ]);
+    assert.deepEqual(toolChunks[2].toolCalls, [
+      { index: 0, id: undefined, name: undefined, arguments: '"Kyiv"}' },
+    ]);
+  });
+
   it('yields usage-only chunk at end of stream', async () => {
     const provider = new OpenAIProvider({ apiKey: 'sk-test' });
     // @ts-expect-error — stub axios for test

--- a/packages/openai-llm/src/openai-provider.ts
+++ b/packages/openai-llm/src/openai-provider.ts
@@ -148,10 +148,26 @@ export class OpenAIProvider extends BaseLLMProvider<OpenAIConfig> {
             const parsed = JSON.parse(data);
             const choice = parsed.choices?.[0];
             if (choice?.delta) {
+              const deltaToolCalls = choice.delta.tool_calls as
+                | Array<{
+                    index: number;
+                    id?: string;
+                    function?: { name?: string; arguments?: string };
+                  }>
+                | undefined;
+              const toolCalls = deltaToolCalls?.length
+                ? deltaToolCalls.map((tc) => ({
+                    index: tc.index,
+                    id: tc.id,
+                    name: tc.function?.name,
+                    arguments: tc.function?.arguments,
+                  }))
+                : undefined;
               yield {
                 content: choice.delta.content || '',
                 finishReason: choice.finish_reason,
                 raw: parsed,
+                ...(toolCalls ? { toolCalls } : {}),
               };
             }
             // Usage-only chunk (stream_options: include_usage)

--- a/packages/sap-aicore-llm/src/sap-core-ai-provider.ts
+++ b/packages/sap-aicore-llm/src/sap-core-ai-provider.ts
@@ -308,6 +308,24 @@ export class SapCoreAIProvider extends BaseLLMProvider<SapCoreAIConfig> {
           emittedContentChars += deltaContent.length;
         }
         const finishReason = chunk.getFinishReason();
+        // SAP AI SDK exposes tool-call deltas via getDeltaToolCalls(); without
+        // forwarding them the agent sees finishReason='tool_calls' but no calls
+        // to dispatch (regression introduced in the 10.x provider split).
+        const sdkToolCalls = chunk.getDeltaToolCalls?.() as
+          | Array<{
+              index: number;
+              id?: string;
+              function?: { name?: string; arguments?: string };
+            }>
+          | undefined;
+        const toolCalls = sdkToolCalls?.length
+          ? sdkToolCalls.map((tc) => ({
+              index: tc.index,
+              id: tc.id,
+              name: tc.function?.name,
+              arguments: tc.function?.arguments,
+            }))
+          : undefined;
         this.log?.debug('SAP AI SDK streamChat chunk received', {
           model,
           chunkIndex,
@@ -328,6 +346,7 @@ export class SapCoreAIProvider extends BaseLLMProvider<SapCoreAIConfig> {
           content: deltaContent,
           finishReason,
           raw: chunk,
+          ...(toolCalls ? { toolCalls } : {}),
           ...(tokenUsage
             ? {
                 usage: {


### PR DESCRIPTION
## Summary

- **Fixes #119** — streaming `tool_calls` were dropped after the 10.x provider split. SAP AI SDK / Anthropic / OpenAI / DeepSeek `streamChat()` now emit normalized `LlmToolCallDelta[]` via a new optional `LLMResponse.toolCalls` field, and `LlmProviderBridge` accumulates from this normalized field instead of digging into provider-specific raw payloads (it previously handled only OpenAI's `choice.delta.tool_calls` shape, so SAP and Anthropic calls were lost). Anthropic also now normalizes `stop_reason='tool_use'` → `finishReason='tool_calls'`.
- **Fixes #118** — `SmartAgentBuilder.build()` swallowed all MCP setup errors via a bare \`catch {}\`. Now binds the error and emits a \`warning\` log entry naming the target (URL or command) and the underlying message, matching the pattern used elsewhere in the same file. Graceful-degradation contract is preserved (agent still builds without that MCP server).

## Files touched

| Layer | File |
|---|---|
| types | \`packages/llm-agent/src/types.ts\` — \`LLMResponse.toolCalls?\` |
| sap-aicore-llm | \`sap-core-ai-provider.ts\` — \`getDeltaToolCalls()\` mapping |
| openai-llm (deepseek inherits) | \`openai-provider.ts\` — \`choice.delta.tool_calls\` mapping |
| anthropic-llm | \`anthropic-provider.ts\` — \`tool_use\`/\`input_json_delta\` blocks + \`stop_reason\` normalization |
| llm-agent-server | \`adapters/llm-provider-bridge.ts\` — accumulate from \`chunk.toolCalls\` |
| llm-agent-server | \`smart-agent/builder.ts\` — log MCP setup failures |

## Test plan

- [x] \`npm run build\` — clean
- [x] \`npm run lint:check\` — clean
- [x] \`npm test --workspace=@mcp-abap-adt/openai-llm\` — 36 pass (incl. new \`forwards tool_calls deltas in normalized form (regression: #119)\`)
- [x] \`npm test --workspace=@mcp-abap-adt/sap-aicore-llm\` — 16 pass
- [x] \`npm test --workspace=@mcp-abap-adt/deepseek-llm\` — 16 pass
- [x] \`npm test --workspace=@mcp-abap-adt/anthropic-llm\` — 19 pass
- [x] \`npm test --workspace=@mcp-abap-adt/llm-agent-server\` — 463 pass (incl. new \`LlmProviderBridge — streaming tool_calls aggregation (#119)\` and \`SmartAgentBuilder — MCP setup failure logging (#118)\`)
- [ ] Smoke test downstream consumer (e.g. cloud-llm-hub) with \`LLM_AGENT_PROVIDER=sap-ai-sdk\` + tool-capable model — verify tool calls dispatch end-to-end against a real SAP AI Core endpoint.
- [ ] Verify with deliberately misconfigured MCP URL that the new warning shows up in logs and \`/health\` still responds with \`mcpReachable: false\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)