### PR TITLE
fix(18.0.1): thread client external tools into Stepper + DAG workers (#167); retain DAG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,37 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [18.0.1] — 2026-06-01
+
+### Fixed
+
+- **Client external tools now reach coordinator workers (#167).** Client-provided
+  external (consumer-executed) function tools — e.g. `create_file`, `rag_add` —
+  were dropped at the worker boundary, so a worker narrated "tool unavailable"
+  instead of emitting a tool call the client fulfils. They are now threaded into
+  BOTH coordinator paths:
+  - **Stepper:** `IStepperInput.externalTools` → interpreter → executor, MERGED
+    with the seeded MCP tools (appended after the MCP seed, de-duped by name, so
+    external tools never suppress MCP seeding).
+  - **DAG:** `InterpretContext.externalTools` → `ISubAgentInput.externalTools` →
+    the worker's nested pipeline (`SmartAgent.process`).
+
+### Changed
+
+- **DAG coordinator is RETAINED, not deprecated.** The 18.0.0 note that
+  `DagCoordinatorHandler` was deprecated and "removed in 19.0" is **reverted**.
+  The DAG coordinator is a supported peer pipeline variant (the strongest
+  single-shot plan-graph; e.g. unaided full-include reviews) alongside the
+  Stepper — `coordinator.planner` selects DAG, `coordinator.mode` / `coordinator.flow`
+  selects the Stepper. The startup `config_warning` is now an informational
+  `config_info` note. No removal is planned.
+
+### Notes
+
+- Issues #157 (coordinator self-dispatch ran toolless → hallucinated) and #166
+  (DAG double-emitted the answer) were verified resolved in the 18.0 Stepper path
+  and closed; use the Stepper for tool-using / streaming coordinator workloads.
+
 ## [18.0.0] — 2026-06-01
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -2391,7 +2391,7 @@
     },
     "packages/anthropic-llm": {
       "name": "@mcp-abap-adt/anthropic-llm",
-      "version": "18.0.0",
+      "version": "18.0.1",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/llm-agent": "^18.0.0",
@@ -2706,7 +2706,7 @@
     },
     "packages/deepseek-llm": {
       "name": "@mcp-abap-adt/deepseek-llm",
-      "version": "18.0.0",
+      "version": "18.0.1",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/llm-agent": "^18.0.0",
@@ -2715,7 +2715,7 @@
     },
     "packages/hana-vector-rag": {
       "name": "@mcp-abap-adt/hana-vector-rag",
-      "version": "18.0.0",
+      "version": "18.0.1",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/llm-agent": "^18.0.0",
@@ -2751,7 +2751,7 @@
     },
     "packages/llm-agent": {
       "name": "@mcp-abap-adt/llm-agent",
-      "version": "18.0.0",
+      "version": "18.0.1",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.3.6"
@@ -2762,7 +2762,7 @@
     },
     "packages/llm-agent-libs": {
       "name": "@mcp-abap-adt/llm-agent-libs",
-      "version": "18.0.0",
+      "version": "18.0.1",
       "dependencies": {
         "@mcp-abap-adt/llm-agent": "^18.0.0",
         "@mcp-abap-adt/llm-agent-mcp": "^18.0.0",
@@ -2851,7 +2851,7 @@
     },
     "packages/llm-agent-mcp": {
       "name": "@mcp-abap-adt/llm-agent-mcp",
-      "version": "18.0.0",
+      "version": "18.0.1",
       "dependencies": {
         "@mcp-abap-adt/llm-agent": "^18.0.0",
         "@modelcontextprotocol/sdk": "^1.28.0"
@@ -4221,7 +4221,7 @@
     },
     "packages/llm-agent-rag": {
       "name": "@mcp-abap-adt/llm-agent-rag",
-      "version": "18.0.0",
+      "version": "18.0.1",
       "dependencies": {
         "@mcp-abap-adt/llm-agent": "^18.0.0"
       },
@@ -4264,7 +4264,7 @@
     },
     "packages/llm-agent-server": {
       "name": "@mcp-abap-adt/llm-agent-server",
-      "version": "18.0.0",
+      "version": "18.0.1",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/anthropic-llm": "^18.0.0",
@@ -8060,7 +8060,7 @@
     },
     "packages/ollama-embedder": {
       "name": "@mcp-abap-adt/ollama-embedder",
-      "version": "18.0.0",
+      "version": "18.0.1",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/llm-agent": "^18.0.0"
@@ -8068,7 +8068,7 @@
     },
     "packages/ollama-llm": {
       "name": "@mcp-abap-adt/ollama-llm",
-      "version": "18.0.0",
+      "version": "18.0.1",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/llm-agent": "^18.0.0",
@@ -8077,7 +8077,7 @@
     },
     "packages/openai-embedder": {
       "name": "@mcp-abap-adt/openai-embedder",
-      "version": "18.0.0",
+      "version": "18.0.1",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/llm-agent": "^18.0.0"
@@ -8085,7 +8085,7 @@
     },
     "packages/openai-llm": {
       "name": "@mcp-abap-adt/openai-llm",
-      "version": "18.0.0",
+      "version": "18.0.1",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/llm-agent": "^18.0.0",
@@ -8400,7 +8400,7 @@
     },
     "packages/pg-vector-rag": {
       "name": "@mcp-abap-adt/pg-vector-rag",
-      "version": "18.0.0",
+      "version": "18.0.1",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/llm-agent": "^18.0.0",
@@ -8657,7 +8657,7 @@
     },
     "packages/qdrant-rag": {
       "name": "@mcp-abap-adt/qdrant-rag",
-      "version": "18.0.0",
+      "version": "18.0.1",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/llm-agent": "^18.0.0"
@@ -8665,7 +8665,7 @@
     },
     "packages/sap-aicore-embedder": {
       "name": "@mcp-abap-adt/sap-aicore-embedder",
-      "version": "18.0.0",
+      "version": "18.0.1",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/llm-agent": "^18.0.0",
@@ -11529,7 +11529,7 @@
     },
     "packages/sap-aicore-llm": {
       "name": "@mcp-abap-adt/sap-aicore-llm",
-      "version": "18.0.0",
+      "version": "18.0.1",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/llm-agent": "^18.0.0",

--- a/packages/anthropic-llm/package.json
+++ b/packages/anthropic-llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/anthropic-llm",
-  "version": "18.0.0",
+  "version": "18.0.1",
   "description": "Anthropic (Claude) LLM provider (ILlm) for @mcp-abap-adt/llm-agent.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/deepseek-llm/package.json
+++ b/packages/deepseek-llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/deepseek-llm",
-  "version": "18.0.0",
+  "version": "18.0.1",
   "description": "DeepSeek LLM provider (ILlm, extends OpenAIProvider) for @mcp-abap-adt/llm-agent.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/hana-vector-rag/package.json
+++ b/packages/hana-vector-rag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/hana-vector-rag",
-  "version": "18.0.0",
+  "version": "18.0.1",
   "description": "HanaVectorRag vector store (SAP HANA Cloud Vector Engine) and HanaVectorRagProvider for @mcp-abap-adt/llm-agent.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/llm-agent-libs/package.json
+++ b/packages/llm-agent-libs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/llm-agent-libs",
-  "version": "18.0.0",
+  "version": "18.0.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/llm-agent-libs/src/coordinator/dag/__tests__/dag-plan-interpreter.test.ts
+++ b/packages/llm-agent-libs/src/coordinator/dag/__tests__/dag-plan-interpreter.test.ts
@@ -55,6 +55,25 @@ describe('DagPlanInterpreter', () => {
     assert.equal(r.output, '42');
   });
 
+  it('#167: threads ctx.externalTools into the worker dispatch', async () => {
+    let seen: ReadonlyArray<{ name: string }> | undefined;
+    const w = worker('w', async (i) => {
+      seen = (i as { externalTools?: ReadonlyArray<{ name: string }> })
+        .externalTools;
+      return { output: 'ok' };
+    });
+    const base = ctx([['w', w]]);
+    await I().interpret(dag([{ id: 'n1', goal: 'g', agent: 'w' }]), {
+      ...base,
+      externalTools: [{ name: 'create_file' }] as never,
+    });
+    assert.deepEqual(
+      seen?.map((t) => t.name),
+      ['create_file'],
+      'worker must receive the client external tools',
+    );
+  });
+
   it('runs a dependency chain in order, feeding outputs forward', async () => {
     const seen: Record<string, string> = {};
     const w = worker('w', async (i) => {

--- a/packages/llm-agent-libs/src/coordinator/dag/dag-plan-interpreter.ts
+++ b/packages/llm-agent-libs/src/coordinator/dag/dag-plan-interpreter.ts
@@ -88,6 +88,8 @@ export class DagPlanInterpreter
               trace: ctx.trace,
               sessionLogger: ctx.sessionLogger,
               onPartial: workerOnPartial,
+              // Issue #167: thread client external tools into the worker.
+              externalTools: ctx.externalTools,
             });
             if (res.errorClass === 'epicfail') {
               outerOnPartial?.({

--- a/packages/llm-agent-libs/src/coordinator/stepper/__tests__/cyclic-react-executor.test.ts
+++ b/packages/llm-agent-libs/src/coordinator/stepper/__tests__/cyclic-react-executor.test.ts
@@ -539,6 +539,46 @@ test('a consumer systemPrompt override replaces the default EXECUTOR_SYSTEM', as
   assert.doesNotMatch(firstSystem, /state in ONE sentence the capability/i);
 });
 
+test('#167: client externalTools are MERGED with seeded MCP tools and offered to the model', async () => {
+  let firstTools: Array<{ name: string }> = [];
+  const llm = {
+    name: 'stub',
+    async chat(_messages: unknown, tools: Array<{ name: string }>) {
+      if (firstTools.length === 0) firstTools = tools ?? [];
+      return {
+        ok: true as const,
+        value: {
+          content: 'done',
+          usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+        },
+      };
+    },
+  };
+  const { rag } = knowledgeStub();
+  const exec = new CyclicReActExecutor({
+    llm: llm as never,
+    callMcp: mcp({}).call,
+    component: 'tool-loop',
+    maxIterations: 10,
+  });
+  await exec.execute({
+    prompt: 'review and save a file',
+    tools: [], // no dispatcher tools → executor seeds MCP from toolsRag
+    externalTools: [{ name: 'create_file' }] as never,
+    knowledgeRag: rag as never,
+    // toolsRag seeds an MCP tool so we can assert BOTH are present (merge, not replace)
+    toolsRag: toolsStub({ GetProgram: { name: 'GetProgram' } }) as never,
+    budget: { depthRemaining: 0, tokens: new TokenLedger(100000) },
+    ...META_BASE,
+  });
+  const names = firstTools.map((t) => t.name);
+  assert.ok(names.includes('create_file'), 'external tool must be offered');
+  assert.ok(
+    names.includes('GetProgram'),
+    'seeded MCP tool must still be offered (merge, not replace)',
+  );
+});
+
 test('scenario: a multi-fetch sequence writes a SEPARATE knowledge-RAG artifact per tool result', async () => {
   // Mirrors the real review shape (read object → list parts → read each part)
   // with neutral tool names: every tool RESULT must be persisted as its own

--- a/packages/llm-agent-libs/src/coordinator/stepper/__tests__/stepper-interpreter.test.ts
+++ b/packages/llm-agent-libs/src/coordinator/stepper/__tests__/stepper-interpreter.test.ts
@@ -72,6 +72,31 @@ const baseCtx = (
   ...over,
 });
 
+test('#167: interpreter threads ctx.externalTools into the executor leaf', async () => {
+  counter = 0;
+  let seen: ReadonlyArray<{ name: string }> | undefined;
+  const exec: IExecutor = {
+    name: 'e',
+    async execute(input) {
+      seen = input.externalTools;
+      return { status: 'ok', usage: ZERO };
+    },
+  };
+  const interp = new StepperInterpreter();
+  await interp.interpret(
+    { objective: 'o', nodes: [{ id: 'a', goal: 'g' }], createdAt: 0 },
+    baseCtx({
+      executor: exec,
+      externalTools: [{ name: 'create_file' }] as never,
+    }),
+  );
+  assert.deepEqual(
+    seen?.map((t) => t.name),
+    ['create_file'],
+    'executor leaf must receive the client external tools',
+  );
+});
+
 test('H.4b depth floor routes subagent node to executor; child.run NOT called; spawned event is the executor virtual ref', async () => {
   counter = 0;
   const child = spyStepper('w');

--- a/packages/llm-agent-libs/src/coordinator/stepper/cyclic-react-executor.ts
+++ b/packages/llm-agent-libs/src/coordinator/stepper/cyclic-react-executor.ts
@@ -153,6 +153,16 @@ export class CyclicReActExecutor implements IExecutor {
       });
     }
 
+    // Issue #167: MERGE client-provided external tools (consumer-executed, e.g.
+    // create_file / rag_add) with the seeded MCP tools — AFTER seeding, so they
+    // never suppress the MCP seed (which only runs when `tools.length === 0`).
+    // De-dup by name so a tool present in both sets is offered once.
+    if (input.externalTools && input.externalTools.length > 0) {
+      const have = new Set(tools.map((t) => t.name));
+      for (const t of input.externalTools)
+        if (!have.has(t.name)) tools.push(t as LlmTool);
+    }
+
     for (let iter = 0; iter < maxIterations; iter++) {
       // Gate BEFORE any further work (review R2-F1/R6-F1). The ledger is the
       // SHARED run-wide counter (not a local snapshot). If it is exhausted we

--- a/packages/llm-agent-libs/src/coordinator/stepper/stepper-interpreter.ts
+++ b/packages/llm-agent-libs/src/coordinator/stepper/stepper-interpreter.ts
@@ -76,6 +76,7 @@ export class StepperInterpreter implements IStepperInterpreter {
           },
           identity: childIdentity,
           taskSpec: ctx.taskSpec,
+          externalTools: ctx.externalTools,
           signal: ctx.signal,
           sessionLogger: ctx.sessionLogger,
           onProgress: ctx.onProgress,
@@ -85,6 +86,7 @@ export class StepperInterpreter implements IStepperInterpreter {
         const r = await ctx.executor.execute({
           prompt: composeTask(node, plan),
           tools: [],
+          externalTools: ctx.externalTools,
           knowledgeRag: ctx.knowledgeRag,
           toolsRag: ctx.toolsRag,
           budget: ctx.budget,

--- a/packages/llm-agent-libs/src/coordinator/stepper/stepper.ts
+++ b/packages/llm-agent-libs/src/coordinator/stepper/stepper.ts
@@ -83,6 +83,7 @@ export class Stepper implements IStepper {
       budget: input.budget,
       identity: input.identity,
       taskSpec: input.taskSpec,
+      externalTools: input.externalTools,
       maxParallelSteps,
       mintStepperId,
       signal: input.signal,

--- a/packages/llm-agent-libs/src/pipeline/handlers/dag-coordinator.ts
+++ b/packages/llm-agent-libs/src/pipeline/handlers/dag-coordinator.ts
@@ -320,6 +320,8 @@ export class DagCoordinatorHandler implements IStageHandler {
             trace: ctx.options?.trace,
             sessionLogger: ctx.options?.sessionLogger,
             onPartial,
+            // Issue #167: thread the client's external tools into worker dispatch.
+            externalTools: ctx.externalTools,
           });
         } catch (err) {
           ctx.error =

--- a/packages/llm-agent-libs/src/subagent/smart-agent-subagent.ts
+++ b/packages/llm-agent-libs/src/subagent/smart-agent-subagent.ts
@@ -32,6 +32,12 @@ export class SmartAgentSubAgent implements ISubAgent {
       trace: input.trace,
       sessionLogger: input.sessionLogger,
       onPartial: input.onPartial,
+      // Issue #167: forward the client's external (consumer-executed) tools into
+      // the worker's nested pipeline so it can emit a tool call the client
+      // fulfils, instead of narrating "tool unavailable".
+      ...(input.externalTools && input.externalTools.length > 0
+        ? { externalTools: [...input.externalTools] }
+        : {}),
     });
 
     if (!res.ok) {

--- a/packages/llm-agent-mcp/package.json
+++ b/packages/llm-agent-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/llm-agent-mcp",
-  "version": "18.0.0",
+  "version": "18.0.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/llm-agent-rag/package.json
+++ b/packages/llm-agent-rag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/llm-agent-rag",
-  "version": "18.0.0",
+  "version": "18.0.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/llm-agent-server/package.json
+++ b/packages/llm-agent-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/llm-agent-server",
-  "version": "18.0.0",
+  "version": "18.0.1",
   "description": "Default SmartAgent implementation with LLM providers, MCP client, HTTP server, and CLI.",
   "type": "module",
   "bin": {

--- a/packages/llm-agent-server/src/smart-agent/smart-server.ts
+++ b/packages/llm-agent-server/src/smart-agent/smart-server.ts
@@ -897,8 +897,8 @@ export function usesStepper(
   // with no mode is still a Stepper config; without this it would silently fall
   // through to the plain smart pipeline.
   if (typeof coordCfg.flow === 'object' && coordCfg.flow !== null) return true;
-  // Legacy 17.0 configs with `coordinator.planner` but no `coordinator.mode`
-  // stay on the deprecated DagCoordinatorHandler (removed in 19.0).
+  // `coordinator.planner` without `coordinator.mode` selects the DAG coordinator
+  // variant (a RETAINED peer pipeline, not deprecated) — not the Stepper.
   return false;
 }
 
@@ -1466,12 +1466,17 @@ export class SmartServer {
           config: rawCoordCfg,
         });
       } else if (coordCfg.planner !== undefined) {
-        // ── Legacy DAG path (deprecated §K — remove in 19.0) ─────────────────
+        // ── DAG coordinator path (a RETAINED peer pipeline variant) ──────────
+        // `coordinator.planner` (no `coordinator.mode`) selects the DAG
+        // coordinator. It is NOT deprecated — it is the strongest single-shot
+        // plan-graph variant (e.g. unaided full-include reviews). The Stepper
+        // (`coordinator.mode` / `coordinator.flow`) is a sibling, not a
+        // replacement. Informational only.
         log({
-          event: 'config_warning',
+          event: 'config_info',
           message:
-            'coordinator.planner without coordinator.mode uses the deprecated DagCoordinatorHandler; ' +
-            'set coordinator.mode to adopt the 18.0 Stepper runtime',
+            'coordinator.planner (no coordinator.mode) selects the DAG coordinator variant; ' +
+            'use coordinator.mode/flow for the Stepper variant',
         });
         // Fail loud if the config mixes DAG and linear fields.
         assertCoordinatorConfigShape(rawCoordCfg);

--- a/packages/llm-agent-server/src/smart-agent/stepper-coordinator-handler.ts
+++ b/packages/llm-agent-server/src/smart-agent/stepper-coordinator-handler.ts
@@ -142,6 +142,9 @@ export class StepperCoordinatorHandler implements IStageHandler {
         budget: built.budget,
         identity,
         taskSpec,
+        // Issue #167: thread the client's external (consumer-executed) tools so
+        // executors can emit tool calls the client fulfils. Empty → MCP-only.
+        externalTools: ctx.externalTools,
         // Thread the client abort signal so cancelling the request actually
         // stops the planner/executor/child-Stepper path, and the sessionLogger
         // so per-step logging (executor_tool_seed, etc.) reaches the request log.

--- a/packages/llm-agent/package.json
+++ b/packages/llm-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/llm-agent",
-  "version": "18.0.0",
+  "version": "18.0.1",
   "description": "Core interfaces, types, and lightweight default implementations for LLM agent orchestration.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/llm-agent/src/interfaces/executor.ts
+++ b/packages/llm-agent/src/interfaces/executor.ts
@@ -10,6 +10,13 @@ export interface IExecutor {
   execute(input: {
     prompt: string;
     tools: readonly LlmTool[];
+    /**
+     * Client-provided external tools (OpenAI-style function tools sent in the
+     * request, e.g. create_file / rag_add) that the CONSUMER executes. They are
+     * MERGED with the seeded MCP tools and offered to the model so a step can
+     * emit a tool call the client fulfils (issue #167). Absent → only MCP tools.
+     */
+    externalTools?: readonly LlmTool[];
     knowledgeRag: IKnowledgeRagHandle;
     toolsRag: IToolsRagHandle;
     needResolver?: INeedResolver;

--- a/packages/llm-agent/src/interfaces/interpreter.ts
+++ b/packages/llm-agent/src/interfaces/interpreter.ts
@@ -3,6 +3,7 @@ import type { DagPlan } from './dag-plan.js';
 import type { IErrorStrategy } from './error-strategy.js';
 import type { OnPartial } from './streaming.js';
 import type { ISubAgent } from './subagent.js';
+import type { LlmTool } from './types.js';
 
 export interface IInterpreter<TInput, TOutput> {
   readonly name: string;
@@ -31,6 +32,10 @@ export interface InterpretContext {
    *  interpreter annotates `nodeId` before calling and emits
    *  `node-start` / `node-end` itself. */
   onPartial?: OnPartial;
+  /** Client external (consumer-executed) tools, threaded into each worker
+   *  dispatch so a worker can emit a tool call the client fulfils (issue #167).
+   *  Absent → workers see only their own MCP tools. */
+  externalTools?: readonly LlmTool[];
 }
 
 export interface NodeResult {

--- a/packages/llm-agent/src/interfaces/stepper-interpreter.ts
+++ b/packages/llm-agent/src/interfaces/stepper-interpreter.ts
@@ -9,6 +9,7 @@ import type {
 } from './stepper.js';
 import type { StreamChunk } from './streaming.js';
 import type { ITaskSpec } from './task-spec.js';
+import type { LlmTool } from './types.js';
 
 export interface IStepperInterpreter {
   readonly name: string;
@@ -23,6 +24,8 @@ export interface IStepperInterpreter {
       budget: Budget;
       identity: RunIdentity;
       taskSpec?: ITaskSpec;
+      /** Client external tools, threaded to each executor (issue #167). */
+      externalTools?: readonly LlmTool[];
       maxParallelSteps: number;
       mintStepperId: () => string;
       signal?: AbortSignal;

--- a/packages/llm-agent/src/interfaces/stepper.ts
+++ b/packages/llm-agent/src/interfaces/stepper.ts
@@ -1,7 +1,7 @@
 import type { IKnowledgeRagHandle, IToolsRagHandle } from './knowledge-rag.js';
 import type { StreamChunk } from './streaming.js';
 import type { ITaskSpec } from './task-spec.js';
-import type { LlmUsage } from './types.js';
+import type { LlmTool, LlmUsage } from './types.js';
 
 /** Identity carried through every layer so executors can stamp
  *  KnowledgeEntryMetadata and the coordinator can attribute streaming
@@ -50,6 +50,10 @@ export interface IStepperInput {
   /** Formalized overall task (optional). Threaded down to every planner and
    *  executor as a compact anchor. Absent → behaves as before. */
   taskSpec?: ITaskSpec;
+  /** Client-provided external tools (consumer-executed function tools from the
+   *  request, e.g. create_file). Threaded down to every executor and merged
+   *  with the seeded MCP tools (issue #167). Absent → only MCP tools. */
+  externalTools?: readonly LlmTool[];
   signal?: AbortSignal;
   sessionLogger?: { logStep(name: string, data: unknown): void };
   onProgress?: (event: StreamChunk) => void;

--- a/packages/llm-agent/src/interfaces/subagent.ts
+++ b/packages/llm-agent/src/interfaces/subagent.ts
@@ -1,6 +1,6 @@
 import type { EpicFailTrace } from './coordinator.js';
 import type { OnPartial } from './streaming.js';
-import type { LlmToolCall, LlmUsage } from './types.js';
+import type { LlmTool, LlmToolCall, LlmUsage } from './types.js';
 
 /**
  * Typed metadata that the planner/validator can read without invoking the
@@ -44,6 +44,11 @@ export interface ISubAgentInput {
    *  Fire-and-forget — implementations must never let the callback throw
    *  break the run. Absence preserves today's silent behaviour. */
   onPartial?: OnPartial;
+  /** Client-provided external (consumer-executed) tools from the request, e.g.
+   *  create_file / rag_add. Threaded from the coordinator into the worker's
+   *  nested pipeline so the worker can emit a tool call the client fulfils
+   *  (issue #167). Absent → the worker sees only its own MCP tools. */
+  externalTools?: readonly LlmTool[];
 }
 
 export interface ISubAgentResult {

--- a/packages/ollama-embedder/package.json
+++ b/packages/ollama-embedder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/ollama-embedder",
-  "version": "18.0.0",
+  "version": "18.0.1",
   "description": "Ollama embedding provider and OllamaRag convenience class for @mcp-abap-adt/llm-agent.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/ollama-llm/package.json
+++ b/packages/ollama-llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/ollama-llm",
-  "version": "18.0.0",
+  "version": "18.0.1",
   "description": "Ollama LLM provider (ILlm, extends OpenAIProvider — Ollama's OpenAI-compatible /v1 API) for @mcp-abap-adt/llm-agent.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/openai-embedder/package.json
+++ b/packages/openai-embedder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/openai-embedder",
-  "version": "18.0.0",
+  "version": "18.0.1",
   "description": "OpenAI embedding provider (IEmbedderBatch) for @mcp-abap-adt/llm-agent.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/openai-llm/package.json
+++ b/packages/openai-llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/openai-llm",
-  "version": "18.0.0",
+  "version": "18.0.1",
   "description": "OpenAI LLM provider (ILlm) for @mcp-abap-adt/llm-agent.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/pg-vector-rag/package.json
+++ b/packages/pg-vector-rag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/pg-vector-rag",
-  "version": "18.0.0",
+  "version": "18.0.1",
   "description": "PgVectorRag (PostgreSQL + pgvector) and PgVectorRagProvider for @mcp-abap-adt/llm-agent.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/qdrant-rag/package.json
+++ b/packages/qdrant-rag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/qdrant-rag",
-  "version": "18.0.0",
+  "version": "18.0.1",
   "description": "QdrantRag vector store and QdrantRagProvider for @mcp-abap-adt/llm-agent.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/sap-aicore-embedder/package.json
+++ b/packages/sap-aicore-embedder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/sap-aicore-embedder",
-  "version": "18.0.0",
+  "version": "18.0.1",
   "description": "SAP AI Core embedding provider (IEmbedder) for @mcp-abap-adt/llm-agent.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/sap-aicore-llm/package.json
+++ b/packages/sap-aicore-llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/sap-aicore-llm",
-  "version": "18.0.0",
+  "version": "18.0.1",
   "description": "SAP AI Core LLM provider (ILlm) for @mcp-abap-adt/llm-agent.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## 18.0.1 hotfix

### #167 — external tools reach coordinator workers
Client external tools (`create_file`, `rag_add`, …) were dropped at the worker boundary in BOTH coordinator paths. Now threaded:
- **Stepper:** `IStepperInput.externalTools` → interpreter → executor, **merged** with seeded MCP tools (appended after the MCP seed, de-duped — never suppresses MCP seeding).
- **DAG:** `InterpretContext.externalTools` → `ISubAgentInput.externalTools` → worker's nested `SmartAgent.process`.

### DAG retained (not deprecated)
Reverts the 18.0.0 "DagCoordinatorHandler removed in 19.0" note — DAG is a supported peer variant (strongest single-shot plan-graph). Startup `config_warning` → informational `config_info`.

### Issue triage
- **#167** — fixed here (both paths).
- **#157 / #166** — verified resolved in the Stepper path, closed separately.

### Tests
3 new guard tests (executor merge, Stepper-interpreter threading, DAG-interpreter threading). libs **612** / server **283** green; lint clean. All packages 18.0.0 → **18.0.1** (caret ranges unchanged); lockfile synced.

Closes #167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)