### PR TITLE
feat(coordinator): slice 2 — plan reviewer gate + roles unified on ISubAgent

### DIFF
--- a/docs/superpowers/plans/2026-05-26-slice2-plan-reviewer.md
+++ b/docs/superpowers/plans/2026-05-26-slice2-plan-reviewer.md
@@ -1,0 +1,826 @@
+# Slice 2: Plan Reviewer Gate — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an optional plan-reviewer gate between planning and execution in the DAG coordinator, and reconcile the planner so both roles run through the one `ISubAgent` path.
+
+**Architecture:** A *role* is a typed adapter that owns a `DirectLlmSubAgent`, builds its `task` from typed input, calls `run()`, and parses the string `output` into a typed structure. `LlmDagPlanner` is refactored onto this pattern (removing its direct `ILlm.chat`). A new `IReviewStrategy` (with `LlmReviewStrategy` + `NoopReviewStrategy`) judges a `DagPlan`; `DagCoordinatorHandler` runs it as a fail-loud gate between `planner.plan()` and `interpreter.interpret()`. Selection is by presence of `coordinator.reviewer` in YAML.
+
+**Tech Stack:** TypeScript (ESM, strict), Node `node:test` runner via `tsx`, Biome, monorepo workspaces.
+
+**Spec:** `docs/superpowers/specs/2026-05-26-slice2-plan-reviewer-design.md`
+
+**Conventions reminder:** ESM `.js` import extensions; interfaces start with `I`; tests live in `__tests__/` beside the unit, named `*.test.ts`; run a package's tests with `npm run test --workspace <pkg>`; build all with `npm run build`; lint with `npm run lint`.
+
+---
+
+### Task 1: `IReviewStrategy` contracts
+
+**Files:**
+- Create: `packages/llm-agent/src/interfaces/review.ts`
+- Modify: `packages/llm-agent/src/interfaces/index.ts` (barrel)
+
+- [ ] **Step 1: Create the contracts file**
+
+Create `packages/llm-agent/src/interfaces/review.ts`:
+
+```ts
+import type { DagPlan } from './dag-plan.js';
+import type { PlannerCatalogEntry } from './planner.js';
+
+export interface ReviewInput {
+  prompt: string;
+  plan: DagPlan;
+  agents: PlannerCatalogEntry[];
+  sessionId: string;
+  signal?: AbortSignal;
+}
+
+export type ReviewVerdict = { pass: true } | { pass: false; feedback: string };
+
+export interface IReviewStrategy {
+  readonly name: string;
+  review(input: ReviewInput): Promise<ReviewVerdict>;
+}
+```
+
+- [ ] **Step 2: Export from the barrel**
+
+In `packages/llm-agent/src/interfaces/index.ts`, add after the planner export block (the `} from './planner.js';` line near line 80):
+
+```ts
+export type {
+  IReviewStrategy,
+  ReviewInput,
+  ReviewVerdict,
+} from './review.js';
+```
+
+- [ ] **Step 3: Build to verify it compiles and re-exports**
+
+Run: `npm run build`
+Expected: build succeeds (the root `src/index.ts` re-exports `interfaces/index.js` via `export * `, so the new types are public automatically).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/llm-agent/src/interfaces/review.ts packages/llm-agent/src/interfaces/index.ts
+git commit -m "feat(slice2): add IReviewStrategy contracts (ReviewInput/ReviewVerdict)"
+```
+
+---
+
+### Task 2: Refactor `LlmDagPlanner` onto a `DirectLlmSubAgent`
+
+This removes the slice-1 direct-`ILlm` call. Behavior (the combined prompt + the parsing/validation) must stay identical — guarded by the existing planner tests.
+
+**Files:**
+- Modify: `packages/llm-agent-libs/src/coordinator/dag/llm-dag-planner.ts`
+- Test: `packages/llm-agent-libs/src/coordinator/dag/__tests__/llm-dag-planner.test.ts` (existing — must keep passing)
+
+- [ ] **Step 1: Run the existing planner tests to confirm the green baseline**
+
+Run: `npm run test --workspace @mcp-abap-adt/llm-agent-libs 2>&1 | grep -iE "fail"`
+Expected: `ℹ fail 0` (all existing tests pass before the refactor).
+
+- [ ] **Step 2: Rewrite `llm-dag-planner.ts` to own a `DirectLlmSubAgent`**
+
+Replace the full contents of `packages/llm-agent-libs/src/coordinator/dag/llm-dag-planner.ts` with:
+
+```ts
+import type {
+  DagPlan,
+  ILlm,
+  IPlanner,
+  PlanNode,
+  PlannerInput,
+} from '@mcp-abap-adt/llm-agent';
+import { DirectLlmSubAgent } from '../../subagent/direct-llm-subagent.js';
+
+// Static planner instructions. The agent catalog and user prompt are NOT here —
+// they are dynamic and go into the per-call `task` (see plan()).
+const PLANNER_SYSTEM = `You are a planner. Decompose the user request into a DAG of tasks.
+Each node: {"id","goal","agent"(optional worker name),"dependsOn"(optional ids),"needsInput"(optional bool)}.
+Use "dependsOn" to express order/data-flow; independent nodes run in parallel.
+If the request needs no decomposition, emit a SINGLE node.
+Emit a plan-level "objective". Respond with ONLY:
+{"objective":"...","nodes":[{"id":"n1","goal":"...","agent":"<worker name or omit>","dependsOn":[],"needsInput":false}]}`;
+
+/**
+ * Role adapter: owns a constrained `DirectLlmSubAgent` and turns its string
+ * output into a typed `DagPlan`. (Slice 2: planner now flows through the one
+ * ISubAgent path instead of calling ILlm directly.)
+ */
+export class LlmDagPlanner implements IPlanner {
+  readonly name = 'llm-dag';
+  private readonly agent: DirectLlmSubAgent;
+
+  constructor(llm: ILlm) {
+    this.agent = new DirectLlmSubAgent('planner', llm, {
+      systemPrompt: PLANNER_SYSTEM,
+      contextPolicy: 'optional',
+    });
+  }
+
+  async plan(input: PlannerInput): Promise<DagPlan> {
+    const catalog = input.agents
+      .map((a) => `- ${a.name}: ${a.description ?? '(no description)'}`)
+      .join('\n');
+    const task = `Available workers:\n${catalog || '(none)'}\n\n${input.prompt}`;
+
+    const res = await this.agent.run({
+      task,
+      sessionId: input.sessionId,
+      signal: input.signal,
+      layer: 0,
+    });
+    const content = res.output;
+
+    const match = content.match(/\{[\s\S]*\}/);
+    if (!match)
+      throw new Error(
+        `Planner output did not contain a JSON object: ${content.slice(0, 200)}`,
+      );
+    // Field values come straight from untrusted JSON, so they are typed as
+    // `unknown` and validated below before being narrowed to PlanNode.
+    let parsed: {
+      objective?: unknown;
+      rationale?: unknown;
+      nodes?: Array<{
+        id?: unknown;
+        goal?: unknown;
+        agent?: unknown;
+        dependsOn?: unknown;
+        needsInput?: unknown;
+      }>;
+    };
+    try {
+      parsed = JSON.parse(match[0]);
+    } catch {
+      throw new Error(
+        `Planner output contained malformed JSON: ${match[0].slice(0, 200)}`,
+      );
+    }
+    if (!Array.isArray(parsed.nodes) || parsed.nodes.length === 0) {
+      throw new Error(`Planner returned no nodes: ${match[0].slice(0, 200)}`);
+    }
+    if (
+      parsed.objective !== undefined &&
+      typeof parsed.objective !== 'string'
+    ) {
+      throw new Error(
+        `Planner objective must be a string: ${JSON.stringify(parsed.objective)}`,
+      );
+    }
+    if (
+      parsed.rationale !== undefined &&
+      typeof parsed.rationale !== 'string'
+    ) {
+      throw new Error(
+        `Planner rationale must be a string: ${JSON.stringify(parsed.rationale)}`,
+      );
+    }
+    const nodes: PlanNode[] = parsed.nodes.map((n, i) => {
+      if (typeof n.goal !== 'string' || n.goal.trim() === '') {
+        throw new Error(`Planner node is missing a goal: ${JSON.stringify(n)}`);
+      }
+      if (n.id !== undefined && typeof n.id !== 'string') {
+        throw new Error(
+          `Planner node has a non-string id: ${JSON.stringify(n)}`,
+        );
+      }
+      if (n.agent !== undefined && typeof n.agent !== 'string') {
+        throw new Error(
+          `Planner node has a non-string agent: ${JSON.stringify(n)}`,
+        );
+      }
+      if (
+        n.dependsOn !== undefined &&
+        (!Array.isArray(n.dependsOn) ||
+          n.dependsOn.some((d) => typeof d !== 'string'))
+      ) {
+        throw new Error(
+          `Planner node dependsOn must be an array of strings: ${JSON.stringify(n)}`,
+        );
+      }
+      if (n.needsInput !== undefined && typeof n.needsInput !== 'boolean') {
+        throw new Error(
+          `Planner node needsInput must be a boolean: ${JSON.stringify(n)}`,
+        );
+      }
+      return {
+        id: (n.id as string | undefined) ?? `n${i + 1}`,
+        goal: n.goal,
+        agent: n.agent as string | undefined,
+        dependsOn: n.dependsOn as string[] | undefined,
+        needsInput: n.needsInput as boolean | undefined,
+      };
+    });
+    return {
+      nodes,
+      objective: parsed.objective as string | undefined,
+      rationale: parsed.rationale as string | undefined,
+      createdAt: Date.now(),
+    };
+  }
+}
+```
+
+- [ ] **Step 3: Run the existing planner tests — they must still pass unchanged**
+
+Run: `npm run test --workspace @mcp-abap-adt/llm-agent-libs 2>&1 | grep -iE "fail"`
+Expected: `ℹ fail 0`. The existing fixtures (single-node, dependsOn, malformed-JSON throw, node-field-type rejects, objective/rationale rejects, "throws the LLM error when not ok") all still pass: the failing-LLM mock makes `DirectLlmSubAgent.run()` throw `res.error`, which propagates identically.
+
+- [ ] **Step 4: Build + lint**
+
+Run: `npm run build && npm run lint`
+Expected: build OK; lint reports `Fixed` at most formatting, no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/llm-agent-libs/src/coordinator/dag/llm-dag-planner.ts
+git commit -m "refactor(slice2): LlmDagPlanner owns a DirectLlmSubAgent (one ISubAgent path)"
+```
+
+---
+
+### Task 3: `LlmReviewStrategy` + `NoopReviewStrategy`
+
+**Files:**
+- Create: `packages/llm-agent-libs/src/coordinator/dag/llm-review-strategy.ts`
+- Create: `packages/llm-agent-libs/src/coordinator/dag/noop-review-strategy.ts`
+- Test: `packages/llm-agent-libs/src/coordinator/dag/__tests__/llm-review-strategy.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/llm-agent-libs/src/coordinator/dag/__tests__/llm-review-strategy.test.ts`:
+
+```ts
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { DagPlan, ILlm, ReviewInput } from '@mcp-abap-adt/llm-agent';
+import { LlmReviewStrategy } from '../llm-review-strategy.js';
+import { NoopReviewStrategy } from '../noop-review-strategy.js';
+
+function llm(content: string): ILlm {
+  return { chat: async () => ({ ok: true, value: { content } }) } as unknown as ILlm;
+}
+const plan: DagPlan = {
+  nodes: [{ id: 'n1', goal: 'do it', agent: 'w' }],
+  createdAt: 0,
+};
+const input: ReviewInput = {
+  prompt: 'do it',
+  plan,
+  agents: [{ name: 'w', description: 'worker' }],
+  sessionId: 't',
+};
+
+describe('LlmReviewStrategy', () => {
+  it('returns pass:true on a positive verdict', async () => {
+    const v = await new LlmReviewStrategy(llm('{"pass": true}')).review(input);
+    assert.deepEqual(v, { pass: true });
+  });
+
+  it('returns pass:false with feedback on a negative verdict', async () => {
+    const v = await new LlmReviewStrategy(
+      llm('{"pass": false, "feedback": "no worker can read tables"}'),
+    ).review(input);
+    assert.deepEqual(v, {
+      pass: false,
+      feedback: 'no worker can read tables',
+    });
+  });
+
+  it('throws on malformed JSON', async () => {
+    await assert.rejects(
+      () => new LlmReviewStrategy(llm('not json')).review(input),
+      /JSON/i,
+    );
+  });
+
+  it('throws when pass is not a boolean', async () => {
+    await assert.rejects(
+      () => new LlmReviewStrategy(llm('{"pass": "yes"}')).review(input),
+      /boolean 'pass'/,
+    );
+  });
+
+  it('throws when a rejection has no feedback string', async () => {
+    await assert.rejects(
+      () => new LlmReviewStrategy(llm('{"pass": false}')).review(input),
+      /feedback/,
+    );
+  });
+
+  it('throws the LLM error when the call is not ok', async () => {
+    const failing = {
+      chat: async () => ({ ok: false, error: new Error('quota') }),
+    } as unknown as ILlm;
+    await assert.rejects(
+      () => new LlmReviewStrategy(failing).review(input),
+      /quota/,
+    );
+  });
+});
+
+describe('NoopReviewStrategy', () => {
+  it('always passes', async () => {
+    const v = await new NoopReviewStrategy().review(input);
+    assert.deepEqual(v, { pass: true });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm run test --workspace @mcp-abap-adt/llm-agent-libs 2>&1 | grep -iE "review|fail|cannot find"`
+Expected: FAIL — module `../llm-review-strategy.js` not found.
+
+- [ ] **Step 3: Implement `NoopReviewStrategy`**
+
+Create `packages/llm-agent-libs/src/coordinator/dag/noop-review-strategy.ts`:
+
+```ts
+import type { IReviewStrategy, ReviewVerdict } from '@mcp-abap-adt/llm-agent';
+
+/** Always-pass reviewer. Explicit opt-out / test double. */
+export class NoopReviewStrategy implements IReviewStrategy {
+  readonly name = 'noop-review';
+  async review(): Promise<ReviewVerdict> {
+    return { pass: true };
+  }
+}
+```
+
+- [ ] **Step 4: Implement `LlmReviewStrategy`**
+
+Create `packages/llm-agent-libs/src/coordinator/dag/llm-review-strategy.ts`:
+
+```ts
+import type {
+  ILlm,
+  IReviewStrategy,
+  ReviewInput,
+  ReviewVerdict,
+} from '@mcp-abap-adt/llm-agent';
+import { DirectLlmSubAgent } from '../../subagent/direct-llm-subagent.js';
+
+// Static critic instructions. The user prompt, plan and catalog are dynamic and
+// go into the per-call `task` (see review()).
+const REVIEWER_SYSTEM = `You are a plan reviewer. Given the user request, the available workers, and a proposed DAG plan, decide whether the plan can fulfil the request with those workers.
+Respond with ONLY a JSON object:
+{"pass": true}  — the plan is adequate
+{"pass": false, "feedback": "<what is wrong or what must be clarified>"}  — otherwise`;
+
+/**
+ * Role adapter: owns a constrained `DirectLlmSubAgent` critic and turns its
+ * string output into a typed `ReviewVerdict`.
+ */
+export class LlmReviewStrategy implements IReviewStrategy {
+  readonly name = 'llm-review';
+  private readonly agent: DirectLlmSubAgent;
+
+  constructor(llm: ILlm) {
+    this.agent = new DirectLlmSubAgent('reviewer', llm, {
+      systemPrompt: REVIEWER_SYSTEM,
+      contextPolicy: 'optional',
+    });
+  }
+
+  async review(input: ReviewInput): Promise<ReviewVerdict> {
+    const catalog = input.agents
+      .map((a) => `- ${a.name}: ${a.description ?? '(no description)'}`)
+      .join('\n');
+    const task = `User request:\n${input.prompt}\n\nAvailable workers:\n${
+      catalog || '(none)'
+    }\n\nProposed plan (JSON):\n${JSON.stringify(input.plan)}`;
+
+    const res = await this.agent.run({
+      task,
+      sessionId: input.sessionId,
+      signal: input.signal,
+      layer: 0,
+    });
+
+    const match = res.output.match(/\{[\s\S]*\}/);
+    if (!match)
+      throw new Error(
+        `Reviewer output did not contain a JSON object: ${res.output.slice(0, 200)}`,
+      );
+    let parsed: { pass?: unknown; feedback?: unknown };
+    try {
+      parsed = JSON.parse(match[0]);
+    } catch {
+      throw new Error(
+        `Reviewer output contained malformed JSON: ${match[0].slice(0, 200)}`,
+      );
+    }
+    if (typeof parsed.pass !== 'boolean') {
+      throw new Error(
+        `Reviewer verdict must have a boolean 'pass': ${match[0].slice(0, 200)}`,
+      );
+    }
+    if (parsed.pass === false) {
+      if (typeof parsed.feedback !== 'string' || parsed.feedback.trim() === '') {
+        throw new Error(
+          `Reviewer rejection must include a non-empty 'feedback' string: ${match[0].slice(0, 200)}`,
+        );
+      }
+      return { pass: false, feedback: parsed.feedback };
+    }
+    return { pass: true };
+  }
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `npm run test --workspace @mcp-abap-adt/llm-agent-libs 2>&1 | grep -iE "fail"`
+Expected: `ℹ fail 0`.
+
+- [ ] **Step 6: Build + lint, then commit**
+
+```bash
+npm run build && npm run lint
+git add packages/llm-agent-libs/src/coordinator/dag/llm-review-strategy.ts \
+        packages/llm-agent-libs/src/coordinator/dag/noop-review-strategy.ts \
+        packages/llm-agent-libs/src/coordinator/dag/__tests__/llm-review-strategy.test.ts
+git commit -m "feat(slice2): LlmReviewStrategy + NoopReviewStrategy"
+```
+
+---
+
+### Task 4: Reviewer gate in `DagCoordinatorHandler`
+
+**Files:**
+- Modify: `packages/llm-agent-libs/src/pipeline/handlers/dag-coordinator.ts`
+- Test: `packages/llm-agent-libs/src/pipeline/handlers/__tests__/dag-coordinator.test.ts` (existing)
+
+The builder/pipeline need NO change: `withDagCoordinator(deps)` stores the whole deps object and the pipeline passes it to `new DagCoordinatorHandler(deps)`, so a new optional `reviewer` field on the deps flows through automatically.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `packages/llm-agent-libs/src/pipeline/handlers/__tests__/dag-coordinator.test.ts`, add these inside the `describe('DagCoordinatorHandler', ...)` block (after the last existing test, before the closing `});`). Note the test helpers `planner`, `interp`, `makeCtx` already exist in this file:
+
+```ts
+  it('passes through to interpret when the reviewer passes', async () => {
+    const { ctx, yields } = makeCtx('hi');
+    const h = new DagCoordinatorHandler({
+      planner: planner([{ id: 'n1', goal: 'g' }]),
+      interpreter: interp({ nodeResults: {}, ok: true, output: '42' }),
+      workers: new Map(),
+      reviewer: { name: 'r', review: async () => ({ pass: true }) },
+    });
+    const ok = await h.execute(ctx, {}, {} as never);
+    assert.equal(ok, true);
+    assert.equal(yields[0].value.content, '42');
+  });
+
+  it('rejects the plan as COORDINATOR_PLAN_REJECTED when the reviewer fails', async () => {
+    const { ctx, yields } = makeCtx('hi');
+    let interpreted = false;
+    const h = new DagCoordinatorHandler({
+      planner: planner([{ id: 'n1', goal: 'g' }]),
+      interpreter: {
+        name: 'i',
+        interpret: async () => {
+          interpreted = true;
+          return { nodeResults: {}, ok: true, output: 'x' };
+        },
+      },
+      workers: new Map(),
+      reviewer: {
+        name: 'r',
+        review: async () => ({ pass: false, feedback: 'no reader worker' }),
+      },
+    });
+    const ok = await h.execute(ctx, {}, {} as never);
+    assert.equal(ok, false);
+    assert.equal(interpreted, false); // gate blocks execution
+    const err = (ctx as unknown as { error?: { code?: string; message?: string } }).error;
+    assert.equal(err?.code, 'COORDINATOR_PLAN_REJECTED');
+    assert.match(err?.message ?? '', /no reader worker/);
+    assert.equal(yields.length, 0);
+  });
+
+  it('maps a reviewer throw to COORDINATOR_REVIEW_FAILED', async () => {
+    const { ctx } = makeCtx('hi');
+    const h = new DagCoordinatorHandler({
+      planner: planner([{ id: 'n1', goal: 'g' }]),
+      interpreter: interp({ nodeResults: {}, ok: true, output: 'x' }),
+      workers: new Map(),
+      reviewer: {
+        name: 'r',
+        review: async () => {
+          throw new Error('critic boom');
+        },
+      },
+    });
+    const ok = await h.execute(ctx, {}, {} as never);
+    assert.equal(ok, false);
+    assert.equal(
+      (ctx as unknown as { error?: { code?: string } }).error?.code,
+      'COORDINATOR_REVIEW_FAILED',
+    );
+  });
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npm run test --workspace @mcp-abap-adt/llm-agent-libs 2>&1 | grep -iE "fail|reviewer"`
+Expected: FAIL — `reviewer` is not a known property of the deps type / gate not implemented.
+
+- [ ] **Step 3: Add `reviewer` to the deps interface**
+
+In `packages/llm-agent-libs/src/pipeline/handlers/dag-coordinator.ts`, add `IReviewStrategy` to the type imports from `@mcp-abap-adt/llm-agent` (the existing import block at the top), and add the field to `DagCoordinatorHandlerDeps`:
+
+```ts
+  /** Optional plan reviewer. When present, the coordinator runs it as a gate
+   *  between planning and execution; a non-pass verdict fails loud (batch).
+   *  Absent → no gate. */
+  reviewer?: IReviewStrategy;
+```
+
+(Add it right after the `activation?: IActivationStrategy;` field.)
+
+- [ ] **Step 4: Insert the gate in `execute()`**
+
+In `dag-coordinator.ts`, between the planner block (which ends by assigning `plan`) and the interpreter block (`let result: InterpretResult; try { result = await this.deps.interpreter.interpret(...) }`), insert:
+
+```ts
+    if (this.deps.reviewer) {
+      let verdict: ReviewVerdict;
+      try {
+        verdict = await this.deps.reviewer.review({
+          prompt: ctx.inputText,
+          plan,
+          agents: [...this.deps.workers.values()].map((w) => ({
+            name: w.name,
+            description: w.description,
+          })),
+          sessionId: ctx.sessionId,
+          signal: ctx.options?.signal,
+        });
+      } catch (err) {
+        ctx.error = new OrchestratorError(
+          errMsg(err),
+          'COORDINATOR_REVIEW_FAILED',
+        );
+        return false;
+      }
+      if (!verdict.pass) {
+        ctx.error = new OrchestratorError(
+          verdict.feedback,
+          'COORDINATOR_PLAN_REJECTED',
+        );
+        return false;
+      }
+    }
+```
+
+Add `ReviewVerdict` to the type imports from `@mcp-abap-adt/llm-agent` as well (alongside `IReviewStrategy`).
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `npm run test --workspace @mcp-abap-adt/llm-agent-libs 2>&1 | grep -iE "fail"`
+Expected: `ℹ fail 0` (new gate tests pass; all prior handler tests — no-reviewer path — still pass).
+
+- [ ] **Step 6: Build + lint, then commit**
+
+```bash
+npm run build && npm run lint
+git add packages/llm-agent-libs/src/pipeline/handlers/dag-coordinator.ts \
+        packages/llm-agent-libs/src/pipeline/handlers/__tests__/dag-coordinator.test.ts
+git commit -m "feat(slice2): plan-reviewer gate in DagCoordinatorHandler (terminal)"
+```
+
+---
+
+### Task 5: Config validation for `coordinator.reviewer`
+
+**Files:**
+- Modify: `packages/llm-agent-server/src/smart-agent/config.ts`
+- Test: `packages/llm-agent-server/src/smart-agent/__tests__/dag-coordinator-config.test.ts` (existing)
+
+- [ ] **Step 1: Write the failing tests**
+
+In `packages/llm-agent-server/src/smart-agent/__tests__/dag-coordinator-config.test.ts`, add inside the `describe(...)` block (before the closing `});`):
+
+```ts
+  it('accepts a DAG coordinator with a reviewer', () => {
+    assert.doesNotThrow(() =>
+      assertCoordinatorConfigShape({
+        planner: { type: 'llm' },
+        reviewer: { type: 'llm', plannerLlm: 'helper' },
+      }),
+    );
+  });
+  it('rejects an unknown reviewer.type', () => {
+    assert.throws(
+      () =>
+        assertCoordinatorConfigShape({
+          planner: { type: 'llm' },
+          reviewer: { type: 'bogus' },
+        }),
+      /reviewer: unknown type 'bogus'/,
+    );
+  });
+  it('rejects a bad reviewer.plannerLlm', () => {
+    assert.throws(
+      () =>
+        assertCoordinatorConfigShape({
+          planner: { type: 'llm' },
+          reviewer: { type: 'llm', plannerLlm: 'bogus' },
+        }),
+      /reviewer\.plannerLlm must be one of/,
+    );
+  });
+  it('rejects reviewer in a linear coordinator', () => {
+    assert.throws(
+      () =>
+        assertCoordinatorConfigShape({
+          planning: 'one-shot',
+          reviewer: { type: 'llm' },
+        }),
+      /reviewer/,
+    );
+  });
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npm run test --workspace @mcp-abap-adt/llm-agent-server 2>&1 | grep -iE "fail|reviewer"`
+Expected: FAIL (reviewer not yet validated / not in DAG_ONLY).
+
+- [ ] **Step 3: Extract a shared LLM-role validator and validate planner + reviewer with it**
+
+In `packages/llm-agent-server/src/smart-agent/config.ts`:
+
+(a) Add `'reviewer'` to the `DAG_ONLY` array:
+
+```ts
+const DAG_ONLY = ['planner', 'interpreter', 'reviewer'];
+```
+
+(b) Add this helper above `assertCoordinatorConfigShape`:
+
+```ts
+/** Validate a `{ type?: 'llm'; plannerLlm?: main|planner|helper }` role block. */
+function assertLlmRoleShape(label: string, role: unknown): void {
+  if (typeof role !== 'object' || role === null || Array.isArray(role)) {
+    throw new Error(
+      `coordinator.${label} must be an object (e.g. { type: llm }), got: ${JSON.stringify(role)}`,
+    );
+  }
+  const kind = (role as { type?: unknown }).type;
+  if (kind !== undefined && kind !== 'llm') {
+    throw new Error(
+      `coordinator.${label}: unknown type '${String(kind)}' (only 'llm' is supported)`,
+    );
+  }
+  const sel = (role as { plannerLlm?: unknown }).plannerLlm;
+  if (
+    sel !== undefined &&
+    sel !== 'main' &&
+    sel !== 'planner' &&
+    sel !== 'helper'
+  ) {
+    throw new Error(
+      `coordinator.${label}.plannerLlm must be one of main | planner | helper, got: ${String(sel)}`,
+    );
+  }
+}
+```
+
+(c) In `assertCoordinatorConfigShape`, replace the existing inline planner-shape validation (the `const planner = coord.planner; if (typeof planner !== 'object' ...) { ... } const plannerKind = ...; const plannerLlmSel = ...;` block inside `if (isDag) { ... }`) with calls to the helper, and validate the reviewer when present:
+
+```ts
+  if (isDag) {
+    assertLlmRoleShape('planner', coord.planner);
+    if (coord.reviewer !== undefined) {
+      assertLlmRoleShape('reviewer', coord.reviewer);
+    }
+    for (const f of LINEAR_ONLY) {
+      if (coord[f] !== undefined) {
+        throw new Error(
+          `coordinator: '${f}' is a linear-only field and cannot be combined with 'planner' (DAG mode)`,
+        );
+      }
+    }
+  } else {
+    for (const f of DAG_ONLY) {
+      if (coord[f] !== undefined) {
+        throw new Error(
+          `coordinator: '${f}' is a DAG-only field; a linear coordinator uses 'planning'/'dispatch'`,
+        );
+      }
+    }
+  }
+```
+
+(d) Add `reviewer?` to the `YamlCoordinator` type (the interface in this file that already declares `planner?` / `interpreter?`):
+
+```ts
+  reviewer?: { type?: string; plannerLlm?: 'main' | 'planner' | 'helper' };
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npm run test --workspace @mcp-abap-adt/llm-agent-server 2>&1 | grep -iE "fail"`
+Expected: `ℹ fail 0` (new reviewer cases pass; the existing planner-shape cases still pass — they now run through `assertLlmRoleShape`, same messages).
+
+- [ ] **Step 5: Build + lint, then commit**
+
+```bash
+npm run build && npm run lint
+git add packages/llm-agent-server/src/smart-agent/config.ts \
+        packages/llm-agent-server/src/smart-agent/__tests__/dag-coordinator-config.test.ts
+git commit -m "feat(slice2): validate coordinator.reviewer config (shared LLM-role validator)"
+```
+
+---
+
+### Task 6: Wire the reviewer in the smart-server DAG branch
+
+**Files:**
+- Modify: `packages/llm-agent-server/src/smart-agent/smart-server.ts`
+
+- [ ] **Step 1: Import the reviewer implementation**
+
+In `smart-server.ts`, find the import that brings in `LlmDagPlanner` / `DagPlanInterpreter` from `@mcp-abap-adt/llm-agent-libs` and add `LlmReviewStrategy` to it. Add `IReviewStrategy` to the type import from `@mcp-abap-adt/llm-agent`.
+
+- [ ] **Step 2: Build the reviewer and pass it to `withDagCoordinator`**
+
+In the DAG branch (the `if (coordCfg.planner !== undefined) { ... }` block), after the `const planner = new LlmDagPlanner(plannerLlm);` line and before the `builder = builder.withDagCoordinator({...})` call, add:
+
+```ts
+        // Optional plan reviewer (presence of `coordinator.reviewer` = gate on).
+        let reviewer: IReviewStrategy | undefined;
+        if (coordCfg.reviewer !== undefined) {
+          const reviewerBlock = coordCfg.reviewer as {
+            plannerLlm?: 'main' | 'planner' | 'helper';
+          };
+          const reviewerLlm =
+            reviewerBlock.plannerLlm === 'main'
+              ? mainLlm
+              : (helperLlm ?? mainLlm);
+          reviewer = new LlmReviewStrategy(reviewerLlm);
+        }
+```
+
+Then add `reviewer` to the `withDagCoordinator` call:
+
+```ts
+        builder = builder.withDagCoordinator({
+          planner,
+          interpreter,
+          workers,
+          activation,
+          reviewer,
+        });
+```
+
+- [ ] **Step 3: Build + lint**
+
+Run: `npm run build && npm run lint`
+Expected: build OK, no lint errors. (`reviewer` is `IReviewStrategy | undefined`, which matches the optional deps field.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/llm-agent-server/src/smart-agent/smart-server.ts
+git commit -m "feat(slice2): wire LlmReviewStrategy from coordinator.reviewer config"
+```
+
+---
+
+### Task 7: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Confirm backward-compat guard still holds**
+
+The existing server test `existing-coordinator-yaml-loads.test.ts` (and `dag-coordinator-config.test.ts` linear cases) guard that example YAMLs without a reviewer still validate as linear. Run:
+
+Run: `npm run test --workspace @mcp-abap-adt/llm-agent-server 2>&1 | grep -iE "fail"`
+Expected: `ℹ fail 0`.
+
+- [ ] **Step 2: Run the whole suite across workspaces**
+
+Run: `npm run test 2>&1 | grep -iE "ℹ fail [1-9]" || echo "NO FAILURES"`
+Expected: `NO FAILURES`.
+
+- [ ] **Step 3: Final build + lint:check**
+
+Run: `npm run build && npm run lint:check`
+Expected: build OK; `No fixes applied` (clean).
+
+- [ ] **Step 4: Commit any formatting-only changes if present**
+
+```bash
+git status --short
+# if anything is modified by lint, stage and commit:
+git add -A && git commit -m "chore(slice2): formatting" || echo "nothing to commit"
+```

--- a/docs/superpowers/specs/2026-05-25-coordinator-redesign-epic-overview.md
+++ b/docs/superpowers/specs/2026-05-25-coordinator-redesign-epic-overview.md
@@ -13,6 +13,34 @@ interface with multiple implementations selected by config/DI — the project's
 established pattern (`IToolSelectionStrategy` #135, the LLM/embedder/RAG
 provider axes, the existing `IPlanning/IDispatch/IActivation` strategies).
 
+## Terminology (locked vocabulary)
+
+These four nouns are distinct levels. Most design confusion comes from collapsing
+them — keep them separate.
+
+| Term | Definition |
+|------|------------|
+| **Pipeline** | The declarative *description* we interpret. Two kinds: the authored **YAML pipeline** and the planner-produced **Plan** (`DagPlan`). A Pipeline is composed of **N ≥ 1 subagents**. It is data, not behaviour. |
+| **Interpreter** (`IInterpreter<TPipeline,TResult>`) | The thing that *executes* a Pipeline (data → running behaviour). Two implementations of one interface: the **YAML interpreter** (the server; YAML → running pipeline) and the **Plan interpreter** (`DagPlan` → executed node results). |
+| **Subagent** (`ISubAgent`) | A *node* a Pipeline is composed of — the unit the interpreter dispatches. The interpreter schedules it **synchronously** (sequentially) or **asynchronously** (a parallel wave, `Promise.all` then await). A subagent may itself be a whole interpreted Pipeline (recursion: interpret → package as subagent → use as a node in a bigger Pipeline). |
+| **Component** | The internal building blocks a subagent is assembled from — stages, strategies, handlers (`IStageHandler`, `IPlanningStrategy`, `IDispatchStrategy`, …). A finer granularity than a subagent; not formalized as one interface. |
+
+Consequences:
+
+- **`sync` vs `async` is a scheduling decision of the Interpreter, not an attribute
+  of a subagent.** Every `ISubAgent.run()` returns a `Promise`; the interpreter
+  decides await-one-by-one vs `Promise.all`. (Already true in slice 1.)
+- **A Pipeline of N = 1 subagent is the classic single-agent path** (today's
+  behaviour; its `classify→rag→tool-loop` internals are *components*). N > 1 with
+  orchestration is the coordinator path. The coordinator is **not a different kind
+  of entity** — it is the Interpreter that handles N > 1. This is the
+  progressive-complexity invariant, and it is *why* old and new configs are one
+  uniform model (backward compatibility is a consequence, not a special case).
+- **Planner and reviewer are subagents** that respectively *produce* a Pipeline
+  (planner → `Plan`) and *judge* a Pipeline (reviewer → verdict). `IPlanner` /
+  `IReviewStrategy` are **typed adapters over `ISubAgent`** (see the invariant
+  below), never a separate execution contract.
+
 ## Invariants (the principles this epic holds)
 
 - **YAML is the complete description of the pipeline — this does NOT change.**

--- a/docs/superpowers/specs/2026-05-26-slice2-plan-reviewer-design.md
+++ b/docs/superpowers/specs/2026-05-26-slice2-plan-reviewer-design.md
@@ -1,0 +1,183 @@
+# Slice 2: Plan reviewer gate + roles unified on `ISubAgent`
+
+Status: design (active — slice 2 of the coordinator-redesign epic)
+Date: 2026-05-26
+Epic anchor: `docs/superpowers/specs/2026-05-25-coordinator-redesign-epic-overview.md`
+Builds on: slice 1 (batch DAG coordinator, merged in #158)
+
+## Goal
+
+Add an optional **plan reviewer gate** between planning and execution in the DAG
+coordinator, and — in the same slice — reconcile the planner so every role
+(planner, reviewer) runs through the **one `ISubAgent` path** the epic mandates,
+instead of calling the LLM directly.
+
+This ships a working, testable capability (a configurable plan critic that can
+reject a plan before any worker runs) AND removes the slice-1 "planner calls the
+LLM directly" MVP debt, aligning the code with the locked terminology.
+
+## Terminology
+
+Uses the locked vocabulary from the epic overview: **Pipeline** (the interpreted
+description), **Interpreter** (executes a Pipeline), **Subagent** (a node the
+interpreter dispatches; `ISubAgent`), **Component** (a subagent's internals).
+
+Planner and reviewer are **subagents that produce / judge a Pipeline**:
+- planner → produces a `DagPlan` (a Plan-pipeline),
+- reviewer → judges a `DagPlan` and returns a verdict.
+
+A **role** = a typed adapter that *owns* an `ISubAgent`, builds the subagent's
+`task` from typed input, calls `run()`, and parses the subagent's string `output`
+into a typed structure. The role does NOT extend or replace `ISubAgent`.
+
+## Scope (batch only)
+
+Slice 2 is **batch / terminal**: a failed review fails the request loudly with the
+critic's feedback as the error. There is **no resume / ask-and-resume** — that is
+the dialog/resumable coordinator (slice 4). The verdict type therefore carries no
+resume token in this slice.
+
+## Architecture
+
+### Part 1 — Reconcile the planner onto `ISubAgent` (remove slice-1 debt)
+
+`LlmDagPlanner` (in `llm-agent-libs/src/coordinator/dag/llm-dag-planner.ts`) stops
+calling `ILlm` directly. Internally it now **owns a `DirectLlmSubAgent`**:
+
+- constructed with `name: 'planner'`, the existing planner system prompt, and
+  `contextPolicy: 'optional'` (the task is self-contained — prompt + catalog);
+- `plan()` composes the task string (user prompt + agent catalog) exactly as the
+  current prompt builder does, calls `subagent.run({ task, sessionId, signal })`,
+  then runs the **same** JSON-extraction + validation already present
+  (objective/rationale/node-field-type checks from the slice-1 review).
+
+Public contract unchanged: `IPlanner`, `new LlmDagPlanner(llm)`, and the YAML
+config (`coordinator.planner: { type: llm, plannerLlm? }`) are all identical. The
+change is internal — the planner now flows through the uniform subagent path.
+
+### Part 2 — Reviewer interfaces and implementations
+
+New contracts in `@mcp-abap-adt/llm-agent` (interfaces package):
+
+```ts
+// review.ts
+export interface ReviewInput {
+  prompt: string;
+  plan: DagPlan;
+  agents: PlannerCatalogEntry[];   // same catalog shape the planner sees
+  sessionId: string;
+  signal?: AbortSignal;
+}
+export type ReviewVerdict =
+  | { pass: true }
+  | { pass: false; feedback: string };
+export interface IReviewStrategy {
+  readonly name: string;
+  review(input: ReviewInput): Promise<ReviewVerdict>;
+}
+```
+
+Implementations in `llm-agent-libs/src/coordinator/dag/`:
+
+- **`LlmReviewStrategy implements IReviewStrategy`** — owns a `DirectLlmSubAgent`
+  critic (`name: 'reviewer'`, `contextPolicy: 'optional'`, a critic system
+  prompt). `review()` composes a task (user prompt + the plan serialized as JSON +
+  the agent catalog), calls `run()`, and parses the critic's output. Output
+  protocol: the critic returns ONLY a JSON object — `{"pass": true}` or
+  `{"pass": false, "feedback": "<why + what to clarify>"}`. Parsing mirrors the
+  planner: regex-extract the JSON object, `JSON.parse` inside try/catch (malformed
+  → throw a clear error), validate `pass` is boolean and `feedback` is a string
+  when `pass === false`.
+- **`NoopReviewStrategy implements IReviewStrategy`** — always returns
+  `{ pass: true }`. For explicit opt-out and tests. (Absence of a reviewer in the
+  handler simply skips the gate; Noop is the explicit always-pass strategy.)
+
+### Part 3 — Gate in `DagCoordinatorHandler`
+
+`DagCoordinatorHandlerDeps` gains an optional `reviewer?: IReviewStrategy`.
+
+`execute()` flow becomes: **plan → (review gate) → interpret**:
+
+```
+plan = await planner.plan({ prompt, agents, sessionId, signal })   // existing
+if (reviewer) {
+  let verdict;
+  try {
+    verdict = await reviewer.review({ prompt: ctx.inputText, plan, agents, sessionId, signal });
+  } catch (err) {
+    ctx.error = new OrchestratorError(errMsg(err), 'COORDINATOR_REVIEW_FAILED');
+    return false;
+  }
+  if (!verdict.pass) {
+    ctx.error = new OrchestratorError(verdict.feedback, 'COORDINATOR_PLAN_REJECTED');
+    return false;
+  }
+}
+result = await interpreter.interpret(plan, ...)                     // existing
+```
+
+- `agents` for the reviewer = the same catalog the handler builds for the planner
+  (`workers.values()` → `{ name, description }`).
+- A rejected plan is **terminal** (fail-loud), surfacing the critic's feedback.
+- Error codes `COORDINATOR_PLAN_REJECTED` / `COORDINATOR_REVIEW_FAILED` are
+  **provisional** — internal codes, not a public API contract; they may be
+  refined/unified in a later pass.
+
+### Part 4 — Builder + server wiring
+
+- **Builder** (`llm-agent-libs/src/builder.ts`): `withDagCoordinator(deps)` accepts
+  `reviewer?` and threads it into the `DagCoordinatorHandler` deps.
+- **Config** (`llm-agent-server/src/smart-agent/config.ts`): add `reviewer` to
+  `DAG_ONLY` (linear configs reject it). In `assertCoordinatorConfigShape`, when a
+  reviewer is present, validate it the same way as the planner: must be an object;
+  `type`, if set, must be `'llm'`; `plannerLlm`, if set, must be one of
+  `main | planner | helper`.
+- **smart-server DAG branch** (`smart-server.ts`): if `coordCfg.reviewer` is
+  present, resolve the reviewer LLM with the same logic as the planner
+  (`reviewer.plannerLlm` → main/helper) and build a `LlmReviewStrategy`, then pass
+  it to `withDagCoordinator`. Absent reviewer → no gate (unchanged behavior).
+
+YAML shape (additive, optional):
+
+```yaml
+coordinator:
+  planner:  { type: llm }
+  reviewer: { type: llm }     # presence => plan reviewer gate ON
+```
+
+## Error handling
+
+| Situation | Handler outcome |
+|-----------|-----------------|
+| reviewer not configured | gate skipped; plan goes straight to interpret |
+| `review()` returns `{ pass: true }` | proceed to interpret |
+| `review()` returns `{ pass: false, feedback }` | `ctx.error = COORDINATOR_PLAN_REJECTED(feedback)`, return false (terminal) |
+| `review()` throws | `ctx.error = COORDINATOR_REVIEW_FAILED`, return false |
+| critic output malformed JSON / bad shape | `LlmReviewStrategy` throws → maps to `COORDINATOR_REVIEW_FAILED` |
+
+## Testing
+
+- **Planner parity** — `LlmDagPlanner` after the refactor still parses the same
+  fixtures into the same `DagPlan` (single-node, dependsOn, malformed-JSON throw,
+  node-field-type rejects, objective/rationale rejects). Behavior unchanged.
+- **`LlmReviewStrategy`** — pass verdict; fail verdict with feedback; malformed
+  JSON throws; non-boolean `pass` / missing `feedback` on fail throws.
+- **`NoopReviewStrategy`** — always `{ pass: true }`.
+- **Handler gate** — pass → interpreter runs and output streams; fail →
+  `COORDINATOR_PLAN_REJECTED` and interpreter NOT called; reviewer throw →
+  `COORDINATOR_REVIEW_FAILED`; no-reviewer → interpreter runs (slice-1 behavior).
+- **Config** — reviewer `{type:llm}` accepted; unknown `reviewer.type` rejected;
+  bad `reviewer.plannerLlm` rejected; `reviewer` in a linear coordinator rejected.
+- **Backward-compat guard** — existing example YAMLs still validate as linear and
+  load unchanged.
+
+## Out of scope (slice 2)
+
+- Resume / ask-and-resume on a failed review (dialog coordinator — slice 4).
+- Result-side review (output ≡ prompt; a separate concern, see epic).
+- Reviewer as a named entry from the `subagents:` catalog (only `{type: llm}` for
+  now).
+- Replan-on-reject (the reviewer's reject is terminal here; replan-by-signal is
+  slice 3 territory).
+- Renaming `ISubAgent` → another noun (terminology is locked at the concept level;
+  no code rename in this slice).

--- a/docs/superpowers/specs/2026-05-26-slice2-plan-reviewer-design.md
+++ b/docs/superpowers/specs/2026-05-26-slice2-plan-reviewer-design.md
@@ -42,14 +42,35 @@ resume token in this slice.
 ### Part 1 — Reconcile the planner onto `ISubAgent` (remove slice-1 debt)
 
 `LlmDagPlanner` (in `llm-agent-libs/src/coordinator/dag/llm-dag-planner.ts`) stops
-calling `ILlm` directly. Internally it now **owns a `DirectLlmSubAgent`**:
+calling `ILlm` directly. Internally it now **owns a `DirectLlmSubAgent`**.
 
-- constructed with `name: 'planner'`, the existing planner system prompt, and
-  `contextPolicy: 'optional'` (the task is self-contained — prompt + catalog);
-- `plan()` composes the task string (user prompt + agent catalog) exactly as the
-  current prompt builder does, calls `subagent.run({ task, sessionId, signal })`,
-  then runs the **same** JSON-extraction + validation already present
-  (objective/rationale/node-field-type checks from the slice-1 review).
+**Prompt split (important).** `DirectLlmSubAgent.systemPrompt` is *static* (set
+once at construction), whereas slice 1 builds the system prompt *per call* with the
+agent catalog embedded at the end. The refactor therefore splits the current
+single prompt into two halves:
+
+- **static `systemPrompt`** = the planner *instructions* only (the "You are a
+  planner… emit JSON with these fields…" text), with the `Available workers:` /
+  catalog portion **removed**;
+- **per-call `task`** = the dynamic data: the agent catalog block + the user
+  prompt. The catalog moves out of the system prompt into the task.
+
+So:
+- construct `DirectLlmSubAgent` with `name: 'planner'`, the static planner
+  instructions as `systemPrompt`, and `contextPolicy: 'optional'` (the task is
+  self-contained — catalog + prompt);
+- `plan()` composes the `task` (catalog block + user prompt), calls
+  `subagent.run({ task, sessionId, signal, layer: 0 })`, then runs the **same**
+  JSON-extraction + validation already present (objective/rationale/node-field-type
+  checks from the slice-1 review).
+
+`layer: 0` — role subagents are invoked once at the coordinator level; they are not
+DAG nodes (the interpreter dispatches workers at `ctx.layer + 1`), so layer 0 is
+correct and avoids plumbing `ctx.layer` through `PlannerInput`.
+
+The combined prompt the model sees (system + task) is **semantically equivalent**
+to slice 1 — same instructions, same catalog, same user prompt — only the
+system/user split changes. Planner-parity tests (below) guard this.
 
 Public contract unchanged: `IPlanner`, `new LlmDagPlanner(llm)`, and the YAML
 config (`coordinator.planner: { type: llm, plannerLlm? }`) are all identical. The
@@ -80,14 +101,17 @@ export interface IReviewStrategy {
 Implementations in `llm-agent-libs/src/coordinator/dag/`:
 
 - **`LlmReviewStrategy implements IReviewStrategy`** — owns a `DirectLlmSubAgent`
-  critic (`name: 'reviewer'`, `contextPolicy: 'optional'`, a critic system
-  prompt). `review()` composes a task (user prompt + the plan serialized as JSON +
-  the agent catalog), calls `run()`, and parses the critic's output. Output
-  protocol: the critic returns ONLY a JSON object — `{"pass": true}` or
-  `{"pass": false, "feedback": "<why + what to clarify>"}`. Parsing mirrors the
-  planner: regex-extract the JSON object, `JSON.parse` inside try/catch (malformed
-  → throw a clear error), validate `pass` is boolean and `feedback` is a string
-  when `pass === false`.
+  critic. Same static/dynamic prompt split as the planner: the **static
+  `systemPrompt`** holds the critic instructions ("You are a plan reviewer… respond
+  with ONLY `{\"pass\":…}`…"); the **per-call `task`** holds the dynamic data — the
+  user prompt + the plan serialized as JSON + the agent catalog. Constructed with
+  `name: 'reviewer'`, `contextPolicy: 'optional'`. `review()` composes the task,
+  calls `subagent.run({ task, sessionId, signal, layer: 0 })`, and parses the
+  critic's output. Output protocol: the critic returns ONLY a JSON object —
+  `{"pass": true}` or `{"pass": false, "feedback": "<why + what to clarify>"}`.
+  Parsing mirrors the planner: regex-extract the JSON object, `JSON.parse` inside
+  try/catch (malformed → throw a clear error), validate `pass` is a boolean and
+  `feedback` is a non-empty string when `pass === false`.
 - **`NoopReviewStrategy implements IReviewStrategy`** — always returns
   `{ pass: true }`. For explicit opt-out and tests. (Absence of a reviewer in the
   handler simply skips the gate; Noop is the explicit always-pass strategy.)

--- a/packages/llm-agent-libs/src/coordinator/dag/__tests__/llm-review-strategy.test.ts
+++ b/packages/llm-agent-libs/src/coordinator/dag/__tests__/llm-review-strategy.test.ts
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { DagPlan, ILlm, ReviewInput } from '@mcp-abap-adt/llm-agent';
+import { LlmReviewStrategy } from '../llm-review-strategy.js';
+import { NoopReviewStrategy } from '../noop-review-strategy.js';
+
+function llm(content: string): ILlm {
+  return {
+    chat: async () => ({ ok: true, value: { content } }),
+  } as unknown as ILlm;
+}
+const plan: DagPlan = {
+  nodes: [{ id: 'n1', goal: 'do it', agent: 'w' }],
+  createdAt: 0,
+};
+const input: ReviewInput = {
+  prompt: 'do it',
+  plan,
+  agents: [{ name: 'w', description: 'worker' }],
+  sessionId: 't',
+};
+
+describe('LlmReviewStrategy', () => {
+  it('returns pass:true on a positive verdict', async () => {
+    const v = await new LlmReviewStrategy(llm('{"pass": true}')).review(input);
+    assert.deepEqual(v, { pass: true });
+  });
+
+  it('returns pass:false with feedback on a negative verdict', async () => {
+    const v = await new LlmReviewStrategy(
+      llm('{"pass": false, "feedback": "no worker can read tables"}'),
+    ).review(input);
+    assert.deepEqual(v, {
+      pass: false,
+      feedback: 'no worker can read tables',
+    });
+  });
+
+  it('throws on malformed JSON', async () => {
+    await assert.rejects(
+      () => new LlmReviewStrategy(llm('not json')).review(input),
+      /JSON/i,
+    );
+  });
+
+  it('throws when pass is not a boolean', async () => {
+    await assert.rejects(
+      () => new LlmReviewStrategy(llm('{"pass": "yes"}')).review(input),
+      /boolean 'pass'/,
+    );
+  });
+
+  it('throws when a rejection has no feedback string', async () => {
+    await assert.rejects(
+      () => new LlmReviewStrategy(llm('{"pass": false}')).review(input),
+      /feedback/,
+    );
+  });
+
+  it('throws the LLM error when the call is not ok', async () => {
+    const failing = {
+      chat: async () => ({ ok: false, error: new Error('quota') }),
+    } as unknown as ILlm;
+    await assert.rejects(
+      () => new LlmReviewStrategy(failing).review(input),
+      /quota/,
+    );
+  });
+});
+
+describe('NoopReviewStrategy', () => {
+  it('always passes', async () => {
+    const v = await new NoopReviewStrategy().review(input);
+    assert.deepEqual(v, { pass: true });
+  });
+});

--- a/packages/llm-agent-libs/src/coordinator/dag/llm-dag-planner.ts
+++ b/packages/llm-agent-libs/src/coordinator/dag/llm-dag-planner.ts
@@ -5,45 +5,51 @@ import type {
   PlanNode,
   PlannerInput,
 } from '@mcp-abap-adt/llm-agent';
+import { DirectLlmSubAgent } from '../../subagent/direct-llm-subagent.js';
+
+// Static planner instructions. The agent catalog and user prompt are NOT here —
+// they are dynamic and go into the per-call `task` (see plan()).
+const PLANNER_SYSTEM = `You are a planner. Decompose the user request into a DAG of tasks.
+Each node: {"id","goal","agent"(optional worker name),"dependsOn"(optional ids),"needsInput"(optional bool)}.
+Use "dependsOn" to express order/data-flow; independent nodes run in parallel.
+If the request needs no decomposition, emit a SINGLE node.
+Emit a plan-level "objective". Respond with ONLY:
+{"objective":"...","nodes":[{"id":"n1","goal":"...","agent":"<worker name or omit>","dependsOn":[],"needsInput":false}]}`;
 
 /**
- * MVP exception (slice 1): calls the ILlm directly rather than wrapping a
- * supervised planner ISubAgent. The IPlanner interface is the stable seam;
- * moving onto the ISubAgent supervision path is deferred to the slice that
- * introduces supervision/restart.
+ * Role adapter: owns a constrained `DirectLlmSubAgent` and turns its string
+ * output into a typed `DagPlan`. (Slice 2: planner now flows through the one
+ * ISubAgent path instead of calling ILlm directly.)
  */
 export class LlmDagPlanner implements IPlanner {
   readonly name = 'llm-dag';
-  constructor(private readonly llm: ILlm) {}
+  private readonly agent: DirectLlmSubAgent;
+
+  constructor(llm: ILlm) {
+    this.agent = new DirectLlmSubAgent('planner', llm, {
+      systemPrompt: PLANNER_SYSTEM,
+      contextPolicy: 'optional',
+    });
+  }
 
   async plan(input: PlannerInput): Promise<DagPlan> {
     const catalog = input.agents
       .map((a) => `- ${a.name}: ${a.description ?? '(no description)'}`)
       .join('\n');
-    const system = `You are a planner. Decompose the user request into a DAG of tasks.
-Each node: {"id","goal","agent"(optional worker name),"dependsOn"(optional ids),"needsInput"(optional bool)}.
-Use "dependsOn" to express order/data-flow; independent nodes run in parallel.
-If the request needs no decomposition, emit a SINGLE node.
-Emit a plan-level "objective". Respond with ONLY:
-{"objective":"...","nodes":[{"id":"n1","goal":"...","agent":"<worker name or omit>","dependsOn":[],"needsInput":false}]}
+    const task = `Available workers:\n${catalog || '(none)'}\n\n${input.prompt}`;
 
-Available workers:
-${catalog || '(none)'}`;
+    const res = await this.agent.run({
+      task,
+      sessionId: input.sessionId,
+      signal: input.signal,
+      layer: 0,
+    });
+    const content = res.output;
 
-    const res = await this.llm.chat(
-      [
-        { role: 'system', content: system },
-        { role: 'user', content: input.prompt },
-      ],
-      [],
-      { signal: input.signal, sessionId: input.sessionId },
-    );
-    if (!res.ok) throw res.error;
-
-    const match = res.value.content.match(/\{[\s\S]*\}/);
+    const match = content.match(/\{[\s\S]*\}/);
     if (!match)
       throw new Error(
-        `Planner output did not contain a JSON object: ${res.value.content.slice(0, 200)}`,
+        `Planner output did not contain a JSON object: ${content.slice(0, 200)}`,
       );
     // Field values come straight from untrusted JSON, so they are typed as
     // `unknown` and validated below before being narrowed to PlanNode.
@@ -68,8 +74,6 @@ ${catalog || '(none)'}`;
     if (!Array.isArray(parsed.nodes) || parsed.nodes.length === 0) {
       throw new Error(`Planner returned no nodes: ${match[0].slice(0, 200)}`);
     }
-    // Plan-level fields also come from untrusted JSON — reject non-string values
-    // rather than leaking them into the typed DagPlan.
     if (
       parsed.objective !== undefined &&
       typeof parsed.objective !== 'string'
@@ -90,9 +94,6 @@ ${catalog || '(none)'}`;
       if (typeof n.goal !== 'string' || n.goal.trim() === '') {
         throw new Error(`Planner node is missing a goal: ${JSON.stringify(n)}`);
       }
-      // Reject malformed field types up front — the interpreter relies on these
-      // matching the exported PlanNode shape (otherwise they surface as opaque
-      // TypeErrors mid-dispatch).
       if (n.id !== undefined && typeof n.id !== 'string') {
         throw new Error(
           `Planner node has a non-string id: ${JSON.stringify(n)}`,

--- a/packages/llm-agent-libs/src/coordinator/dag/llm-review-strategy.ts
+++ b/packages/llm-agent-libs/src/coordinator/dag/llm-review-strategy.ts
@@ -1,0 +1,77 @@
+import type {
+  ILlm,
+  IReviewStrategy,
+  ReviewInput,
+  ReviewVerdict,
+} from '@mcp-abap-adt/llm-agent';
+import { DirectLlmSubAgent } from '../../subagent/direct-llm-subagent.js';
+
+// Static critic instructions. The user prompt, plan and catalog are dynamic and
+// go into the per-call `task` (see review()).
+const REVIEWER_SYSTEM = `You are a plan reviewer. Given the user request, the available workers, and a proposed DAG plan, decide whether the plan can fulfil the request with those workers.
+Respond with ONLY a JSON object:
+{"pass": true}  — the plan is adequate
+{"pass": false, "feedback": "<what is wrong or what must be clarified>"}  — otherwise`;
+
+/**
+ * Role adapter: owns a constrained `DirectLlmSubAgent` critic and turns its
+ * string output into a typed `ReviewVerdict`.
+ */
+export class LlmReviewStrategy implements IReviewStrategy {
+  readonly name = 'llm-review';
+  private readonly agent: DirectLlmSubAgent;
+
+  constructor(llm: ILlm) {
+    this.agent = new DirectLlmSubAgent('reviewer', llm, {
+      systemPrompt: REVIEWER_SYSTEM,
+      contextPolicy: 'optional',
+    });
+  }
+
+  async review(input: ReviewInput): Promise<ReviewVerdict> {
+    const catalog = input.agents
+      .map((a) => `- ${a.name}: ${a.description ?? '(no description)'}`)
+      .join('\n');
+    const task = `User request:\n${input.prompt}\n\nAvailable workers:\n${
+      catalog || '(none)'
+    }\n\nProposed plan (JSON):\n${JSON.stringify(input.plan)}`;
+
+    const res = await this.agent.run({
+      task,
+      sessionId: input.sessionId,
+      signal: input.signal,
+      layer: 0,
+    });
+
+    const match = res.output.match(/\{[\s\S]*\}/);
+    if (!match)
+      throw new Error(
+        `Reviewer output did not contain a JSON object: ${res.output.slice(0, 200)}`,
+      );
+    let parsed: { pass?: unknown; feedback?: unknown };
+    try {
+      parsed = JSON.parse(match[0]);
+    } catch {
+      throw new Error(
+        `Reviewer output contained malformed JSON: ${match[0].slice(0, 200)}`,
+      );
+    }
+    if (typeof parsed.pass !== 'boolean') {
+      throw new Error(
+        `Reviewer verdict must have a boolean 'pass': ${match[0].slice(0, 200)}`,
+      );
+    }
+    if (parsed.pass === false) {
+      if (
+        typeof parsed.feedback !== 'string' ||
+        parsed.feedback.trim() === ''
+      ) {
+        throw new Error(
+          `Reviewer rejection must include a non-empty 'feedback' string: ${match[0].slice(0, 200)}`,
+        );
+      }
+      return { pass: false, feedback: parsed.feedback };
+    }
+    return { pass: true };
+  }
+}

--- a/packages/llm-agent-libs/src/coordinator/dag/noop-review-strategy.ts
+++ b/packages/llm-agent-libs/src/coordinator/dag/noop-review-strategy.ts
@@ -1,0 +1,9 @@
+import type { IReviewStrategy, ReviewVerdict } from '@mcp-abap-adt/llm-agent';
+
+/** Always-pass reviewer. Explicit opt-out / test double. */
+export class NoopReviewStrategy implements IReviewStrategy {
+  readonly name = 'noop-review';
+  async review(): Promise<ReviewVerdict> {
+    return { pass: true };
+  }
+}

--- a/packages/llm-agent-libs/src/coordinator/index.ts
+++ b/packages/llm-agent-libs/src/coordinator/index.ts
@@ -3,6 +3,7 @@ export { ExplicitActivation } from './activation/explicit.js';
 export { DagPlanInterpreter } from './dag/dag-plan-interpreter.js';
 export { LlmDagPlanner } from './dag/llm-dag-planner.js';
 export { LlmReviewStrategy } from './dag/llm-review-strategy.js';
+export { NoopReviewStrategy } from './dag/noop-review-strategy.js';
 export { HybridDispatch } from './dispatch/hybrid.js';
 export { SelfDispatch } from './dispatch/self.js';
 export { SubAgentDispatch } from './dispatch/subagent.js';

--- a/packages/llm-agent-libs/src/coordinator/index.ts
+++ b/packages/llm-agent-libs/src/coordinator/index.ts
@@ -2,6 +2,7 @@ export { AutoActivation } from './activation/auto.js';
 export { ExplicitActivation } from './activation/explicit.js';
 export { DagPlanInterpreter } from './dag/dag-plan-interpreter.js';
 export { LlmDagPlanner } from './dag/llm-dag-planner.js';
+export { LlmReviewStrategy } from './dag/llm-review-strategy.js';
 export { HybridDispatch } from './dispatch/hybrid.js';
 export { SelfDispatch } from './dispatch/self.js';
 export { SubAgentDispatch } from './dispatch/subagent.js';

--- a/packages/llm-agent-libs/src/index.ts
+++ b/packages/llm-agent-libs/src/index.ts
@@ -53,6 +53,7 @@ export {
   ExplicitActivation,
   HybridDispatch,
   LlmDagPlanner,
+  LlmReviewStrategy,
   OneShotPlanning,
   ReplanOnErrorPlanning,
   SelfDispatch,

--- a/packages/llm-agent-libs/src/index.ts
+++ b/packages/llm-agent-libs/src/index.ts
@@ -54,6 +54,7 @@ export {
   HybridDispatch,
   LlmDagPlanner,
   LlmReviewStrategy,
+  NoopReviewStrategy,
   OneShotPlanning,
   ReplanOnErrorPlanning,
   SelfDispatch,

--- a/packages/llm-agent-libs/src/pipeline/handlers/__tests__/dag-coordinator.test.ts
+++ b/packages/llm-agent-libs/src/pipeline/handlers/__tests__/dag-coordinator.test.ts
@@ -115,6 +115,69 @@ describe('DagCoordinatorHandler', () => {
     );
   });
 
+  it('passes through to interpret when the reviewer passes', async () => {
+    const { ctx, yields } = makeCtx('hi');
+    const h = new DagCoordinatorHandler({
+      planner: planner([{ id: 'n1', goal: 'g' }]),
+      interpreter: interp({ nodeResults: {}, ok: true, output: '42' }),
+      workers: new Map(),
+      reviewer: { name: 'r', review: async () => ({ pass: true }) },
+    });
+    const ok = await h.execute(ctx, {}, {} as never);
+    assert.equal(ok, true);
+    assert.equal(yields[0].value.content, '42');
+  });
+
+  it('rejects the plan as COORDINATOR_PLAN_REJECTED when the reviewer fails', async () => {
+    const { ctx, yields } = makeCtx('hi');
+    let interpreted = false;
+    const h = new DagCoordinatorHandler({
+      planner: planner([{ id: 'n1', goal: 'g' }]),
+      interpreter: {
+        name: 'i',
+        interpret: async () => {
+          interpreted = true;
+          return { nodeResults: {}, ok: true, output: 'x' };
+        },
+      },
+      workers: new Map(),
+      reviewer: {
+        name: 'r',
+        review: async () => ({ pass: false, feedback: 'no reader worker' }),
+      },
+    });
+    const ok = await h.execute(ctx, {}, {} as never);
+    assert.equal(ok, false);
+    assert.equal(interpreted, false);
+    const err = (
+      ctx as unknown as { error?: { code?: string; message?: string } }
+    ).error;
+    assert.equal(err?.code, 'COORDINATOR_PLAN_REJECTED');
+    assert.match(err?.message ?? '', /no reader worker/);
+    assert.equal(yields.length, 0);
+  });
+
+  it('maps a reviewer throw to COORDINATOR_REVIEW_FAILED', async () => {
+    const { ctx } = makeCtx('hi');
+    const h = new DagCoordinatorHandler({
+      planner: planner([{ id: 'n1', goal: 'g' }]),
+      interpreter: interp({ nodeResults: {}, ok: true, output: 'x' }),
+      workers: new Map(),
+      reviewer: {
+        name: 'r',
+        review: async () => {
+          throw new Error('critic boom');
+        },
+      },
+    });
+    const ok = await h.execute(ctx, {}, {} as never);
+    assert.equal(ok, false);
+    assert.equal(
+      (ctx as unknown as { error?: { code?: string } }).error?.code,
+      'COORDINATOR_REVIEW_FAILED',
+    );
+  });
+
   it("rejects a worker with contextPolicy='required' at construction", () => {
     const worker = (policy: 'required' | 'optional') =>
       ({

--- a/packages/llm-agent-libs/src/pipeline/handlers/dag-coordinator.ts
+++ b/packages/llm-agent-libs/src/pipeline/handlers/dag-coordinator.ts
@@ -4,7 +4,9 @@ import type {
   IInterpreter,
   InterpretResult,
   IPlanner,
+  IReviewStrategy,
   ISubAgent,
+  ReviewVerdict,
 } from '@mcp-abap-adt/llm-agent';
 import { OrchestratorError } from '../../agent.js';
 import type { ISpan } from '../../tracer/types.js';
@@ -19,6 +21,10 @@ export interface DagCoordinatorHandlerDeps {
    *  omitted, the pipeline defaults to ExplicitActivation. The handler itself
    *  does not read this; the pipeline uses it to wire `coordinator-activate`. */
   activation?: IActivationStrategy;
+  /** Optional plan reviewer. When present, the coordinator runs it as a gate
+   *  between planning and execution; a non-pass verdict fails loud (batch).
+   *  Absent → no gate. */
+  reviewer?: IReviewStrategy;
 }
 
 export class DagCoordinatorHandler implements IStageHandler {
@@ -58,6 +64,35 @@ export class DagCoordinatorHandler implements IStageHandler {
     } catch (err) {
       ctx.error = new OrchestratorError(errMsg(err), 'COORDINATOR_PLAN_FAILED');
       return false;
+    }
+
+    if (this.deps.reviewer) {
+      let verdict: ReviewVerdict;
+      try {
+        verdict = await this.deps.reviewer.review({
+          prompt: ctx.inputText,
+          plan,
+          agents: [...this.deps.workers.values()].map((w) => ({
+            name: w.name,
+            description: w.description,
+          })),
+          sessionId: ctx.sessionId,
+          signal: ctx.options?.signal,
+        });
+      } catch (err) {
+        ctx.error = new OrchestratorError(
+          errMsg(err),
+          'COORDINATOR_REVIEW_FAILED',
+        );
+        return false;
+      }
+      if (!verdict.pass) {
+        ctx.error = new OrchestratorError(
+          verdict.feedback,
+          'COORDINATOR_PLAN_REJECTED',
+        );
+        return false;
+      }
     }
 
     let result: InterpretResult;

--- a/packages/llm-agent-server/src/smart-agent/__tests__/dag-coordinator-config.test.ts
+++ b/packages/llm-agent-server/src/smart-agent/__tests__/dag-coordinator-config.test.ts
@@ -98,4 +98,42 @@ describe('coordinator config shape (DAG vs linear)', () => {
       /must be an object/,
     );
   });
+  it('accepts a DAG coordinator with a reviewer', () => {
+    assert.doesNotThrow(() =>
+      assertCoordinatorConfigShape({
+        planner: { type: 'llm' },
+        reviewer: { type: 'llm', plannerLlm: 'helper' },
+      }),
+    );
+  });
+  it('rejects an unknown reviewer.type', () => {
+    assert.throws(
+      () =>
+        assertCoordinatorConfigShape({
+          planner: { type: 'llm' },
+          reviewer: { type: 'bogus' },
+        }),
+      /reviewer: unknown type 'bogus'/,
+    );
+  });
+  it('rejects a bad reviewer.plannerLlm', () => {
+    assert.throws(
+      () =>
+        assertCoordinatorConfigShape({
+          planner: { type: 'llm' },
+          reviewer: { type: 'llm', plannerLlm: 'bogus' },
+        }),
+      /reviewer\.plannerLlm must be one of/,
+    );
+  });
+  it('rejects reviewer in a linear coordinator', () => {
+    assert.throws(
+      () =>
+        assertCoordinatorConfigShape({
+          planning: 'one-shot',
+          reviewer: { type: 'llm' },
+        }),
+      /reviewer/,
+    );
+  });
 });

--- a/packages/llm-agent-server/src/smart-agent/config.ts
+++ b/packages/llm-agent-server/src/smart-agent/config.ts
@@ -41,6 +41,7 @@ export interface YamlCoordinator {
     | { type?: string; plannerLlm?: 'main' | 'planner' | 'helper' }
     | Record<string, unknown>;
   interpreter?: { type?: string } | Record<string, unknown>;
+  reviewer?: { type?: string; plannerLlm?: 'main' | 'planner' | 'helper' };
 }
 
 const LINEAR_ONLY = [
@@ -52,7 +53,33 @@ const LINEAR_ONLY = [
   'maxLayer',
   'plannerLlm',
 ];
-const DAG_ONLY = ['planner', 'interpreter'];
+const DAG_ONLY = ['planner', 'interpreter', 'reviewer'];
+
+/** Validate a `{ type?: 'llm'; plannerLlm?: main|planner|helper }` role block. */
+function assertLlmRoleShape(label: string, role: unknown): void {
+  if (typeof role !== 'object' || role === null || Array.isArray(role)) {
+    throw new Error(
+      `coordinator.${label} must be an object (e.g. { type: llm }), got: ${JSON.stringify(role)}`,
+    );
+  }
+  const kind = (role as { type?: unknown }).type;
+  if (kind !== undefined && kind !== 'llm') {
+    throw new Error(
+      `coordinator.${label}: unknown type '${String(kind)}' (only 'llm' is supported)`,
+    );
+  }
+  const sel = (role as { plannerLlm?: unknown }).plannerLlm;
+  if (
+    sel !== undefined &&
+    sel !== 'main' &&
+    sel !== 'planner' &&
+    sel !== 'helper'
+  ) {
+    throw new Error(
+      `coordinator.${label}.plannerLlm must be one of main | planner | helper, got: ${String(sel)}`,
+    );
+  }
+}
 
 /** Fail-loud guard: a coordinator block is either DAG (has `planner`) or linear,
  *  never mixed. `activation` is shared and always allowed. */
@@ -61,34 +88,9 @@ export function assertCoordinatorConfigShape(
 ): void {
   const isDag = coord.planner !== undefined;
   if (isDag) {
-    // `planner` is the DAG selector — a malformed or unknown planner must fail
-    // loud rather than silently wiring the default LlmDagPlanner.
-    const planner = coord.planner;
-    if (
-      typeof planner !== 'object' ||
-      planner === null ||
-      Array.isArray(planner)
-    ) {
-      throw new Error(
-        `coordinator.planner must be an object (e.g. { type: llm }), got: ${JSON.stringify(planner)}`,
-      );
-    }
-    const plannerKind = (planner as { type?: unknown }).type;
-    if (plannerKind !== undefined && plannerKind !== 'llm') {
-      throw new Error(
-        `coordinator.planner: unknown type '${String(plannerKind)}' (only 'llm' is supported)`,
-      );
-    }
-    const plannerLlmSel = (planner as { plannerLlm?: unknown }).plannerLlm;
-    if (
-      plannerLlmSel !== undefined &&
-      plannerLlmSel !== 'main' &&
-      plannerLlmSel !== 'planner' &&
-      plannerLlmSel !== 'helper'
-    ) {
-      throw new Error(
-        `coordinator.planner.plannerLlm must be one of main | planner | helper, got: ${String(plannerLlmSel)}`,
-      );
+    assertLlmRoleShape('planner', coord.planner);
+    if (coord.reviewer !== undefined) {
+      assertLlmRoleShape('reviewer', coord.reviewer);
     }
     for (const f of LINEAR_ONLY) {
       if (coord[f] !== undefined) {

--- a/packages/llm-agent-server/src/smart-agent/smart-server.ts
+++ b/packages/llm-agent-server/src/smart-agent/smart-server.ts
@@ -15,6 +15,7 @@ import type {
   IModelProvider,
   IModelResolver,
   IRequestLogger,
+  IReviewStrategy,
   ISkillManager,
   Message,
   NormalizedRequest,
@@ -47,6 +48,7 @@ import {
   HealthChecker,
   type HotReloadableConfig,
   LlmDagPlanner,
+  LlmReviewStrategy,
   makeLlm,
   SessionLogger,
   SmartAgentBuilder,
@@ -655,6 +657,20 @@ export class SmartServer {
           plannerLlmKey === 'main' ? mainLlm : (helperLlm ?? mainLlm);
 
         const planner = new LlmDagPlanner(plannerLlm);
+
+        // Optional plan reviewer (presence of `coordinator.reviewer` = gate on).
+        let reviewer: IReviewStrategy | undefined;
+        if (coordCfg.reviewer !== undefined) {
+          const reviewerBlock = coordCfg.reviewer as {
+            plannerLlm?: 'main' | 'planner' | 'helper';
+          };
+          const reviewerLlm =
+            reviewerBlock.plannerLlm === 'main'
+              ? mainLlm
+              : (helperLlm ?? mainLlm);
+          reviewer = new LlmReviewStrategy(reviewerLlm);
+        }
+
         const interpreter = new DagPlanInterpreter();
         // Reuse the registry built above — same ISubAgent instances already
         // passed to builder.withSubAgents(). No second buildSubAgent calls.
@@ -677,6 +693,7 @@ export class SmartServer {
           interpreter,
           workers,
           activation,
+          reviewer,
         });
         log({ event: 'dag_coordinator_configured', config: coordCfg });
       } else {

--- a/packages/llm-agent/src/interfaces/index.ts
+++ b/packages/llm-agent/src/interfaces/index.ts
@@ -117,6 +117,11 @@ export type {
   ToolCallEntry,
 } from './request-logger.js';
 export type { IReranker } from './reranker.js';
+export type {
+  IReviewStrategy,
+  ReviewInput,
+  ReviewVerdict,
+} from './review.js';
 export type { ISessionManager } from './session.js';
 export type {
   ISkill,

--- a/packages/llm-agent/src/interfaces/review.ts
+++ b/packages/llm-agent/src/interfaces/review.ts
@@ -1,0 +1,17 @@
+import type { DagPlan } from './dag-plan.js';
+import type { PlannerCatalogEntry } from './planner.js';
+
+export interface ReviewInput {
+  prompt: string;
+  plan: DagPlan;
+  agents: PlannerCatalogEntry[];
+  sessionId: string;
+  signal?: AbortSignal;
+}
+
+export type ReviewVerdict = { pass: true } | { pass: false; feedback: string };
+
+export interface IReviewStrategy {
+  readonly name: string;
+  review(input: ReviewInput): Promise<ReviewVerdict>;
+}


### PR DESCRIPTION
## Summary

Slice 2 of the coordinator-redesign epic. Adds an **optional plan-reviewer gate** between planning and execution in the DAG coordinator, and reconciles the planner so both roles run through the **one `ISubAgent` path** (removing the slice-1 direct-LLM debt).

- **Terminology locked** in the epic overview: *Pipeline · Interpreter · Subagent · Component* (a Pipeline of N=1 subagent is the classic single-agent path; N>1 is the coordinator path — one model covers old and new).
- **`IReviewStrategy`** contract (`{pass:true} | {pass:false, feedback}`) + `LlmReviewStrategy` (DirectLlmSubAgent critic) + `NoopReviewStrategy`.
- **`LlmDagPlanner`** now owns a `DirectLlmSubAgent` (static instructions in systemPrompt, catalog+prompt in task; `layer:0`); behavior is parity-equivalent (guarded by existing tests).
- **Gate** in `DagCoordinatorHandler` between plan and interpret — **terminal/fail-loud** in batch: non-pass → `COORDINATOR_PLAN_REJECTED`, reviewer throw → `COORDINATOR_REVIEW_FAILED` (provisional codes). Interpreter is NOT called on reject.
- **Config**: `coordinator.reviewer: { type: llm, plannerLlm? }` (presence = gate on); shared `assertLlmRoleShape` validator; `reviewer` is DAG-only (rejected in linear configs).
- **Wiring** in smart-server mirrors the planner LLM resolution.

Additive and optional only; the linear coordinator path and existing YAML configs are untouched (backward-compat guard green).

Out of scope (later slices): resume/ask-and-resume on reject (dialog, slice 4), result-side review, reviewer-as-named-catalog-subagent, replan-on-reject (slice 3).

Spec: `docs/superpowers/specs/2026-05-26-slice2-plan-reviewer-design.md`
Plan: `docs/superpowers/plans/2026-05-26-slice2-plan-reviewer.md`

## Test Plan
- [x] `npm run build` — clean across 16 packages
- [x] `npm run lint:check` — clean (459 files)
- [x] full `npm run test` — 0 failures (llm-agent-libs 436, llm-agent-server 117, + others)
- [x] planner parity tests unchanged & green after the refactor
- [x] new tests: review strategies (7), handler gate (3), config validation (4)
- [x] backward-compat guard: existing example YAMLs still validate as linear
- [x] final code review (opus): APPROVED_WITH_NITS — both nits addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)