### PR TITLE
fix(18.0.2): linear self-dispatch tool-loop (#157) + DAG single-emit (#166)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [18.0.2] — 2026-06-01
+
+### Fixed
+
+- **DAG coordinator no longer double-emits the answer (#166).** A single `onPartial`
+  was passed to both the interpreter and the finalizer, so a non-streaming client
+  received the answer twice (streamed node content + the finalizer's re-emission).
+  The interpreter's node-content now goes to the session log only; the **finalizer is
+  the sole source of client-facing content**, emitting the answer once.
+- **Linear coordinator self-dispatch can now call MCP tools (#157).** `SelfDispatch`
+  (and `HybridDispatch`, which delegates self-steps to it) ran a single toolless
+  `llm.chat()`, so tool-needing steps hallucinated instead of calling MCP. It now runs
+  a **bounded tool-loop** (≤6 iterations) over the per-request RAG-selected tools when
+  the coordinator threads them: `ICoordinatorContext` gains `selectedTools` + a
+  `callTool` executor, populated by `CoordinatorHandler` from the connected MCP clients
+  (`toolClientMap`) and the request's active tools. No tools/executor → unchanged
+  single-chat behaviour. (The DAG path already gave workers real tools in 18.0.)
+
+### Notes
+
+- Reaffirms 18.0.1: the **DAG coordinator is a retained peer pipeline variant** (not
+  deprecated). Both the DAG and linear coordinators now make real MCP calls.
+
 ## [18.0.1] — 2026-06-01
 
 ### Fixed

--- a/docs/examples/dag-coordinator/02b-hybrid-generic-worker.yaml
+++ b/docs/examples/dag-coordinator/02b-hybrid-generic-worker.yaml
@@ -1,0 +1,32 @@
+# CONTROL DAG: sonnet planner + GENERIC (agnostic) worker. Mirrors
+# 02-hybrid-sonnet-haiku.yaml but the worker has no domain systemPrompt.
+port: ${SMART_SERVER_PORT:-4017}
+host: 0.0.0.0
+mode: smart
+llm:
+  main:
+    provider: sap-ai-sdk
+    model: ${SAP_AI_MAIN_MODEL:-anthropic--claude-4.6-sonnet}
+    resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
+    temperature: 0.5
+  planner:
+    provider: sap-ai-sdk
+    model: ${SAP_AI_PLANNER_MODEL:-anthropic--claude-4.6-sonnet}
+    resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
+    temperature: 0.3
+rag:
+  type: in-memory
+  embedder: sap-ai-core
+  model: ${EMBEDDING_MODEL:-text-embedding-3-small}
+  resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
+coordinator:
+  activation: explicit
+  planner: { type: llm, plannerLlm: planner }
+  finalizer: { type: passthrough }
+subagents:
+  - name: abap-analyst
+    description: |
+      Analyzes repository objects via available MCP tools.
+    config: ./worker-generic.yaml
+logDir: ./.run/control-dag-generic-sessions
+log: ./.run/control-dag-generic-server.log

--- a/docs/examples/dag-coordinator/worker-generic.yaml
+++ b/docs/examples/dag-coordinator/worker-generic.yaml
@@ -1,0 +1,43 @@
+# CONTROL: DAG worker with a fully AGNOSTIC system prompt (no SAP/ABAP, no "never
+# fabricate" domain nudge). Everything else identical to worker-haiku.yaml.
+mode: smart
+agent:
+  maxIterations: 25
+  ragQueryK: 10
+  healthTimeoutMs: 15000
+rag:
+  type: in-memory
+  embedder: sap-ai-core
+  model: ${EMBEDDING_MODEL:-text-embedding-3-small}
+  resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
+systemPrompt: |
+  You complete the task by calling the available tools. If a tool call fails or
+  returns an error / empty / "not found" result, do not guess or fabricate; try
+  another available tool or state the capability you still need. Produce your
+  final answer only once you actually have the data the task requires.
+pipeline:
+  llm:
+    main:
+      provider: sap-ai-sdk
+      model: ${SAP_AI_WORKER_MODEL:-anthropic--claude-4.5-haiku}
+      resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
+      temperature: 0.2
+    classifier:
+      provider: sap-ai-sdk
+      model: ${SAP_AI_WORKER_MODEL:-anthropic--claude-4.5-haiku}
+      resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
+      temperature: 0.1
+  mcp:
+    - type: http
+      url: ${MCP_ENDPOINT:-http://localhost:3001/mcp/stream/http}
+  version: "1"
+  stages:
+    - { id: classify, type: classify }
+    - id: rag-retrieval
+      type: parallel
+      stages:
+        - { id: rag-tools, type: rag-query, config: { store: tools, k: 10 } }
+      after:
+        - { id: tool-select, type: tool-select }
+    - { id: assemble, type: assemble }
+    - { id: tool-loop, type: tool-loop, config: { maxIterations: 25 } }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2391,7 +2391,7 @@
     },
     "packages/anthropic-llm": {
       "name": "@mcp-abap-adt/anthropic-llm",
-      "version": "18.0.1",
+      "version": "18.0.2",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/llm-agent": "^18.0.0",
@@ -2706,7 +2706,7 @@
     },
     "packages/deepseek-llm": {
       "name": "@mcp-abap-adt/deepseek-llm",
-      "version": "18.0.1",
+      "version": "18.0.2",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/llm-agent": "^18.0.0",
@@ -2715,7 +2715,7 @@
     },
     "packages/hana-vector-rag": {
       "name": "@mcp-abap-adt/hana-vector-rag",
-      "version": "18.0.1",
+      "version": "18.0.2",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/llm-agent": "^18.0.0",
@@ -2751,7 +2751,7 @@
     },
     "packages/llm-agent": {
       "name": "@mcp-abap-adt/llm-agent",
-      "version": "18.0.1",
+      "version": "18.0.2",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.3.6"
@@ -2762,7 +2762,7 @@
     },
     "packages/llm-agent-libs": {
       "name": "@mcp-abap-adt/llm-agent-libs",
-      "version": "18.0.1",
+      "version": "18.0.2",
       "dependencies": {
         "@mcp-abap-adt/llm-agent": "^18.0.0",
         "@mcp-abap-adt/llm-agent-mcp": "^18.0.0",
@@ -2851,7 +2851,7 @@
     },
     "packages/llm-agent-mcp": {
       "name": "@mcp-abap-adt/llm-agent-mcp",
-      "version": "18.0.1",
+      "version": "18.0.2",
       "dependencies": {
         "@mcp-abap-adt/llm-agent": "^18.0.0",
         "@modelcontextprotocol/sdk": "^1.28.0"
@@ -4221,7 +4221,7 @@
     },
     "packages/llm-agent-rag": {
       "name": "@mcp-abap-adt/llm-agent-rag",
-      "version": "18.0.1",
+      "version": "18.0.2",
       "dependencies": {
         "@mcp-abap-adt/llm-agent": "^18.0.0"
       },
@@ -4264,7 +4264,7 @@
     },
     "packages/llm-agent-server": {
       "name": "@mcp-abap-adt/llm-agent-server",
-      "version": "18.0.1",
+      "version": "18.0.2",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/anthropic-llm": "^18.0.0",
@@ -8060,7 +8060,7 @@
     },
     "packages/ollama-embedder": {
       "name": "@mcp-abap-adt/ollama-embedder",
-      "version": "18.0.1",
+      "version": "18.0.2",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/llm-agent": "^18.0.0"
@@ -8068,7 +8068,7 @@
     },
     "packages/ollama-llm": {
       "name": "@mcp-abap-adt/ollama-llm",
-      "version": "18.0.1",
+      "version": "18.0.2",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/llm-agent": "^18.0.0",
@@ -8077,7 +8077,7 @@
     },
     "packages/openai-embedder": {
       "name": "@mcp-abap-adt/openai-embedder",
-      "version": "18.0.1",
+      "version": "18.0.2",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/llm-agent": "^18.0.0"
@@ -8085,7 +8085,7 @@
     },
     "packages/openai-llm": {
       "name": "@mcp-abap-adt/openai-llm",
-      "version": "18.0.1",
+      "version": "18.0.2",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/llm-agent": "^18.0.0",
@@ -8400,7 +8400,7 @@
     },
     "packages/pg-vector-rag": {
       "name": "@mcp-abap-adt/pg-vector-rag",
-      "version": "18.0.1",
+      "version": "18.0.2",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/llm-agent": "^18.0.0",
@@ -8657,7 +8657,7 @@
     },
     "packages/qdrant-rag": {
       "name": "@mcp-abap-adt/qdrant-rag",
-      "version": "18.0.1",
+      "version": "18.0.2",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/llm-agent": "^18.0.0"
@@ -8665,7 +8665,7 @@
     },
     "packages/sap-aicore-embedder": {
       "name": "@mcp-abap-adt/sap-aicore-embedder",
-      "version": "18.0.1",
+      "version": "18.0.2",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/llm-agent": "^18.0.0",
@@ -11529,7 +11529,7 @@
     },
     "packages/sap-aicore-llm": {
       "name": "@mcp-abap-adt/sap-aicore-llm",
-      "version": "18.0.1",
+      "version": "18.0.2",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/llm-agent": "^18.0.0",

--- a/packages/anthropic-llm/package.json
+++ b/packages/anthropic-llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/anthropic-llm",
-  "version": "18.0.1",
+  "version": "18.0.2",
   "description": "Anthropic (Claude) LLM provider (ILlm) for @mcp-abap-adt/llm-agent.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/deepseek-llm/package.json
+++ b/packages/deepseek-llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/deepseek-llm",
-  "version": "18.0.1",
+  "version": "18.0.2",
   "description": "DeepSeek LLM provider (ILlm, extends OpenAIProvider) for @mcp-abap-adt/llm-agent.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/hana-vector-rag/package.json
+++ b/packages/hana-vector-rag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/hana-vector-rag",
-  "version": "18.0.1",
+  "version": "18.0.2",
   "description": "HanaVectorRag vector store (SAP HANA Cloud Vector Engine) and HanaVectorRagProvider for @mcp-abap-adt/llm-agent.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/llm-agent-libs/package.json
+++ b/packages/llm-agent-libs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/llm-agent-libs",
-  "version": "18.0.1",
+  "version": "18.0.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/llm-agent-libs/src/coordinator/dispatch/__tests__/self-dispatch.test.ts
+++ b/packages/llm-agent-libs/src/coordinator/dispatch/__tests__/self-dispatch.test.ts
@@ -48,3 +48,93 @@ describe('SelfDispatch task composition', () => {
     );
   });
 });
+
+describe('SelfDispatch #157 tool-loop', () => {
+  const step: PlanStep = {
+    id: 's1',
+    goal: 'Read table T000',
+    status: 'pending',
+  };
+
+  it('runs a tool-loop: calls the tool, feeds the result back, returns the final answer', async () => {
+    const toolArgsSeen: unknown[] = [];
+    let turn = 0;
+    const llm = {
+      chat: async (_messages: unknown, tools: Array<{ name: string }>) => {
+        turn++;
+        if (turn === 1) {
+          // first turn: the model requests the tool (tools were offered)
+          assert.ok(
+            tools.some((t) => t.name === 'GetTableContents'),
+            'selected tools must be offered to the model',
+          );
+          return {
+            ok: true as const,
+            value: {
+              content: '',
+              toolCalls: [
+                {
+                  id: 'c1',
+                  name: 'GetTableContents',
+                  arguments: { table: 'T000' },
+                },
+              ],
+              usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+            },
+          };
+        }
+        // second turn: answer from the observed tool result
+        return {
+          ok: true as const,
+          value: {
+            content: 'T000 has 3 clients.',
+            usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+          },
+        };
+      },
+    } as unknown as ILlm;
+
+    let called = '';
+    const ctx = {
+      inputText: 'read T000',
+      registry: new Map(),
+      stepResults: {},
+      sessionId: 't',
+      selectedTools: [{ name: 'GetTableContents' }],
+      callTool: async (name: string, args: unknown) => {
+        called = name;
+        toolArgsSeen.push(args);
+        return 'MANDT=000;100;200';
+      },
+    } as unknown as ICoordinatorContext;
+
+    const res = await new SelfDispatch(llm).dispatch(step, ctx);
+    assert.equal(res.ok, true);
+    assert.equal(called, 'GetTableContents', 'the MCP tool must be invoked');
+    assert.deepEqual(toolArgsSeen[0], { table: 'T000' });
+    assert.equal(res.output, 'T000 has 3 clients.');
+    // usage accumulated across both turns (2 + 2)
+    assert.equal(res.usage?.totalTokens, 4);
+  });
+
+  it('falls back to a single toolless chat when no tools/executor are present', async () => {
+    let calls = 0;
+    const llm = {
+      chat: async (_m: unknown, tools: unknown[]) => {
+        calls++;
+        assert.deepEqual(tools, [], 'legacy path offers no tools');
+        return { ok: true as const, value: { content: 'plain answer' } };
+      },
+    } as unknown as ILlm;
+    const ctx = {
+      inputText: 'x',
+      registry: new Map(),
+      stepResults: {},
+      sessionId: 't',
+    } as unknown as ICoordinatorContext;
+    const res = await new SelfDispatch(llm).dispatch(step, ctx);
+    assert.equal(res.ok, true);
+    assert.equal(res.output, 'plain answer');
+    assert.equal(calls, 1, 'exactly one toolless chat');
+  });
+});

--- a/packages/llm-agent-libs/src/coordinator/dispatch/self.ts
+++ b/packages/llm-agent-libs/src/coordinator/dispatch/self.ts
@@ -2,10 +2,17 @@ import type {
   ICoordinatorContext,
   IDispatchStrategy,
   ILlm,
+  LlmTool,
+  LlmUsage,
+  Message,
   PlanStep,
   StepResult,
 } from '@mcp-abap-adt/llm-agent';
 import { composeTask } from './compose-task.js';
+
+/** Bound on the self-dispatch tool-loop — enough for a read→observe→answer
+ *  cycle without runaway. */
+const MAX_TOOL_ITERATIONS = 6;
 
 export class SelfDispatch implements IDispatchStrategy {
   readonly name = 'self';
@@ -31,6 +38,23 @@ export class SelfDispatch implements IDispatchStrategy {
 
     const started = Date.now();
     try {
+      // #157: when the coordinator threaded the per-request RAG-selected tools
+      // and a tool executor, run a bounded tool-loop so a self-dispatched step
+      // can actually CALL MCP (read a table, list a package, …) instead of a
+      // single toolless chat that hallucinates the result. No tools / no
+      // executor → the legacy single-chat behaviour (below).
+      const tools = (ctx.selectedTools ?? []) as LlmTool[];
+      if (tools.length > 0 && typeof ctx.callTool === 'function') {
+        const r = await this.runToolLoop(sys, userMsg, tools, ctx);
+        return {
+          stepId: step.id,
+          output: r.content,
+          usage: r.usage,
+          durationMs: Date.now() - started,
+          ok: true,
+        };
+      }
+
       const res = await this.llm.chat(
         [
           { role: 'system', content: sys },
@@ -56,5 +80,73 @@ export class SelfDispatch implements IDispatchStrategy {
         error: err instanceof Error ? err.message : String(err),
       };
     }
+  }
+
+  /** Bounded ReAct loop: chat with tools → execute any tool calls via
+   *  `ctx.callTool` → feed results back → repeat until the model answers with no
+   *  tool call (or the cap is hit). Mirrors the wire shape providers expect
+   *  (assistant `tool_calls` followed by matching `tool` messages). */
+  private async runToolLoop(
+    sys: string,
+    userMsg: string,
+    tools: LlmTool[],
+    ctx: ICoordinatorContext,
+  ): Promise<{ content: string; usage?: LlmUsage }> {
+    const callTool = ctx.callTool as NonNullable<
+      ICoordinatorContext['callTool']
+    >;
+    const messages: Message[] = [
+      { role: 'system', content: sys },
+      { role: 'user', content: userMsg },
+    ];
+    let usage: LlmUsage | undefined;
+    const add = (u?: LlmUsage) => {
+      if (!u) return;
+      usage = usage
+        ? {
+            promptTokens: usage.promptTokens + u.promptTokens,
+            completionTokens: usage.completionTokens + u.completionTokens,
+            totalTokens: usage.totalTokens + u.totalTokens,
+          }
+        : { ...u };
+    };
+
+    for (let iter = 0; iter < MAX_TOOL_ITERATIONS; iter++) {
+      const res = await this.llm.chat(messages, tools, {
+        signal: ctx.signal,
+        sessionId: ctx.sessionId,
+      });
+      if (!res.ok) throw res.error;
+      add(res.value.usage);
+      const toolCalls = res.value.toolCalls ?? [];
+      if (toolCalls.length === 0) return { content: res.value.content, usage };
+
+      messages.push({
+        role: 'assistant',
+        content: res.value.content || null,
+        tool_calls: toolCalls.map((tc) => ({
+          id: tc.id,
+          type: 'function' as const,
+          function: {
+            name: tc.name,
+            arguments: JSON.stringify(tc.arguments ?? {}),
+          },
+        })),
+      });
+      for (const tc of toolCalls) {
+        const out = await callTool(tc.name, tc.arguments ?? {}, ctx.signal);
+        messages.push({ role: 'tool', content: out, tool_call_id: tc.id });
+      }
+    }
+
+    // Iteration cap hit: one final tool-free turn so we answer from what was
+    // gathered instead of returning empty.
+    const final = await this.llm.chat(messages, [], {
+      signal: ctx.signal,
+      sessionId: ctx.sessionId,
+    });
+    if (!final.ok) throw final.error;
+    add(final.value.usage);
+    return { content: final.value.content, usage };
   }
 }

--- a/packages/llm-agent-libs/src/pipeline/handlers/__tests__/dag-coordinator-stream.test.ts
+++ b/packages/llm-agent-libs/src/pipeline/handlers/__tests__/dag-coordinator-stream.test.ts
@@ -9,7 +9,7 @@ import type {
 } from '@mcp-abap-adt/llm-agent';
 import { DagCoordinatorHandler } from '../dag-coordinator.js';
 
-test('handler yields content deltas as soon as interpreter/finalizer emit them', async () => {
+test('#166: the answer reaches the client once (finalizer only); interpreter node content is not double-emitted', async () => {
   const planner: IPlanner = {
     name: 'p',
     async plan() {
@@ -88,16 +88,17 @@ test('handler yields content deltas as soon as interpreter/finalizer emit them',
   });
   await h.execute(ctx, {}, {} as never);
 
-  // Content yields:
-  //   foo  (worker delta)
-  //   bar  (worker delta)
-  //   foobar (PassthroughFinalizer one-shot)
+  // #166 regression guard: the answer must reach the client EXACTLY ONCE — from
+  // the finalizer. The interpreter's node-content deltas ('foo','bar') go to the
+  // session log only, NOT to the client (previously they were ALSO yielded, so a
+  // non-streaming client got the answer twice: 'foo'+'bar' + 'foobar').
   const contentYields = yielded.filter(
     (y) => (y.content ?? '') !== '' && !y.finishReason,
   );
   assert.deepEqual(
     contentYields.map((y) => y.content),
-    ['foo', 'bar', 'foobar'],
+    ['foobar'],
+    'only the finalizer emits client content — no interpreter double-emit',
   );
 
   // Final stop yield still present (with empty content, finishReason='stop'):

--- a/packages/llm-agent-libs/src/pipeline/handlers/coordinator.ts
+++ b/packages/llm-agent-libs/src/pipeline/handlers/coordinator.ts
@@ -59,6 +59,10 @@ export class CoordinatorHandler implements IStageHandler {
       stepResults: {},
       signal: ctx.options?.signal,
       sessionId: ctx.sessionId,
+      // #157: thread the per-request RAG-selected tools + an MCP executor so a
+      // self-dispatched step runs a real tool-loop instead of a toolless chat.
+      selectedTools: ctx.activeTools ?? ctx.selectedTools,
+      callTool: buildCallTool(ctx),
     };
 
     let plan: Plan;
@@ -286,6 +290,32 @@ function wrapError(err: unknown, code: string): OrchestratorError {
     err instanceof Error ? err.message : String(err),
     code,
   );
+}
+
+/**
+ * Build a tool executor for self-dispatched coordinator steps (#157): resolve
+ * the owning MCP client from `toolClientMap` and call it, returning the textual
+ * result (mirrors the default tool-loop's extraction). Returns undefined when no
+ * MCP clients are connected, so SelfDispatch keeps its toolless behaviour.
+ */
+function buildCallTool(
+  ctx: PipelineContext,
+): ICoordinatorContext['callTool'] | undefined {
+  const map = ctx.toolClientMap;
+  if (!map || map.size === 0) return undefined;
+  return async (name: string, args: unknown) => {
+    const client = map.get(name);
+    if (!client) return `Tool not found: ${name}`;
+    const r = await client.callTool(
+      name,
+      (args ?? {}) as Record<string, unknown>,
+      ctx.options,
+    );
+    if (!r.ok) return r.error.message;
+    return typeof r.value.content === 'string'
+      ? r.value.content
+      : JSON.stringify(r.value.content);
+  };
 }
 
 /**

--- a/packages/llm-agent-libs/src/pipeline/handlers/dag-coordinator.ts
+++ b/packages/llm-agent-libs/src/pipeline/handlers/dag-coordinator.ts
@@ -300,11 +300,20 @@ export class DagCoordinatorHandler implements IStageHandler {
           }
         }
 
-        const onPartial: OnPartial = (chunk) => {
+        // #166 fix: the FINALIZER is the single source of client-facing content.
+        // Previously ONE onPartial was passed to BOTH the interpreter and the
+        // finalizer, so a non-streaming client received the answer TWICE — once
+        // as streamed node content (A) and again as the finalizer's re-emission
+        // of the joined output (B). Now the interpreter's progress (node content,
+        // node-start/end, tool-call) goes to the session log ONLY; the finalizer's
+        // onPartial is the one that yields content to the client.
+        const interpreterOnPartial: OnPartial = (chunk) => {
+          ctx.options?.sessionLogger?.logStep('dag_stream', chunk);
+        };
+        const finalizerOnPartial: OnPartial = (chunk) => {
           if (chunk.kind === 'content') {
             ctx.yield({ ok: true, value: { content: chunk.delta } });
           }
-          // node-start / node-end / tool-call → session log only (NOT yielded to client)
           ctx.options?.sessionLogger?.logStep('dag_stream', chunk);
         };
 
@@ -319,7 +328,7 @@ export class DagCoordinatorHandler implements IStageHandler {
             ancestorContext,
             trace: ctx.options?.trace,
             sessionLogger: ctx.options?.sessionLogger,
-            onPartial,
+            onPartial: interpreterOnPartial,
             // Issue #167: thread the client's external tools into worker dispatch.
             externalTools: ctx.externalTools,
           });
@@ -361,7 +370,7 @@ export class DagCoordinatorHandler implements IStageHandler {
                 sessionId: ctx.sessionId,
                 signal: ctx.options?.signal,
                 trace: ctx.options?.trace,
-                onPartial,
+                onPartial: finalizerOnPartial,
               }),
           );
           if ('ended' in finalRes) return true;

--- a/packages/llm-agent-mcp/package.json
+++ b/packages/llm-agent-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/llm-agent-mcp",
-  "version": "18.0.1",
+  "version": "18.0.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/llm-agent-rag/package.json
+++ b/packages/llm-agent-rag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/llm-agent-rag",
-  "version": "18.0.1",
+  "version": "18.0.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/llm-agent-server/package.json
+++ b/packages/llm-agent-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/llm-agent-server",
-  "version": "18.0.1",
+  "version": "18.0.2",
   "description": "Default SmartAgent implementation with LLM providers, MCP client, HTTP server, and CLI.",
   "type": "module",
   "bin": {

--- a/packages/llm-agent/package.json
+++ b/packages/llm-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/llm-agent",
-  "version": "18.0.1",
+  "version": "18.0.2",
   "description": "Core interfaces, types, and lightweight default implementations for LLM agent orchestration.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/llm-agent/src/interfaces/coordinator.ts
+++ b/packages/llm-agent/src/interfaces/coordinator.ts
@@ -5,7 +5,7 @@ import type {
   ISubAgentResult,
   SubAgentRegistry,
 } from './subagent.js';
-import type { LlmUsage } from './types.js';
+import type { LlmTool, LlmUsage } from './types.js';
 
 export interface PlanStep {
   id: string;
@@ -87,6 +87,24 @@ export interface ICoordinatorContext {
   stepResults: Record<string, StepResult>;
   signal?: AbortSignal;
   sessionId: string;
+  /**
+   * Per-request RAG-selected tools (MCP + client external) available to a
+   * self-dispatched step's tool-loop (#157). Empty/absent → the step runs a
+   * single toolless `llm.chat()` (legacy behaviour).
+   */
+  selectedTools?: readonly LlmTool[];
+  /**
+   * Executes a tool by name and returns its textual result. Built by the
+   * coordinator handler from the connected MCP clients. With `selectedTools`,
+   * this lets a self-dispatched step actually CALL MCP (read a table, list a
+   * package, …) instead of hallucinating a toolless answer (#157). Absent →
+   * no tool-loop.
+   */
+  callTool?: (
+    name: string,
+    args: unknown,
+    signal?: AbortSignal,
+  ) => Promise<string>;
 }
 
 export interface IPlanningStrategy {

--- a/packages/ollama-embedder/package.json
+++ b/packages/ollama-embedder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/ollama-embedder",
-  "version": "18.0.1",
+  "version": "18.0.2",
   "description": "Ollama embedding provider and OllamaRag convenience class for @mcp-abap-adt/llm-agent.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/ollama-llm/package.json
+++ b/packages/ollama-llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/ollama-llm",
-  "version": "18.0.1",
+  "version": "18.0.2",
   "description": "Ollama LLM provider (ILlm, extends OpenAIProvider — Ollama's OpenAI-compatible /v1 API) for @mcp-abap-adt/llm-agent.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/openai-embedder/package.json
+++ b/packages/openai-embedder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/openai-embedder",
-  "version": "18.0.1",
+  "version": "18.0.2",
   "description": "OpenAI embedding provider (IEmbedderBatch) for @mcp-abap-adt/llm-agent.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/openai-llm/package.json
+++ b/packages/openai-llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/openai-llm",
-  "version": "18.0.1",
+  "version": "18.0.2",
   "description": "OpenAI LLM provider (ILlm) for @mcp-abap-adt/llm-agent.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/pg-vector-rag/package.json
+++ b/packages/pg-vector-rag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/pg-vector-rag",
-  "version": "18.0.1",
+  "version": "18.0.2",
   "description": "PgVectorRag (PostgreSQL + pgvector) and PgVectorRagProvider for @mcp-abap-adt/llm-agent.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/qdrant-rag/package.json
+++ b/packages/qdrant-rag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/qdrant-rag",
-  "version": "18.0.1",
+  "version": "18.0.2",
   "description": "QdrantRag vector store and QdrantRagProvider for @mcp-abap-adt/llm-agent.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/sap-aicore-embedder/package.json
+++ b/packages/sap-aicore-embedder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/sap-aicore-embedder",
-  "version": "18.0.1",
+  "version": "18.0.2",
   "description": "SAP AI Core embedding provider (IEmbedder) for @mcp-abap-adt/llm-agent.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/sap-aicore-llm/package.json
+++ b/packages/sap-aicore-llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/sap-aicore-llm",
-  "version": "18.0.1",
+  "version": "18.0.2",
   "description": "SAP AI Core LLM provider (ILlm) for @mcp-abap-adt/llm-agent.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## 18.0.2 — coordinator fixes (DAG retained)

### #157 — linear coordinator self-dispatch now calls MCP tools
`SelfDispatch` (and `HybridDispatch` via delegation) ran a single toolless `llm.chat()` → tool-needing steps hallucinated. Now a **bounded tool-loop** (≤6 iters) over the per-request RAG-selected tools: `ICoordinatorContext` gains `selectedTools` + a `callTool` executor, populated by `CoordinatorHandler` from the connected MCP clients (`toolClientMap`) + active tools. No tools/executor → unchanged single chat.

### #166 — DAG coordinator emits the answer once
One `onPartial` fed BOTH the interpreter and the finalizer → non-streaming clients got the answer twice. Split: interpreter node-content → session log only; **finalizer is the sole client-content source**.

### Tests
SelfDispatch tool-loop (2) + DAG single-emit regression guard. libs **614** / server **283** green; lint clean. All packages → **18.0.2**; lockfile synced.

Closes #157, #166.

🤖 Generated with [Claude Code](https://claude.com/claude-code)