### PR TITLE
fix(release): publish-all.sh aborts on first publish failure

### DIFF
--- a/scripts/publish-all.sh
+++ b/scripts/publish-all.sh
@@ -35,7 +35,6 @@ PACKAGES=(
 
 PUBLISHED=0
 SKIPPED=0
-FAILED=()
 
 for pkg in "${PACKAGES[@]}"; do
   echo
@@ -50,16 +49,26 @@ for pkg in "${PACKAGES[@]}"; do
     continue
   fi
 
-  if npm publish --workspace "$name" --access public; then
-    PUBLISHED=$((PUBLISHED + 1))
-  else
-    FAILED+=("$name@$version")
+  # Publish in dependency order. Abort immediately on ANY failure. A single
+  # failed publish (404/401/403 because the npm login / 2FA session dropped, or
+  # a network error) means continuing would publish dependents on top of an
+  # unpublished dependency — producing a broken, uninstallable release set
+  # (the #142 class of bug). Fail fast instead of collecting failures.
+  npm publish --workspace "$name" --access public
+  status=$?
+  if [ "$status" -ne 0 ]; then
+    echo >&2
+    echo "ERROR: 'npm publish' failed for $name@$version (exit $status)." >&2
+    echo "Aborting: the remaining packages will NOT be published." >&2
+    echo "A 404/401/403 here usually means the npm login / 2FA session dropped —" >&2
+    echo "re-authenticate ('npm whoami' to check, 'npm login' to renew) and re-run." >&2
+    echo "Already-published packages are detected and skipped on the next run." >&2
+    echo >&2
+    echo "Published before failure: $PUBLISHED  Skipped: $SKIPPED" >&2
+    exit "$status"
   fi
+  PUBLISHED=$((PUBLISHED + 1))
 done
 
 echo
-echo "Published: $PUBLISHED  Skipped: $SKIPPED  Failed: ${#FAILED[@]}"
-if [ "${#FAILED[@]}" -gt 0 ]; then
-  printf '  - %s\n' "${FAILED[@]}"
-  exit 1
-fi
+echo "Published: $PUBLISHED  Skipped: $SKIPPED"


### PR DESCRIPTION
## Summary
`scripts/publish-all.sh` collected publish failures and continued through the remaining packages, exiting only at the end. Because packages publish in dependency order, a single failure — e.g. a 404/401/403 when the npm login / 2FA session drops, or a network error — would let the script publish dependents on top of an unpublished dependency, producing a broken, uninstallable release set (the #142 class of bug).

Now any non-zero `npm publish` exit **aborts immediately**, prints a diagnostic (pointing at the likely dropped-login cause), and propagates the real exit code. Already-published packages are still detected and skipped, so re-running after re-authenticating resumes cleanly.

## Test Plan
- [x] `bash -n scripts/publish-all.sh` — no syntax errors
- [ ] Dry behavior: on a simulated publish failure the loop exits without attempting later packages (verified by reading; publish itself is user-driven via yubikey)

🤖 Generated with [Claude Code](https://claude.com/claude-code)