### PR TITLE
ci: drop Node 20 — matrix on Node 22 + 24, bump actions to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,16 @@ jobs:
   ci:
     runs-on: ubuntu-latest
 
-    steps:
-      - uses: actions/checkout@v4
+    strategy:
+      matrix:
+        node-version: ['22', '24']
 
-      - uses: actions/setup-node@v4
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
         with:
-          node-version: '22'
+          node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+- **Supported Node bumped to ≥ 22** (`engines.node` `>=18` → `>=22`, `npm` `>=10`). Node 18 is EOL and 20 reaches EOL in April 2026. CI now runs the matrix on Node **22 and 24** (both active LTS), and the GitHub Actions are bumped to `actions/checkout@v5` / `actions/setup-node@v5` (Node 24 action runtime). Repo/dev policy only — published packages declare no `engines`, so installs are unaffected.
+
 ## [16.2.0] — 2026-05-25
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ still install only what they need.)
 - **Biome** for lint/format (not ESLint/Prettier): 2 spaces, single quotes, always semicolons
 - **Conventional Commits**: `feat:`, `fix:`, `refactor:`, `chore:`, `docs:`
 - TypeScript strict mode; avoid `any` (Biome warns)
-- Node ≥ 18 required
+- Node ≥ 22 required (CI runs on 22 and 24)
 
 ## Environment
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "url": "git+https://github.com/fr0ster/llm-agent.git"
   },
   "engines": {
-    "node": ">=18.0.0",
-    "npm": ">=9.0.0"
+    "node": ">=22.0.0",
+    "npm": ">=10.0.0"
   }
 }


### PR DESCRIPTION
## Summary
Drops Node 20 from the supported set and silences the GitHub Actions Node-20 runtime deprecation.

- **`ci.yml`** — test matrix on Node **22 and 24** (both active LTS; was a single Node 22); `actions/checkout@v5` + `actions/setup-node@v5`.
- **`release.yml`** — `actions/checkout@v5`.
- **`engines`** — `node` `>=18` → `>=22`, `npm` `>=9` → `>=10` (Node 18 EOL; 20 EOL Apr 2026). Repo/dev policy only — published packages declare no `engines`, so consumer installs are unaffected.
- **docs** — `CLAUDE.md` Node requirement; `CHANGELOG` `[Unreleased]` note.

Note: the "Node 20" deprecation was the **action runtime** (checkout/setup-node ran on Node 20 internally), independent of the project's test Node. v5 actions run on Node 24.

## Test Plan
- [x] `engines` valid JSON; both workflow files valid YAML
- [ ] CI green on the new matrix (Node 22 + 24) once this PR runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)