### PR TITLE
feat(#171): client-provided external tools under the DAG coordinator

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -287,7 +287,7 @@ sequenceDiagram
 
 ### Key decision points
 
-1. **Mode selection** — `pass` skips the entire pipeline and streams directly from LLM. `smart` runs full orchestration. `hard` forces MCP-only tools (no external tools).
+1. **Mode selection** — `pass` skips the entire pipeline and streams directly from LLM. `smart` runs full orchestration. `hard` forces the worker to execute only internal MCP tools; client/external tools are still offered and their calls surfaced to the consumer.
 2. **RAG retrieval** — When RAG stores are configured, they are queried in parallel. Each store can have its own search strategy (`ISearchStrategy`) and query preprocessors (`IQueryPreprocessor`). The preprocessor chain runs before embedding — e.g. `TranslatePreprocessor` translates non-English queries, `ExpandPreprocessor` adds synonyms. The search strategy scores candidates — `RrfStrategy` (Reciprocal Rank Fusion) is recommended for best results. `CompositeStrategy` allows combining multiple strategies with configurable weights.
 3. **Tool routing** — Tool calls from LLM are classified as: internal (MCP), external (client-provided), hallucinated (unknown), or blocked (temporarily unavailable). Each category has distinct handling.
 4. **Loop termination** — The tool loop exits on: `finishReason: stop`, `maxIterations` reached, `maxToolCalls` exhausted, abort signal, or external tool call delegation.
@@ -493,7 +493,8 @@ Configured via `SmartAgentConfig.mode` and `SmartServerMode`:
 
 - `hard`:
 - SAP/MCP-focused behavior with strict internal tool context.
-- External tools are not active in MCP execution loop.
+- The worker executes only internal MCP tools; client/external tools remain
+  offered and their calls are surfaced to the consumer (consumer-executed).
 
 - `pass`:
 - Pure passthrough to main LLM stream over provided history/tools.

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -642,6 +642,36 @@ A browser frontend on a different origin (e.g. `https://app.example.com` calling
 
 Auth-enabled downstream builds (bearer tokens / OIDC / mTLS) may handle session identity differently — those flows are out of scope for the default cookie path.
 
+## External (client-provided) tools under the coordinator
+
+Tools you declare in the request `tools` array (the standard OpenAI/Anthropic
+field) are treated as **external** — they are always available regardless of
+`mode` (including `hard`), and they are **consumer-executed**: the worker never
+runs them. When a worker decides to call an external tool, the agent surfaces a
+standard `tool_call` with `finish_reason: tool_calls` (Anthropic: a `tool_use`
+block, `stop_reason: tool_use`) and stops. Your client executes the tool and
+sends the result back via the normal round-trip — append the assistant
+`tool_calls` turn and a `role:'tool'` / `tool_result` message, then re-issue the
+request. External call ids are deterministic and prefixed `ext:`, so a stateless
+re-run correlates each returned result by id (the server extracts those turns
+into an `extId → result` map and strips them before re-planning). When several
+parallel DAG workers each emit an external call, they are collected into a single
+assistant turn carrying all the `ext:` `tool_calls`, so the client can run them
+together and answer in one follow-up.
+
+```jsonc
+// follow-up request after running ext:abc locally
+{
+  "messages": [
+    /* ...prior turns... */
+    { "role": "assistant", "tool_calls": [{ "id": "ext:abc", "type": "function",
+      "function": { "name": "get_weather", "arguments": "{\"city\":\"Kyiv\"}" } }] },
+    { "role": "tool", "tool_call_id": "ext:abc", "content": "sunny, 21C" }
+  ],
+  "tools": [ /* the same external tool declaration */ ]
+}
+```
+
 ## IMcpClient
 
 **File:** `packages/llm-agent/src/interfaces/mcp-client.ts`

--- a/packages/llm-agent-libs/src/__tests__/agent-hard-mode-external.test.ts
+++ b/packages/llm-agent-libs/src/__tests__/agent-hard-mode-external.test.ts
@@ -1,0 +1,102 @@
+/**
+ * D4 contract: flat (non-pipeline) SmartAgent in mode:'hard' must still offer
+ * client external tools in the tools[] sent to the LLM.
+ * Mode governs only INTERNAL (MCP) execution posture, not external tool surfacing.
+ */
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type {
+  LlmError,
+  LlmStreamChunk,
+  LlmTool,
+  Result,
+} from '@mcp-abap-adt/llm-agent';
+import { SmartAgent } from '../agent.js';
+import { makeDefaultDeps } from '../testing/index.js';
+
+const EXTERNAL_TOOL: LlmTool = {
+  name: 'client_write_file',
+  description: 'Write a file (client-provided)',
+  inputSchema: { type: 'object', properties: { path: { type: 'string' } } },
+};
+
+function makeSpyLlm() {
+  const capturedTools: LlmTool[][] = [];
+  const spy = {
+    capturedTools,
+    async chat() {
+      return {
+        ok: true as const,
+        value: { content: 'ok', finishReason: 'stop' as const },
+      };
+    },
+    async *streamChat(
+      _msgs: unknown,
+      tools?: LlmTool[],
+    ): AsyncIterable<Result<LlmStreamChunk, LlmError>> {
+      capturedTools.push(tools ?? []);
+      yield {
+        ok: true,
+        value: { content: 'done', finishReason: 'stop' as const },
+      };
+    },
+    async healthCheck() {
+      return { ok: true as const, value: true };
+    },
+  };
+  return spy;
+}
+
+describe('D4 — flat SmartAgent hard mode keeps client external tools', () => {
+  it('mode:hard — external tool IS included in tools[] sent to LLM', async () => {
+    const spy = makeSpyLlm();
+    const { deps } = makeDefaultDeps({ llmResponses: [{ content: 'unused' }] });
+    deps.mainLlm = spy;
+    // mode is a SmartAgent config option, not a per-request option
+    const agent = new SmartAgent(deps, { maxIterations: 5, mode: 'hard' });
+
+    const result = await agent.process('do something', {
+      externalTools: [EXTERNAL_TOOL],
+      sessionId: 'test-hard-d4',
+    });
+
+    assert.ok(result.ok, 'request should succeed');
+    assert.ok(
+      spy.capturedTools.length > 0,
+      'LLM streamChat should have been called at least once',
+    );
+
+    const firstCallTools = spy.capturedTools[0];
+    const externalToolNames = firstCallTools.map((t) => t.name);
+    assert.ok(
+      externalToolNames.includes(EXTERNAL_TOOL.name),
+      `External tool '${EXTERNAL_TOOL.name}' must be in tools[] in hard mode. Got: [${externalToolNames.join(', ')}]`,
+    );
+  });
+
+  it('mode:smart — external tool IS included in tools[] sent to LLM (control)', async () => {
+    const spy = makeSpyLlm();
+    const { deps } = makeDefaultDeps({ llmResponses: [{ content: 'unused' }] });
+    deps.mainLlm = spy;
+    // mode:smart is the default, external tools should always be included
+    const agent = new SmartAgent(deps, { maxIterations: 5, mode: 'smart' });
+
+    const result = await agent.process('do something', {
+      externalTools: [EXTERNAL_TOOL],
+      sessionId: 'test-smart-d4',
+    });
+
+    assert.ok(result.ok, 'request should succeed');
+    assert.ok(
+      spy.capturedTools.length > 0,
+      'LLM streamChat should have been called at least once',
+    );
+
+    const firstCallTools = spy.capturedTools[0];
+    const externalToolNames = firstCallTools.map((t) => t.name);
+    assert.ok(
+      externalToolNames.includes(EXTERNAL_TOOL.name),
+      `External tool '${EXTERNAL_TOOL.name}' must be in tools[] in smart mode. Got: [${externalToolNames.join(', ')}]`,
+    );
+  });
+});

--- a/packages/llm-agent-libs/src/__tests__/external-results-threading.test.ts
+++ b/packages/llm-agent-libs/src/__tests__/external-results-threading.test.ts
@@ -1,0 +1,102 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type {
+  DagPlan,
+  IInterpreter,
+  InterpretContext,
+  InterpretResult,
+  IPlanner,
+  ISubAgent,
+  ISubAgentInput,
+  ISubAgentResult,
+} from '@mcp-abap-adt/llm-agent';
+import { AbortErrorStrategy } from '../coordinator/dag/abort-error-strategy.js';
+import { DagPlanInterpreter } from '../coordinator/dag/dag-plan-interpreter.js';
+import { SessionRequestLogger } from '../logger/session-request-logger.js';
+import { DagCoordinatorHandler } from '../pipeline/handlers/dag-coordinator.js';
+
+function worker(
+  name: string,
+  run: (i: ISubAgentInput) => Promise<Partial<ISubAgentResult>>,
+): ISubAgent {
+  return {
+    name,
+    capabilities: { contextPolicy: 'optional' },
+    run: run as ISubAgent['run'],
+  } as ISubAgent;
+}
+
+const dag = (nodes: DagPlan['nodes']): DagPlan => ({ nodes, createdAt: 0 });
+
+describe('externalResults threading (#171, review#7)', () => {
+  it('interpret → worker.run: the same map reaches the worker input', async () => {
+    const map = new Map<string, string>([['ext:abc', 'RESULT']]);
+    let seen: Map<string, string> | undefined;
+    const w = worker('w', async (i) => {
+      seen = i.externalResults as Map<string, string> | undefined;
+      return { output: 'OK', status: 'complete' };
+    });
+    const ctx: InterpretContext = {
+      inputText: 'RAW',
+      workers: new Map([['w', w]]),
+      sessionId: 't',
+      errorStrategy: new AbortErrorStrategy(),
+      externalResults: map,
+    };
+    await new DagPlanInterpreter().interpret(
+      dag([{ id: 'a', goal: 'g', agent: 'w' }]),
+      ctx,
+    );
+    assert.equal(seen, map, 'worker received the SAME externalResults map');
+    assert.equal(seen?.get('ext:abc'), 'RESULT');
+  });
+
+  it('coordinator → interpret: ctx.externalResults reaches the InterpretContext', async () => {
+    const map = new Map<string, string>([['ext:xyz', 'R2']]);
+    let seenInterpret: Map<string, string> | undefined;
+    const planner: IPlanner = {
+      name: 'p',
+      async plan() {
+        return { plan: dag([{ id: 'a', goal: 'g' }]) };
+      },
+    };
+    const interpreter: IInterpreter<DagPlan, InterpretResult> = {
+      name: 'i',
+      async interpret(p, ictx) {
+        seenInterpret = ictx.externalResults as Map<string, string> | undefined;
+        return {
+          ok: true,
+          nodeResults: {
+            a: { nodeId: 'a', output: 'X', status: 'done', durationMs: 1 },
+          },
+          output: 'X',
+          executedPlan: p,
+          executionOrder: ['a'],
+        };
+      },
+    };
+    const w = worker('w', async () => ({ output: 'OK', status: 'complete' }));
+    const h = new DagCoordinatorHandler({
+      planner,
+      interpreter,
+      workers: new Map([['w', w]]),
+    });
+    const logger = new SessionRequestLogger();
+    logger.startRequest('t1');
+    const ctx = {
+      inputText: 'do thing',
+      sessionId: 's1',
+      history: [],
+      requestLogger: logger,
+      externalResults: map,
+      yield() {},
+      options: { trace: { traceId: 't1' } },
+    } as never;
+    await h.execute(ctx, {}, {} as never);
+    assert.equal(
+      seenInterpret,
+      map,
+      'interpret received the same map from ctx',
+    );
+  });
+});

--- a/packages/llm-agent-libs/src/agent.ts
+++ b/packages/llm-agent-libs/src/agent.ts
@@ -908,10 +908,9 @@ export class SmartAgent {
           ragResults: rerankedMap,
           tools: selectedMcpTools,
         };
-        finalTools =
-          mode === 'hard'
-            ? (selectedMcpTools as LlmTool[])
-            : [...(selectedMcpTools as LlmTool[]), ...externalTools];
+        // D4: external (client) tools are always offered regardless of mode;
+        // mode governs only the worker's INTERNAL execution posture.
+        finalTools = [...(selectedMcpTools as LlmTool[]), ...externalTools];
         opts?.sessionLogger?.logStep('external_tools_merge', {
           mode,
           mcpCount: selectedMcpTools.length,
@@ -1084,7 +1083,7 @@ export class SmartAgent {
         opts,
         rootSpan,
         sessionId,
-        mode === 'hard' ? [] : externalTools,
+        externalTools,
         finalTools,
         detectedAdapter,
       );

--- a/packages/llm-agent-libs/src/coordinator/dag/__tests__/dag-interpreter-external.test.ts
+++ b/packages/llm-agent-libs/src/coordinator/dag/__tests__/dag-interpreter-external.test.ts
@@ -1,0 +1,140 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type {
+  DagPlan,
+  InterpretContext,
+  ISubAgent,
+  ISubAgentInput,
+  ISubAgentResult,
+} from '@mcp-abap-adt/llm-agent';
+import { AbortErrorStrategy } from '../abort-error-strategy.js';
+import { DagPlanInterpreter } from '../dag-plan-interpreter.js';
+
+function worker(
+  name: string,
+  run: (i: ISubAgentInput) => Promise<Partial<ISubAgentResult>>,
+): ISubAgent {
+  return {
+    name,
+    capabilities: { contextPolicy: 'optional' },
+    run: run as ISubAgent['run'],
+  } as ISubAgent;
+}
+
+function ctx(workers: Array<[string, ISubAgent]>): InterpretContext {
+  return {
+    inputText: 'RAW',
+    workers: new Map(workers),
+    sessionId: 't',
+    errorStrategy: new AbortErrorStrategy(),
+  };
+}
+
+const dag = (nodes: DagPlan['nodes']): DagPlan => ({ nodes, createdAt: 0 });
+
+describe('DagPlanInterpreter external tool calls (#171)', () => {
+  const I = () => new DagPlanInterpreter();
+
+  it('collects pending external calls from two parallel awaiting-external nodes (FIFO topo order)', async () => {
+    const w = worker('w', async (i) => {
+      const id = i.task.includes('NODE_A') ? 'ext:a' : 'ext:b';
+      const tool = i.task.includes('NODE_A') ? 'create_file' : 'rag_add';
+      return {
+        output: '',
+        status: 'awaiting-external',
+        pendingExternalToolCalls: [{ id, name: tool, arguments: {} }],
+      };
+    });
+    const r = await I().interpret(
+      dag([
+        { id: 'a', goal: 'NODE_A', agent: 'w' },
+        { id: 'b', goal: 'NODE_B', agent: 'w' },
+      ]),
+      ctx([['w', w]]),
+    );
+    assert.equal(r.ok, true);
+    assert.equal(r.nodeResults.a.status, 'awaiting-external');
+    assert.equal(r.nodeResults.b.status, 'awaiting-external');
+    assert.deepEqual(
+      r.pendingExternalToolCalls?.map((c) => c.id),
+      ['ext:a', 'ext:b'],
+    );
+  });
+
+  it('mixed: one done + one awaiting-external — settles both, collects the one pending call', async () => {
+    const w = worker('w', async (i) => {
+      if (i.task.includes('NODE_A')) {
+        return { output: 'A-OUTPUT', status: 'complete' };
+      }
+      return {
+        output: '',
+        status: 'awaiting-external',
+        pendingExternalToolCalls: [
+          { id: 'ext:b', name: 'create_file', arguments: {} },
+        ],
+      };
+    });
+    const r = await I().interpret(
+      dag([
+        { id: 'a', goal: 'NODE_A', agent: 'w' },
+        { id: 'b', goal: 'NODE_B', agent: 'w' },
+      ]),
+      ctx([['w', w]]),
+    );
+    assert.equal(r.ok, true);
+    assert.equal(r.nodeResults.a.status, 'done');
+    assert.equal(r.nodeResults.a.output, 'A-OUTPUT');
+    assert.equal(r.nodeResults.b.status, 'awaiting-external');
+    assert.deepEqual(
+      r.pendingExternalToolCalls?.map((c) => c.id),
+      ['ext:b'],
+    );
+  });
+
+  it('dedupes pending calls by id', async () => {
+    const w = worker('w', async () => ({
+      output: '',
+      status: 'awaiting-external' as const,
+      pendingExternalToolCalls: [
+        { id: 'ext:dup', name: 'create_file', arguments: {} },
+      ],
+    }));
+    const r = await I().interpret(
+      dag([
+        { id: 'a', goal: 'NODE_A', agent: 'w' },
+        { id: 'b', goal: 'NODE_B', agent: 'w' },
+      ]),
+      ctx([['w', w]]),
+    );
+    assert.equal(r.ok, true);
+    assert.deepEqual(
+      r.pendingExternalToolCalls?.map((c) => c.id),
+      ['ext:dup'],
+    );
+  });
+
+  it('does not schedule dependents of an awaiting-external node (no real input yet)', async () => {
+    const w = worker('w', async (i) => {
+      if (i.task.includes('ROOT')) {
+        return {
+          output: '',
+          status: 'awaiting-external',
+          pendingExternalToolCalls: [
+            { id: 'ext:r', name: 'create_file', arguments: {} },
+          ],
+        };
+      }
+      return { output: 'CHILD', status: 'complete' };
+    });
+    const r = await I().interpret(
+      dag([
+        { id: 'root', goal: 'ROOT', agent: 'w' },
+        { id: 'child', goal: 'CHILD', agent: 'w', dependsOn: ['root'] },
+      ]),
+      ctx([['w', w]]),
+    );
+    assert.equal(r.ok, true);
+    assert.equal(r.nodeResults.root.status, 'awaiting-external');
+    assert.notEqual(r.nodeResults.child.status, 'done');
+  });
+});

--- a/packages/llm-agent-libs/src/coordinator/dag/__tests__/llm-dag-planner-external.test.ts
+++ b/packages/llm-agent-libs/src/coordinator/dag/__tests__/llm-dag-planner-external.test.ts
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { ILlm, PlannerInput } from '@mcp-abap-adt/llm-agent';
+import { LlmDagPlanner, parseDagPlan } from '../llm-dag-planner.js';
+
+function llm(content: string): ILlm {
+  return {
+    chat: async () => ({ ok: true, value: { content } }),
+  } as unknown as ILlm;
+}
+
+describe('LlmDagPlanner — bare external-tool requests (#171 obs 2c)', () => {
+  // A request that is purely "call external tool X with args Y" cannot be
+  // decomposed into an internal MCP action, so the planner LLM may return an
+  // empty node list. Without a fallback node, the DAG runs no worker and the
+  // request returns `(no response)`. The planner must instead emit at least
+  // one node so a worker runs, the worker LLM emits the external tool_call,
+  // and the #171 machinery surfaces it.
+  const externalInput: PlannerInput = {
+    prompt: 'call rag_add with collection=context and content=X',
+    agents: [{ name: 'w', description: 'general worker' }],
+    sessionId: 't',
+  };
+
+  it('emits at least one node when the LLM returns an empty plan', async () => {
+    // LLM decided it has nothing to decompose → empty nodes.
+    const p = await new LlmDagPlanner(llm('{"nodes":[]}')).plan(externalInput);
+    assert.ok(
+      p.plan.nodes.length >= 1,
+      'expected a fallback node so a worker runs',
+    );
+    // The fallback node must carry the user objective so the worker can emit
+    // the external call.
+    assert.match(p.plan.nodes[0].goal, /rag_add/);
+  });
+
+  it('still emits a node when the LLM omits the nodes field entirely', async () => {
+    const p = await new LlmDagPlanner(llm('{"objective":"O"}')).plan(
+      externalInput,
+    );
+    assert.ok(p.plan.nodes.length >= 1);
+  });
+
+  it('parseDagPlan still throws on empty nodes when no fallbackGoal is given', () => {
+    // Backwards-compat: the shared parser (used by the Stepper planner) must
+    // keep its strict no-nodes error when no fallback objective is supplied.
+    assert.throws(
+      () => parseDagPlan('{"nodes":[]}'),
+      /Planner returned no nodes/,
+    );
+  });
+});

--- a/packages/llm-agent-libs/src/coordinator/dag/dag-plan-interpreter.ts
+++ b/packages/llm-agent-libs/src/coordinator/dag/dag-plan-interpreter.ts
@@ -4,6 +4,7 @@ import type {
   InterpretContext,
   InterpretResult,
   ISubAgent,
+  LlmToolCall,
   NodeResult,
   PlanNode,
   StreamChunk,
@@ -29,6 +30,21 @@ export class DagPlanInterpreter
     const results: Record<string, NodeResult> = {};
     const done = new Set<string>();
     const executionOrder: string[] = [];
+    // #171: collect-all-at-settle. Accumulate external tool calls surfaced by
+    // awaiting-external nodes, preserving plan/topological wave order, deduped
+    // by deterministic `ext:` id. An awaiting-external node is recorded in
+    // `results` (so its wave excludes it) but NOT added to `done`, so its
+    // dependents never become ready and fall through to the skipped-assignment
+    // loop below — they re-run on resume once the client returns the result.
+    const pendingExternalAccumulator: LlmToolCall[] = [];
+    const seenExternalIds = new Set<string>();
+    const collectExternal = (calls: readonly LlmToolCall[] | undefined) => {
+      for (const call of calls ?? []) {
+        if (seenExternalIds.has(call.id)) continue;
+        seenExternalIds.add(call.id);
+        pendingExternalAccumulator.push(call);
+      }
+    };
     let currentPlan = plan;
     const maxReplans = ctx.errorStrategy.maxReplans ?? 4;
     let replansUsed = 0;
@@ -42,6 +58,12 @@ export class DagPlanInterpreter
 
       type Outcome =
         | { node: PlanNode; kind: 'done'; output: string; durationMs: number }
+        | {
+            node: PlanNode;
+            kind: 'awaiting-external';
+            pendingExternalToolCalls: LlmToolCall[];
+            durationMs: number;
+          }
         | {
             node: PlanNode;
             kind: 'failed';
@@ -105,6 +127,21 @@ export class DagPlanInterpreter
                 durationMs: Date.now() - started,
               };
             }
+            if (res.status === 'awaiting-external') {
+              // #171: the worker surfaced a client external tool call and is
+              // waiting for its result. Not a failure — settle as awaiting.
+              outerOnPartial?.({
+                kind: 'stepper-done',
+                source: { stepperId: n.id, name: n.id },
+                ok: true,
+              });
+              return {
+                node: n,
+                kind: 'awaiting-external',
+                pendingExternalToolCalls: res.pendingExternalToolCalls ?? [],
+                durationMs: Date.now() - started,
+              };
+            }
             outerOnPartial?.({
               kind: 'stepper-done',
               source: { stepperId: n.id, name: n.id },
@@ -145,6 +182,21 @@ export class DagPlanInterpreter
         };
         done.add(o.node.id);
         executionOrder.push(o.node.id);
+      }
+      // #171: record awaiting-external nodes in wave (plan/topo) order. They go
+      // into `results` so the next wave's `ready` filter excludes them, but are
+      // intentionally NOT added to `done` — so their dependents never become
+      // ready this run and fall through to the skipped-assignment loop.
+      for (const o of outcomes) {
+        if (o.kind !== 'awaiting-external') continue;
+        results[o.node.id] = {
+          nodeId: o.node.id,
+          output: '',
+          status: 'awaiting-external',
+          durationMs: o.durationMs,
+        };
+        executionOrder.push(o.node.id);
+        collectExternal(o.pendingExternalToolCalls);
       }
       const failures = outcomes.filter(
         (o): o is Extract<Outcome, { kind: 'failed' }> => o.kind === 'failed',
@@ -197,6 +249,28 @@ export class DagPlanInterpreter
           durationMs: 0,
         };
       }
+    }
+
+    // #171: an awaiting-external run is NOT a failure. If at least one node is
+    // awaiting-external and no node actually failed, settle as ok=true and let
+    // the coordinator branch on pendingExternalToolCalls (Task 6). Dependents of
+    // awaiting nodes are 'skipped' this run and re-run on resume; they must not
+    // be counted as failures here.
+    const anyAwaiting = currentPlan.nodes.some(
+      (n) => results[n.id].status === 'awaiting-external',
+    );
+    const anyFailed = currentPlan.nodes.some(
+      (n) => results[n.id].status === 'failed',
+    );
+    if (anyAwaiting && !anyFailed) {
+      return {
+        nodeResults: results,
+        ok: true,
+        output: '',
+        executedPlan: currentPlan,
+        executionOrder,
+        pendingExternalToolCalls: pendingExternalAccumulator,
+      };
     }
 
     const failed = currentPlan.nodes.filter(

--- a/packages/llm-agent-libs/src/coordinator/dag/dag-plan-interpreter.ts
+++ b/packages/llm-agent-libs/src/coordinator/dag/dag-plan-interpreter.ts
@@ -112,6 +112,9 @@ export class DagPlanInterpreter
               onPartial: workerOnPartial,
               // Issue #167: thread client external tools into the worker.
               externalTools: ctx.externalTools,
+              // #171 (review#7): thread the validated extId→result map so a
+              // re-surfaced external call resolves from history on resume.
+              externalResults: ctx.externalResults,
             });
             if (res.errorClass === 'epicfail') {
               outerOnPartial?.({

--- a/packages/llm-agent-libs/src/coordinator/dag/llm-dag-planner.ts
+++ b/packages/llm-agent-libs/src/coordinator/dag/llm-dag-planner.ts
@@ -53,8 +53,21 @@ Emit a plan-level "objective". Respond with ONLY one of:
  * Throws `NeedInfoSignal`, `ClarifySignal`, or plain `Error` on bad input.
  * The optional `usage` argument is attached to thrown errors so callers can
  * still bill LLM spend even when parsing fails.
+ *
+ * When `fallbackGoal` is supplied and the LLM returns a structurally valid
+ * plan with ZERO nodes (and no needInfo/clarify), the parser synthesizes a
+ * single fallback node carrying that goal instead of throwing. This is the
+ * #171 obs-2c fix: a bare "call external tool X" request cannot be decomposed
+ * into an internal MCP action, so the LLM may legitimately emit no nodes — but
+ * the DAG must still run ONE worker so the worker LLM can emit the external
+ * tool_call that the #171 surfacing machinery then handles. Callers that want
+ * the strict no-nodes error (e.g. the Stepper planner) simply omit it.
  */
-export function parseDagPlan(content: string, usage?: LlmUsage): DagPlan {
+export function parseDagPlan(
+  content: string,
+  usage?: LlmUsage,
+  fallbackGoal?: string,
+): DagPlan {
   const match = content.match(/\{[\s\S]*\}/);
   if (!match)
     throw withUsage(
@@ -93,10 +106,18 @@ export function parseDagPlan(content: string, usage?: LlmUsage): DagPlan {
     throw new ClarifySignal(parsed.clarify, usage);
   }
   if (!Array.isArray(parsed.nodes) || parsed.nodes.length === 0) {
-    throw withUsage(
-      new Error(`Planner returned no nodes: ${match[0].slice(0, 200)}`),
-      usage,
-    );
+    // #171 obs 2c: rather than yield an empty plan (→ no worker → `(no
+    // response)`), synthesize a single node carrying the user objective so a
+    // worker always runs. Only when a fallbackGoal was supplied AND the LLM
+    // did not request needInfo/clarify (handled above).
+    if (fallbackGoal?.trim()) {
+      parsed.nodes = [{ id: 'n1', goal: fallbackGoal }];
+    } else {
+      throw withUsage(
+        new Error(`Planner returned no nodes: ${match[0].slice(0, 200)}`),
+        usage,
+      );
+    }
   }
   if (parsed.objective !== undefined && typeof parsed.objective !== 'string') {
     throw withUsage(
@@ -218,7 +239,11 @@ export class LlmDagPlanner implements IPlanner {
     // parseDagPlan throws NeedInfoSignal / ClarifySignal / parse errors,
     // forwarding res.usage so the coordinator can attribute planner-LLM spend
     // even when the role short-circuits.
-    const plan = parseDagPlan(res.output, res.usage);
+    // Pass the user prompt as a fallback objective: if the LLM cannot
+    // decompose the request (e.g. a bare "call external tool X") and returns
+    // zero nodes, parseDagPlan synthesizes one node carrying the prompt so a
+    // worker still runs and can surface the external tool_call (#171 obs 2c).
+    const plan = parseDagPlan(res.output, res.usage, input.prompt);
     return {
       plan,
       // Forward the underlying ILlm.chat usage on the WRAPPER (not on the

--- a/packages/llm-agent-libs/src/pipeline/context.ts
+++ b/packages/llm-agent-libs/src/pipeline/context.ts
@@ -139,6 +139,15 @@ export interface PipelineContext {
   selectedTools: LlmTool[];
   /** External tools provided by the client. */
   externalTools: LlmTool[];
+  /**
+   * Results for previously-surfaced external (client-executed) tool calls,
+   * keyed by deterministic `externalToolCallId(name, args)` (spec D1). Built by
+   * the coordinator from the incoming history on a stateless resume. When the
+   * worker LLM re-emits an external call whose `extId` is present here, the
+   * tool-loop injects the result as a matched assistant→tool pair and CONTINUES
+   * instead of re-surfacing it. Absent on a first request.
+   */
+  externalResults?: Map<string, string>;
   /** Final assembled messages for LLM input. */
   assembledMessages: Message[];
   /** Currently active tools (after availability filtering). */

--- a/packages/llm-agent-libs/src/pipeline/default-pipeline.ts
+++ b/packages/llm-agent-libs/src/pipeline/default-pipeline.ts
@@ -506,6 +506,13 @@ export class DefaultPipeline implements IPipeline {
       mcpTools: [],
       selectedTools: [],
       externalTools: externalTools ?? [],
+      // #171 (review#7): the validated `extId → result` map built at the server
+      // boundary is threaded down via AgentCallOptions; the worker tool-loop
+      // reads ctx.externalResults to resolve a re-surfaced external call from
+      // history on stateless resume. Typed as CallOptions here (the field lives
+      // on AgentCallOptions, structurally present at runtime).
+      externalResults: (options as { externalResults?: Map<string, string> })
+        ?.externalResults,
       assembledMessages: [],
       activeTools: [],
       selectedSkills: [],

--- a/packages/llm-agent-libs/src/pipeline/handlers/__tests__/dag-coordinator-external.test.ts
+++ b/packages/llm-agent-libs/src/pipeline/handlers/__tests__/dag-coordinator-external.test.ts
@@ -140,6 +140,60 @@ test('no-finalizer branch: pending external tool calls yield a tool_calls turn a
   assert.ok(terminal, 'expected terminal finishReason=tool_calls chunk');
 });
 
+test('regression #171: two pending external calls get distinct indices [0,1], not [0,0]', async () => {
+  const pending: LlmToolCall[] = [
+    { id: 'ext:aaa111', name: 'rag_add', arguments: { a: 1 } },
+    { id: 'ext:bbb222', name: 'rag_add', arguments: { b: 2 } },
+  ];
+  const h = new DagCoordinatorHandler({
+    planner,
+    interpreter: pendingInterpreter(pending),
+    workers: new Map([['w', worker]]),
+  });
+  const { ctx, yields } = makeCtx();
+  await h.execute(ctx, {}, {} as never);
+
+  // Find the toolCalls chunk.
+  const tcYield = yields.find(
+    (y) =>
+      Array.isArray(y.value.toolCalls) &&
+      (y.value.toolCalls as unknown[]).length > 0,
+  );
+  assert.ok(tcYield, 'expected a chunk carrying toolCalls');
+
+  const calls = tcYield.value.toolCalls as Array<{
+    index: number;
+    id: string;
+    name: string;
+    arguments: string;
+  }>;
+  assert.equal(calls.length, 2, 'both external calls must be surfaced');
+
+  // Regression: with the old bug both entries had index 0 (all-0). Now they
+  // must be mapped by array position.
+  const indices = calls.map((c) => c.index);
+  assert.deepEqual(
+    indices,
+    [0, 1],
+    `expected distinct indices [0,1], got ${JSON.stringify(indices)}`,
+  );
+
+  const ids = calls.map((c) => c.id);
+  assert.deepEqual(
+    ids,
+    ['ext:aaa111', 'ext:bbb222'],
+    `expected ids in order, got ${JSON.stringify(ids)}`,
+  );
+
+  // Arguments serialised correctly.
+  assert.equal(calls[0].arguments, JSON.stringify({ a: 1 }));
+  assert.equal(calls[1].arguments, JSON.stringify({ b: 2 }));
+
+  // Terminal chunk present.
+  const terminal = yields.find((y) => y.value.finishReason === 'tool_calls');
+  assert.ok(terminal, 'expected terminal finishReason=tool_calls chunk');
+});
+
 test('no-finalizer branch: empty pending → finalizer IS invoked (existing path)', async () => {
   let finalizeCalls = 0;
   const finalizer: IFinalizer = {

--- a/packages/llm-agent-libs/src/pipeline/handlers/__tests__/dag-coordinator-external.test.ts
+++ b/packages/llm-agent-libs/src/pipeline/handlers/__tests__/dag-coordinator-external.test.ts
@@ -1,0 +1,171 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import type {
+  DagPlan,
+  IFinalizer,
+  IInterpreter,
+  InterpretResult,
+  IPlanner,
+  ISubAgent,
+  LlmToolCall,
+} from '@mcp-abap-adt/llm-agent';
+import { SessionRequestLogger } from '../../../logger/session-request-logger.js';
+import { DagCoordinatorHandler } from '../dag-coordinator.js';
+
+function plan(): DagPlan {
+  return {
+    objective: 'plan-obj',
+    nodes: [{ id: 'a', goal: 'ga' }],
+    createdAt: 0,
+  };
+}
+
+const planner: IPlanner = {
+  name: 'p',
+  async plan() {
+    return { plan: plan() };
+  },
+};
+
+const worker: ISubAgent = {
+  name: 'w',
+  description: 'd',
+  capabilities: { contextPolicy: 'optional' },
+  async run() {
+    return { output: 'unused' };
+  },
+};
+
+function makeCtx() {
+  const yields: Array<{ ok: boolean; value: Record<string, unknown> }> = [];
+  const logger = new SessionRequestLogger();
+  logger.startRequest('t1');
+  return {
+    yields,
+    ctx: {
+      inputText: 'do thing',
+      sessionId: 's1',
+      history: [],
+      requestLogger: logger,
+      yield(chunk: { ok: boolean; value: Record<string, unknown> }) {
+        yields.push(chunk);
+      },
+      options: { trace: { traceId: 't1' } },
+    } as never,
+  };
+}
+
+function pendingInterpreter(
+  pending: LlmToolCall[],
+): IInterpreter<DagPlan, InterpretResult> {
+  return {
+    name: 'i',
+    async interpret(p) {
+      return {
+        ok: true,
+        nodeResults: {
+          a: {
+            nodeId: 'a',
+            output: '',
+            status: 'awaiting-external',
+            durationMs: 1,
+          },
+        },
+        output: '',
+        executedPlan: p,
+        executionOrder: ['a'],
+        pendingExternalToolCalls: pending,
+      };
+    },
+  };
+}
+
+const completeInterpreter: IInterpreter<DagPlan, InterpretResult> = {
+  name: 'i',
+  async interpret(p) {
+    return {
+      ok: true,
+      nodeResults: {
+        a: { nodeId: 'a', output: 'A-OUT', status: 'done', durationMs: 1 },
+      },
+      output: 'A-OUT',
+      executedPlan: p,
+      executionOrder: ['a'],
+    };
+  },
+};
+
+test('no-finalizer branch: pending external tool calls yield a tool_calls turn and SKIP the finalizer', async () => {
+  let finalizeCalls = 0;
+  const finalizer: IFinalizer = {
+    name: 'spy',
+    async finalize() {
+      finalizeCalls++;
+      return { output: 'SHOULD-NOT-RUN' };
+    },
+  };
+  const pending: LlmToolCall[] = [
+    { id: 'ext:abc123', name: 'rag_add', arguments: { content: 'hi' } },
+  ];
+  const h = new DagCoordinatorHandler({
+    planner,
+    interpreter: pendingInterpreter(pending),
+    workers: new Map([['w', worker]]),
+    finalizer,
+  });
+  const { ctx, yields } = makeCtx();
+  await h.execute(ctx, {}, {} as never);
+
+  assert.equal(finalizeCalls, 0, 'finalizer must NOT be invoked');
+
+  // First the tool_calls chunk carrying the external call (wire delta shape).
+  const tcYield = yields.find(
+    (y) => Array.isArray(y.value.toolCalls) && y.value.toolCalls.length > 0,
+  );
+  assert.ok(tcYield, 'expected a chunk carrying toolCalls');
+  const tc = (
+    tcYield.value.toolCalls as Array<{
+      index: number;
+      id: string;
+      name: string;
+      arguments: string;
+    }>
+  )[0];
+  assert.equal(tc.id, 'ext:abc123');
+  assert.equal(tc.name, 'rag_add');
+  assert.equal(tc.arguments, JSON.stringify({ content: 'hi' }));
+
+  // Then the terminal tool_calls finishReason chunk.
+  const terminal = yields.find((y) => y.value.finishReason === 'tool_calls');
+  assert.ok(terminal, 'expected terminal finishReason=tool_calls chunk');
+});
+
+test('no-finalizer branch: empty pending → finalizer IS invoked (existing path)', async () => {
+  let finalizeCalls = 0;
+  const finalizer: IFinalizer = {
+    name: 'spy',
+    async finalize(input) {
+      finalizeCalls++;
+      input.onPartial?.({ kind: 'content', delta: 'FINAL' });
+      return { output: 'FINAL' };
+    },
+  };
+  const h = new DagCoordinatorHandler({
+    planner,
+    interpreter: completeInterpreter,
+    workers: new Map([['w', worker]]),
+    finalizer,
+  });
+  const { ctx, yields } = makeCtx();
+  await h.execute(ctx, {}, {} as never);
+
+  assert.equal(
+    finalizeCalls,
+    1,
+    'finalizer must be invoked on the normal path',
+  );
+  const contentYield = yields.find(
+    (y) => y.value.content && y.value.finishReason !== 'stop',
+  );
+  assert.equal(contentYield?.value.content, 'FINAL');
+});

--- a/packages/llm-agent-libs/src/pipeline/handlers/__tests__/tool-loop-external.test.ts
+++ b/packages/llm-agent-libs/src/pipeline/handlers/__tests__/tool-loop-external.test.ts
@@ -293,6 +293,89 @@ test('miss: external call ends the turn with rewritten extId, not executed', asy
   assert.ok(terminal, 'terminal finishReason tool_calls chunk yielded');
 });
 
+test('regression #171: two external-miss calls get distinct indices [0,1], not [0,0]', async () => {
+  const args0 = { a: 1 };
+  const args1 = { b: 2 };
+  const extId0 = externalToolCallId('rag_add', args0);
+  const extId1 = externalToolCallId('rag_add', args1);
+
+  // Stream emits both calls in a single delta chunk then finishes with tool_calls.
+  const twoExternalStream: () => AsyncIterable<
+    Result<LlmStreamChunk, LlmError>
+  > = async function* () {
+    yield {
+      ok: true,
+      value: {
+        content: '',
+        toolCalls: [
+          {
+            index: 0,
+            id: 'raw_0',
+            name: 'rag_add',
+            arguments: JSON.stringify(args0),
+          },
+          {
+            index: 1,
+            id: 'raw_1',
+            name: 'rag_add',
+            arguments: JSON.stringify(args1),
+          },
+        ],
+      },
+    } as Result<LlmStreamChunk, LlmError>;
+    yield {
+      ok: true,
+      value: {
+        content: '',
+        finishReason: 'tool_calls',
+        usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+      },
+    } as Result<LlmStreamChunk, LlmError>;
+  };
+
+  const { ctx, yielded } = makeCtx({
+    mode: 'smart',
+    externalTools: [RAG_ADD],
+    streams: [twoExternalStream],
+  });
+
+  const ok = await new ToolLoopHandler().execute(ctx, {}, makeSpan());
+  assert.equal(ok, true);
+
+  // Find the toolCalls chunk surfaced by the miss path.
+  const callChunks = yielded.filter(
+    (c) => c.ok && Array.isArray((c.value as LlmStreamChunk).toolCalls),
+  ) as Array<Result<LlmStreamChunk, unknown>>;
+  assert.ok(callChunks.length >= 1, 'an external toolCalls chunk was yielded');
+
+  const calls = (callChunks[0].value as LlmStreamChunk).toolCalls ?? [];
+  assert.equal(calls.length, 2, 'both external calls must be surfaced');
+
+  // Regression: with the old bug both entries had index 0 (all-0). Now they
+  // must be mapped by array position.
+  const indices = calls.map((c) => (c as { index: number }).index);
+  assert.deepEqual(
+    indices,
+    [0, 1],
+    `expected distinct indices [0,1], got ${JSON.stringify(indices)}`,
+  );
+
+  const ids = calls.map((c) => (c as { id?: string }).id);
+  assert.ok(
+    ids.includes(extId0),
+    `first call must carry extId for args0 (${extId0})`,
+  );
+  assert.ok(
+    ids.includes(extId1),
+    `second call must carry extId for args1 (${extId1})`,
+  );
+
+  const terminal = yielded.find(
+    (c) => c.ok && (c.value as LlmStreamChunk).finishReason === 'tool_calls',
+  );
+  assert.ok(terminal, 'terminal finishReason tool_calls chunk yielded');
+});
+
 test('hit: matched pair injected, loop continues, no external chunk leaked', async () => {
   const args = { content: 'hello' };
   const extId = externalToolCallId('rag_add', args);

--- a/packages/llm-agent-libs/src/pipeline/handlers/__tests__/tool-loop-external.test.ts
+++ b/packages/llm-agent-libs/src/pipeline/handlers/__tests__/tool-loop-external.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Task 4 (#171) — tool-loop surfaces external (client-provided) tool calls.
+ *
+ * Verifies:
+ *  1. `mode: 'hard'` still OFFERS external tools to the LLM (no drop).
+ *  2. Miss (no externalResults entry): the worker turn ENDS with
+ *     finishReason 'tool_calls', yielding the external call with its id
+ *     rewritten to externalToolCallId(name, args); the tool is NOT executed.
+ *  3. Hit (externalResults has extId): the worker conversation gets a matched
+ *     assistant(tool_calls=[extId]) -> tool(tool_call_id=extId) pair and the
+ *     loop CONTINUES; NO client-facing toolCalls chunk is yielded for the call.
+ */
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import type {
+  CallOptions,
+  ILlm,
+  IRequestLogger,
+  LlmCallEntry,
+  LlmError,
+  LlmResponse,
+  LlmStreamChunk,
+  LlmTool,
+  Message,
+  OnPartial,
+  RagQueryEntry,
+  RequestSummary,
+  Result,
+  ToolCallEntry,
+} from '@mcp-abap-adt/llm-agent';
+import { externalToolCallId, NoopToolCache } from '@mcp-abap-adt/llm-agent';
+import { PendingToolResultsRegistry } from '../../../policy/pending-tool-results-registry.js';
+import { ToolAvailabilityRegistry } from '../../../policy/tool-availability-registry.js';
+import type { ISpan } from '../../../tracer/types.js';
+import type { PipelineContext } from '../../context.js';
+import { ToolLoopHandler } from '../tool-loop.js';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+class NoopLogger implements IRequestLogger {
+  logLlmCall(_e: LlmCallEntry): void {}
+  logRagQuery(_e: RagQueryEntry): void {}
+  logToolCall(_e: ToolCallEntry): void {}
+  startRequest(): void {}
+  endRequest(): void {}
+  dropRequest(): void {}
+  getSummary(): RequestSummary {
+    return {
+      byModel: {},
+      byComponent: {},
+      byCategory: {},
+      ragQueries: 0,
+      toolCalls: 0,
+      totalDurationMs: 0,
+    };
+  }
+  reset(): void {}
+}
+
+function makeSpan(): ISpan {
+  return {
+    name: 's',
+    setAttribute() {},
+    setStatus() {},
+    addEvent() {},
+    end() {},
+  } as unknown as ISpan;
+}
+
+interface CapturedCall {
+  messages: Message[];
+  tools: LlmTool[];
+}
+
+const RAG_ADD: LlmTool = {
+  name: 'rag_add',
+  description: '[client-provided] add to rag',
+  parameters: { type: 'object', properties: {} },
+} as unknown as LlmTool;
+
+/**
+ * Builds a ctx whose llmCallStrategy returns the i-th programmed stream on the
+ * i-th call, capturing the (messages, tools) of each call.
+ */
+function makeCtx(opts: {
+  mode?: 'smart' | 'hard';
+  externalTools?: LlmTool[];
+  externalResults?: Map<string, string>;
+  streams: Array<() => AsyncIterable<Result<LlmStreamChunk, LlmError>>>;
+  onPartial?: OnPartial;
+}): {
+  ctx: PipelineContext;
+  captured: CapturedCall[];
+  yielded: Result<LlmStreamChunk, unknown>[];
+} {
+  const captured: CapturedCall[] = [];
+  const yielded: Result<LlmStreamChunk, unknown>[] = [];
+  let callIdx = 0;
+
+  const mainLlm: ILlm = {
+    model: 'stub-model',
+    async chat(): Promise<Result<LlmResponse, LlmError>> {
+      return {
+        ok: true,
+        value: { content: '', finishReason: 'stop' } as LlmResponse,
+      };
+    },
+    streamChat: () => opts.streams[0](),
+  };
+
+  const ctx = {
+    config: {
+      maxIterations: 5,
+      maxToolCalls: 5,
+      heartbeatIntervalMs: 5000,
+      mode: opts.mode ?? 'smart',
+      refreshToolsPerIteration: false,
+    } as PipelineContext['config'],
+    options: {} as CallOptions,
+    sessionId: 's-ext',
+    mcpClients: [],
+    mainLlm,
+    inputText: '',
+    history: [] as Message[],
+    assembledMessages: [
+      { role: 'system', content: 'sys' } as Message,
+      { role: 'user', content: 'hi' } as Message,
+    ],
+    activeTools: (opts.externalTools ?? []) as LlmTool[],
+    externalTools: (opts.externalTools ?? []) as LlmTool[],
+    externalResults: opts.externalResults,
+    selectedTools: [] as LlmTool[],
+    mcpTools: [],
+    toolClientMap: new Map(),
+    toolCache: new NoopToolCache(),
+    ragStores: {},
+    timing: [],
+    pendingToolResults: new PendingToolResultsRegistry(),
+    toolAvailabilityRegistry: new ToolAvailabilityRegistry(),
+    requestLogger: new NoopLogger(),
+    metrics: {
+      llmCallCount: { add() {} },
+      llmCallLatency: { record() {} },
+      toolCallCount: { add() {} },
+      toolCacheHitCount: { add() {} },
+    } as unknown as PipelineContext['metrics'],
+    tracer: {
+      startSpan: () => makeSpan(),
+    } as unknown as PipelineContext['tracer'],
+    sessionManager: {
+      addTokens() {},
+      isOverBudget: () => false,
+      reset() {},
+      totalTokens: 0,
+    } as unknown as PipelineContext['sessionManager'],
+    outputValidator: {
+      async validate() {
+        return { ok: true, value: { valid: true } };
+      },
+    } as unknown as PipelineContext['outputValidator'],
+    llmCallStrategy: {
+      call: (
+        _llm: ILlm,
+        msgs: Message[],
+        tools: LlmTool[],
+        _o?: CallOptions,
+      ) => {
+        captured.push({ messages: msgs, tools });
+        const fn =
+          opts.streams[callIdx] ?? opts.streams[opts.streams.length - 1];
+        callIdx += 1;
+        return fn();
+      },
+    } as unknown as PipelineContext['llmCallStrategy'],
+    onPartial: opts.onPartial,
+    yield(chunk: Result<LlmStreamChunk, unknown>) {
+      yielded.push(chunk);
+    },
+  } as unknown as PipelineContext;
+
+  return { ctx, captured, yielded };
+}
+
+/** A stream that emits a single external tool_call delta then finishes. */
+function externalCallStream(
+  name: string,
+  args: Record<string, unknown>,
+  rawId = 'call_raw',
+): () => AsyncIterable<Result<LlmStreamChunk, LlmError>> {
+  return async function* () {
+    yield {
+      ok: true,
+      value: {
+        content: '',
+        toolCalls: [
+          { index: 0, id: rawId, name, arguments: JSON.stringify(args) },
+        ],
+      },
+    } as Result<LlmStreamChunk, LlmError>;
+    yield {
+      ok: true,
+      value: {
+        content: '',
+        finishReason: 'tool_calls',
+        usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+      },
+    } as Result<LlmStreamChunk, LlmError>;
+  };
+}
+
+/** A plain stream that finishes with stop. */
+function stopStream(
+  content = 'done',
+): () => AsyncIterable<Result<LlmStreamChunk, LlmError>> {
+  return async function* () {
+    yield {
+      ok: true,
+      value: {
+        content,
+        finishReason: 'stop',
+        usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+      },
+    } as Result<LlmStreamChunk, LlmError>;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test('hard mode still offers external tools to the LLM', async () => {
+  const args = { content: 'x' };
+  const { ctx, captured } = makeCtx({
+    mode: 'hard',
+    externalTools: [RAG_ADD],
+    streams: [externalCallStream('rag_add', args)],
+  });
+
+  await new ToolLoopHandler().execute(ctx, {}, makeSpan());
+
+  assert.ok(captured.length >= 1, 'at least one LLM call');
+  const toolNames = captured[0].tools.map((t) => t.name);
+  assert.ok(
+    toolNames.includes('rag_add'),
+    `hard mode must offer external tools, got: ${toolNames.join(',')}`,
+  );
+});
+
+test('miss: external call ends the turn with rewritten extId, not executed', async () => {
+  const args = { content: 'hello' };
+  const extId = externalToolCallId('rag_add', args);
+  let toolExecuted = false;
+
+  const { ctx, yielded } = makeCtx({
+    mode: 'smart',
+    externalTools: [RAG_ADD],
+    streams: [externalCallStream('rag_add', args)],
+  });
+  // Spy: if a client were registered we'd see execution. rag_add is NOT in
+  // toolClientMap, so it can never be executed; assert no tool result chunk.
+  ctx.toolCache = {
+    get() {
+      toolExecuted = true;
+      return undefined;
+    },
+    set() {},
+  } as unknown as PipelineContext['toolCache'];
+
+  const ok = await new ToolLoopHandler().execute(ctx, {}, makeSpan());
+  assert.equal(ok, true);
+  assert.equal(toolExecuted, false, 'external tool must not be executed');
+
+  // Find the toolCalls chunk and the terminal chunk.
+  const callChunks = yielded.filter(
+    (c) => c.ok && Array.isArray((c.value as LlmStreamChunk).toolCalls),
+  ) as Array<Result<LlmStreamChunk, unknown>>;
+  assert.ok(callChunks.length >= 1, 'an external toolCalls chunk was yielded');
+  const calls = (callChunks[0].value as LlmStreamChunk).toolCalls ?? [];
+  const ids = calls.map((c) =>
+    'id' in c ? (c as { id?: string }).id : undefined,
+  );
+  assert.ok(
+    ids.includes(extId),
+    `surfaced call carries extId ${extId}, got ${JSON.stringify(ids)}`,
+  );
+
+  const terminal = yielded.find(
+    (c) => c.ok && (c.value as LlmStreamChunk).finishReason === 'tool_calls',
+  );
+  assert.ok(terminal, 'terminal finishReason tool_calls chunk yielded');
+});
+
+test('hit: matched pair injected, loop continues, no external chunk leaked', async () => {
+  const args = { content: 'hello' };
+  const extId = externalToolCallId('rag_add', args);
+
+  const { ctx, captured, yielded } = makeCtx({
+    mode: 'smart',
+    externalTools: [RAG_ADD],
+    externalResults: new Map([[extId, 'RESULT']]),
+    streams: [externalCallStream('rag_add', args), stopStream('final')],
+  });
+
+  const ok = await new ToolLoopHandler().execute(ctx, {}, makeSpan());
+  assert.equal(ok, true);
+
+  // (a) The SECOND LLM call's messages contain the adjacent matched pair.
+  assert.ok(captured.length >= 2, 'loop continued to a second LLM call');
+  const msgs = captured[1].messages;
+  let foundPair = false;
+  for (let i = 0; i < msgs.length - 1; i++) {
+    const a = msgs[i] as Message & {
+      tool_calls?: Array<{ id: string }>;
+    };
+    const t = msgs[i + 1] as Message & { tool_call_id?: string };
+    if (
+      a.role === 'assistant' &&
+      Array.isArray(a.tool_calls) &&
+      a.tool_calls.some((tc) => tc.id === extId) &&
+      t.role === 'tool' &&
+      t.tool_call_id === extId
+    ) {
+      foundPair = true;
+      assert.equal(t.content, 'RESULT', 'tool message carries the result');
+    }
+  }
+  assert.ok(
+    foundPair,
+    'adjacent assistant(tool_calls=[extId]) -> tool(tool_call_id=extId) pair present',
+  );
+
+  // (b) NO client-facing external toolCalls chunk was yielded for the resumed call.
+  const leaked = yielded.filter((c) => {
+    if (!c.ok) return false;
+    const v = c.value as LlmStreamChunk;
+    return (
+      Array.isArray(v.toolCalls) &&
+      v.toolCalls.some(
+        (tc) => 'id' in tc && (tc as { id?: string }).id === extId,
+      )
+    );
+  });
+  assert.equal(leaked.length, 0, 'resumed external call must NOT be surfaced');
+});

--- a/packages/llm-agent-libs/src/pipeline/handlers/dag-coordinator.ts
+++ b/packages/llm-agent-libs/src/pipeline/handlers/dag-coordinator.ts
@@ -362,8 +362,8 @@ export class DagCoordinatorHandler implements IStageHandler {
               ok: true,
               value: {
                 content: '',
-                toolCalls: result.pendingExternalToolCalls.map((tc) => ({
-                  index: 0,
+                toolCalls: result.pendingExternalToolCalls.map((tc, index) => ({
+                  index,
                   id: tc.id,
                   name: tc.name,
                   arguments: JSON.stringify(tc.arguments),

--- a/packages/llm-agent-libs/src/pipeline/handlers/dag-coordinator.ts
+++ b/packages/llm-agent-libs/src/pipeline/handlers/dag-coordinator.ts
@@ -331,6 +331,9 @@ export class DagCoordinatorHandler implements IStageHandler {
             onPartial: interpreterOnPartial,
             // Issue #167: thread the client's external tools into worker dispatch.
             externalTools: ctx.externalTools,
+            // #171 (review#7): thread the validated extId→result map so a
+            // re-surfaced external call resolves from history on resume.
+            externalResults: ctx.externalResults,
           });
         } catch (err) {
           ctx.error =
@@ -344,6 +347,43 @@ export class DagCoordinatorHandler implements IStageHandler {
         }
 
         if (result.ok) {
+          // #171 (D2): no-finalizer branch. If the run settled with pending
+          // external (client-executed) tool calls, end the turn carrying those
+          // calls as a standard `tool_calls` assistant turn — the consumer runs
+          // them and re-sends results (stateless round-trip). Do NOT run the
+          // finalizer. The wire toolCalls shape matches the tool-loop's external
+          // surface yield (LlmToolCallDelta: index/id/name/arguments-as-string).
+          if (result.pendingExternalToolCalls?.length) {
+            ctx.options?.sessionLogger?.logStep('dag_coordinator_external', {
+              count: result.pendingExternalToolCalls.length,
+              ids: result.pendingExternalToolCalls.map((c) => c.id),
+            });
+            ctx.yield({
+              ok: true,
+              value: {
+                content: '',
+                toolCalls: result.pendingExternalToolCalls.map((tc) => ({
+                  index: 0,
+                  id: tc.id,
+                  name: tc.name,
+                  arguments: JSON.stringify(tc.arguments),
+                })),
+              },
+            });
+            const traceIdExt = ctx.options?.trace?.traceId;
+            const usageExt = traceIdExt
+              ? summaryToUsage(ctx.requestLogger.getSummary(traceIdExt))
+              : undefined;
+            ctx.yield({
+              ok: true,
+              value: {
+                content: '',
+                finishReason: 'tool_calls',
+                ...(usageExt ? { usage: usageExt } : {}),
+              },
+            });
+            return true;
+          }
           ctx.options?.sessionLogger?.logStep('dag_coordinator_final', {
             nodeCount: plan.nodes.length,
             outputLength: result.output.length,

--- a/packages/llm-agent-libs/src/pipeline/handlers/tool-loop.ts
+++ b/packages/llm-agent-libs/src/pipeline/handlers/tool-loop.ts
@@ -749,8 +749,8 @@ export class ToolLoopHandler implements IStageHandler {
             ok: true,
             value: {
               content: '',
-              toolCalls: misses.map((tc) => ({
-                index: 0,
+              toolCalls: misses.map((tc, index) => ({
+                index,
                 id: tc.extId,
                 name: tc.name,
                 arguments: JSON.stringify(tc.arguments),

--- a/packages/llm-agent-libs/src/pipeline/handlers/tool-loop.ts
+++ b/packages/llm-agent-libs/src/pipeline/handlers/tool-loop.ts
@@ -32,6 +32,7 @@ import type {
   TimingEntry,
 } from '@mcp-abap-adt/llm-agent';
 import {
+  externalToolCallId,
   getStreamToolCallName,
   toToolCallDelta,
 } from '@mcp-abap-adt/llm-agent';
@@ -108,8 +109,11 @@ export class ToolLoopHandler implements IStageHandler {
       ctx.config.heartbeatIntervalMs ??
       5000;
 
-    const mode = ctx.config.mode || 'smart';
-    const externalTools = mode === 'hard' ? [] : ctx.externalTools;
+    // External (client-provided) tools are mode-independent (spec D1/D4): the
+    // worker never executes them, so `hard` (which constrains only INTERNAL
+    // execution posture) must still OFFER them and surface their calls. The
+    // previous `mode === 'hard' ? []` drop is removed.
+    const externalTools = ctx.externalTools;
     const externalToolNames = new Set(externalTools.map((t) => t.name));
 
     let toolCallCount = 0;
@@ -449,23 +453,17 @@ export class ToolLoopHandler implements IStageHandler {
           }
         }
         if (chunk.toolCalls) {
-          // Register newly seen external tool indices
+          // Track which streaming indices belong to external tools. External
+          // tool-call deltas are BUFFERED (accumulated into toolCallsMap) and
+          // NOT yielded live: an external call is surfaced only AFTER the stream
+          // settles — and only if it has no resume result (miss). This avoids
+          // leaking a call we may instead resolve from `ctx.externalResults`.
           for (const tc of chunk.toolCalls) {
             const name = getStreamToolCallName(tc);
             if (name && externalToolNames.has(name)) {
               const delta = toToolCallDelta(tc, 0);
               externalToolIndices.add(delta.index);
             }
-          }
-          const externalDeltas = chunk.toolCalls.filter((tc) => {
-            const delta = toToolCallDelta(tc, 0);
-            return externalToolIndices.has(delta.index);
-          });
-          if (externalDeltas.length > 0) {
-            ctx.yield({
-              ok: true,
-              value: { content: '', toolCalls: externalDeltas },
-            });
           }
           for (const [
             fallbackIndex,
@@ -673,43 +671,117 @@ export class ToolLoopHandler implements IStageHandler {
         continue;
       }
 
-      // -- Handle external tool calls (delegate to consumer) -----------------
+      // -- Handle external (client-provided) tool calls (spec D1) ------------
+      // Each external call is rewritten to a deterministic content-addressed id
+      // (`externalToolCallId`). Two paths:
+      //   HIT  — `ctx.externalResults` already has the result (stateless resume
+      //          from the client's prior round-trip): inject a MATCHED
+      //          assistant(tool_calls=[extId]) -> tool(tool_call_id=extId) pair
+      //          and CONTINUE the loop (no re-surface).
+      //   MISS — no result yet: surface the call (with extId) to the consumer
+      //          and END the worker turn (`finish_reason: tool_calls`); never
+      //          execute it server-side.
       if (validExternalCalls.length > 0) {
-        if (internalCalls.length > 0) {
-          fireInternalToolsAsync(
-            content,
-            internalCalls,
-            ctx.pendingToolResults,
-            ctx.sessionId,
+        const externalWithId = validExternalCalls.map((tc) => ({
+          ...tc,
+          extId: externalToolCallId(tc.name, tc.arguments),
+        }));
+        const hits = externalWithId.filter((tc) =>
+          ctx.externalResults?.has(tc.extId),
+        );
+        const misses = externalWithId.filter(
+          (tc) => !ctx.externalResults?.has(tc.extId),
+        );
+
+        // HIT path: inject matched pairs (assistant tool_call + tool result),
+        // each correlated by the SAME extId, and resolve them in-conversation.
+        if (hits.length > 0) {
+          messages = [
+            ...messages,
             {
-              toolClientMap: ctx.toolClientMap,
-              toolCache: ctx.toolCache,
-              metrics: ctx.metrics,
-              options: ctx.options,
+              role: 'assistant' as const,
+              content: null,
+              tool_calls: hits.map((tc) => ({
+                id: tc.extId,
+                type: 'function' as const,
+                function: {
+                  name: tc.name,
+                  arguments: JSON.stringify(tc.arguments),
+                },
+              })),
             },
-          );
-          ctx.options?.sessionLogger?.logStep('mixed_tool_calls', {
-            internal: internalCalls.map((tc) => tc.name),
-            external: validExternalCalls.map((tc) => tc.name),
+            ...hits.map((tc) => ({
+              role: 'tool' as const,
+              content: ctx.externalResults?.get(tc.extId) ?? '',
+              tool_call_id: tc.extId,
+            })),
+          ];
+          ctx.options?.sessionLogger?.logStep('external_results_resumed', {
+            extIds: hits.map((tc) => tc.extId),
+            toolNames: hits.map((tc) => tc.name),
           });
         }
 
-        timingLog.push({ phase: 'total', duration: Date.now() - loopStart });
-        ctx.timing.push(...timingLog);
-        ctx.yield({
-          ok: true,
-          value: {
-            content: '',
-            finishReason: 'tool_calls',
-            usage: {
-              ...usage,
-              models: ctx.requestLogger.getSummary().byModel,
-              components: ctx.requestLogger.getSummary().byComponent,
+        // MISS path: surface the unresolved external call(s) and end the turn.
+        if (misses.length > 0) {
+          if (internalCalls.length > 0) {
+            fireInternalToolsAsync(
+              content,
+              internalCalls,
+              ctx.pendingToolResults,
+              ctx.sessionId,
+              {
+                toolClientMap: ctx.toolClientMap,
+                toolCache: ctx.toolCache,
+                metrics: ctx.metrics,
+                options: ctx.options,
+              },
+            );
+            ctx.options?.sessionLogger?.logStep('mixed_tool_calls', {
+              internal: internalCalls.map((tc) => tc.name),
+              external: misses.map((tc) => tc.name),
+            });
+          }
+
+          // Surface the external calls with their deterministic extId so the
+          // consumer executes them and re-sends results (correlated on resume).
+          ctx.yield({
+            ok: true,
+            value: {
+              content: '',
+              toolCalls: misses.map((tc) => ({
+                index: 0,
+                id: tc.extId,
+                name: tc.name,
+                arguments: JSON.stringify(tc.arguments),
+              })),
             },
-            timing: timingLog,
-          },
-        });
-        return true;
+          });
+
+          timingLog.push({ phase: 'total', duration: Date.now() - loopStart });
+          ctx.timing.push(...timingLog);
+          ctx.yield({
+            ok: true,
+            value: {
+              content: '',
+              finishReason: 'tool_calls',
+              usage: {
+                ...usage,
+                models: ctx.requestLogger.getSummary().byModel,
+                components: ctx.requestLogger.getSummary().byComponent,
+              },
+              timing: timingLog,
+            },
+          });
+          return true;
+        }
+
+        // Only hits (no misses): if there are no internal calls to execute,
+        // continue the loop directly so the worker consumes the injected
+        // results. With internal calls present, fall through to execute them.
+        if (internalCalls.length === 0) {
+          continue;
+        }
       }
 
       // -- Execute internal MCP tool calls -----------------------------------

--- a/packages/llm-agent-libs/src/subagent/__tests__/smart-agent-subagent-external.test.ts
+++ b/packages/llm-agent-libs/src/subagent/__tests__/smart-agent-subagent-external.test.ts
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  externalToolCallId,
+  type ISubAgentInput,
+  type LlmTool,
+} from '@mcp-abap-adt/llm-agent';
+import type { SmartAgent } from '../../agent.js';
+import { SmartAgentSubAgent } from '../smart-agent-subagent.js';
+
+function makeAgent(value: unknown): SmartAgent {
+  return {
+    async process() {
+      return { ok: true, value };
+    },
+  } as unknown as SmartAgent;
+}
+
+const ragAdd: LlmTool = {
+  name: 'rag_add',
+  description: 'add to rag',
+  inputSchema: { type: 'object', properties: {} },
+};
+
+describe('SmartAgentSubAgent external-tool mapping', () => {
+  it('maps a tool_calls stop on an external tool to awaiting-external with rewritten ext id', async () => {
+    const agent = makeAgent({
+      content: '',
+      iterations: 1,
+      toolCallCount: 1,
+      stopReason: 'tool_calls',
+      toolCalls: [
+        {
+          id: 'call_x',
+          type: 'function',
+          function: { name: 'rag_add', arguments: '{"collection":"context"}' },
+        },
+      ],
+    });
+    const sub = new SmartAgentSubAgent('worker', agent);
+    const input: ISubAgentInput = {
+      task: 'do it',
+      externalTools: [ragAdd],
+    };
+
+    const res = await sub.run(input);
+
+    assert.equal(res.status, 'awaiting-external');
+    assert.deepEqual(res.pendingExternalToolCalls, [
+      {
+        id: externalToolCallId('rag_add', { collection: 'context' }),
+        name: 'rag_add',
+        arguments: { collection: 'context' },
+      },
+    ]);
+  });
+
+  it('returns complete when the worker stops normally with no tool calls', async () => {
+    const agent = makeAgent({
+      content: 'done',
+      iterations: 1,
+      toolCallCount: 0,
+      stopReason: 'stop',
+    });
+    const sub = new SmartAgentSubAgent('worker', agent);
+
+    const res = await sub.run({ task: 'do it' });
+
+    assert.notEqual(res.status, 'awaiting-external');
+    assert.equal(res.pendingExternalToolCalls, undefined);
+    assert.equal(res.output, 'done');
+  });
+});

--- a/packages/llm-agent-libs/src/subagent/smart-agent-subagent.ts
+++ b/packages/llm-agent-libs/src/subagent/smart-agent-subagent.ts
@@ -39,6 +39,11 @@ export class SmartAgentSubAgent implements ISubAgent {
       ...(input.externalTools && input.externalTools.length > 0
         ? { externalTools: [...input.externalTools] }
         : {}),
+      // #171 (review#7): thread the validated extId→result map into the
+      // worker pipeline so a re-surfaced external call resolves from history.
+      ...(input.externalResults
+        ? { externalResults: input.externalResults }
+        : {}),
     });
 
     if (!res.ok) {

--- a/packages/llm-agent-libs/src/subagent/smart-agent-subagent.ts
+++ b/packages/llm-agent-libs/src/subagent/smart-agent-subagent.ts
@@ -1,9 +1,10 @@
-import type {
-  ISubAgent,
-  ISubAgentInput,
-  ISubAgentResult,
-  LlmToolCall,
-  SubAgentCapabilities,
+import {
+  externalToolCallId,
+  type ISubAgent,
+  type ISubAgentInput,
+  type ISubAgentResult,
+  type LlmToolCall,
+  type SubAgentCapabilities,
 } from '@mcp-abap-adt/llm-agent';
 import type { SmartAgent } from '../agent.js';
 
@@ -44,7 +45,45 @@ export class SmartAgentSubAgent implements ISubAgent {
       throw res.error;
     }
 
-    const { content, toolCalls, usage } = res.value;
+    const { content, toolCalls, stopReason, usage } = res.value;
+
+    const mappedUsage = usage
+      ? {
+          promptTokens: usage.promptTokens,
+          completionTokens: usage.completionTokens,
+          totalTokens: usage.totalTokens,
+        }
+      : undefined;
+
+    // Issue #171: when the worker tool-loop stops on a client-provided
+    // (consumer-executed) external tool call, it surfaces the call instead of
+    // executing it. Translate that stop into a typed awaiting-external result
+    // with deterministic `ext:` ids the client can correlate. Internal MCP
+    // calls are executed inside the worker loop and never reach here.
+    if (stopReason === 'tool_calls' && toolCalls && toolCalls.length > 0) {
+      const extNames = new Set((input.externalTools ?? []).map((t) => t.name));
+      const pending: LlmToolCall[] = toolCalls
+        .filter((tc) => extNames.has(tc.function.name))
+        .map((tc) => {
+          const args = JSON.parse(tc.function.arguments) as Record<
+            string,
+            unknown
+          >;
+          return {
+            id: externalToolCallId(tc.function.name, args),
+            name: tc.function.name,
+            arguments: args,
+          };
+        });
+      if (pending.length > 0) {
+        return {
+          output: content,
+          usage: mappedUsage,
+          status: 'awaiting-external',
+          pendingExternalToolCalls: pending,
+        };
+      }
+    }
 
     const mappedToolCalls: LlmToolCall[] | undefined = toolCalls?.map((tc) => ({
       id: tc.id,
@@ -55,13 +94,8 @@ export class SmartAgentSubAgent implements ISubAgent {
     return {
       output: content,
       toolCalls: mappedToolCalls,
-      usage: usage
-        ? {
-            promptTokens: usage.promptTokens,
-            completionTokens: usage.completionTokens,
-            totalTokens: usage.totalTokens,
-          }
-        : undefined,
+      usage: mappedUsage,
+      status: 'complete',
     };
   }
 }

--- a/packages/llm-agent-server-libs/src/__tests__/dag-coordinator-mcp.integration.test.ts
+++ b/packages/llm-agent-server-libs/src/__tests__/dag-coordinator-mcp.integration.test.ts
@@ -20,12 +20,15 @@
  *       records real MCP tool execution (dag_stream chunks of kind mcp-call /
  *       mcp-result naming real tools, plus a dag_coordinator_final trace)
  *
- * ── Env gating (MUST skip cleanly in CI) ────────────────────────────────────
- * CI runs `npm run test --workspaces` with NO live services. This test SKIPS
+ * ── Env gating (MUST skip cleanly in CI and on a plain `npm test`) ───────────
+ * This is a LIVE test (spawns a server, calls real MCP + LLMs). It SKIPS
  * (exit 0, not fail) unless ALL preconditions hold:
+ *   - RUN_LIVE_INTEGRATION=1 set (explicit opt-in — so a plain `npm test`/CI
+ *     NEVER runs it even if API keys happen to be present in the environment)
  *   - MCP_ENDPOINT reachable (probed via a short `tools/list` POST)
  *   - DEEPSEEK_API_KEY present (planner + worker LLM)
  *   - AICORE_SERVICE_KEY present (SAP AI Core embedder for tool-select)
+ * Run it: `RUN_LIVE_INTEGRATION=1 MCP_ENDPOINT=... node --import tsx/esm --env-file=.env --test <this file>`
  *
  * ── Server boot/teardown ────────────────────────────────────────────────────
  * We SPAWN the same entrypoint the manual script uses
@@ -95,6 +98,14 @@ async function mcpReachable(): Promise<boolean> {
 
 /** Compute the skip reason (empty string ⇒ run). */
 async function computeSkip(): Promise<string> {
+  // Explicit opt-in: a LIVE test (spawns a server, calls real MCP + LLMs) must
+  // NEVER run on a plain `npm test`, even when API keys happen to be present in
+  // the environment — otherwise it slows/flakes ordinary test runs and CI. It
+  // runs ONLY when explicitly requested, so `npm test` is deterministically
+  // green everywhere. To run it: `RUN_LIVE_INTEGRATION=1 ... node --test ...`.
+  if (!process.env.RUN_LIVE_INTEGRATION) {
+    return 'live integration not opted in (set RUN_LIVE_INTEGRATION=1)';
+  }
   const missing: string[] = [];
   if (!process.env.DEEPSEEK_API_KEY) missing.push('DEEPSEEK_API_KEY');
   if (!process.env.AICORE_SERVICE_KEY) missing.push('AICORE_SERVICE_KEY');

--- a/packages/llm-agent-server-libs/src/__tests__/dag-coordinator-mcp.integration.test.ts
+++ b/packages/llm-agent-server-libs/src/__tests__/dag-coordinator-mcp.integration.test.ts
@@ -280,4 +280,105 @@ describe('DAG-coordinator ↔ MCP integration (#159)', () => {
       `[#159] PASS — prompt_tokens=${promptTokens}, tool=${toolHit.tool} (${toolHit.kind}), trace=${path.basename(finalTrace)}`,
     );
   });
+
+  // -------------------------------------------------------------------------
+  // #171: external (client-provided) tool round-trip under the coordinator.
+  //
+  // Declare a simple external tool in the request `tools`, ask the model to
+  // call it, and assert the response SURFACES the call (finish_reason
+  // tool_calls + an `ext:`-prefixed tool_call id) instead of the worker
+  // executing it. This proves external tools are consumer-executed and that
+  // the deterministic `ext:` id is exposed for stateless resume.
+  //
+  // Scope limit: we assert only the FIRST half of the round-trip (the call is
+  // surfaced). Sending the result back and asserting the follow-up answer is
+  // covered by the unit tests for buildExternalResults + adapter
+  // normalization; wiring a full live two-leg round-trip here would add
+  // significant flakiness for little extra signal. Same env-gating as above.
+  // -------------------------------------------------------------------------
+  it('surfaces a client external-tool call (ext: id) instead of executing it', {
+    timeout: 600_000,
+  }, async (t) => {
+    if (skipReason) {
+      t.skip(skipReason);
+      return;
+    }
+
+    const res = await fetch(`${BASE}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'deepseek-chat',
+        stream: false,
+        messages: [
+          {
+            role: 'user',
+            content:
+              'Call the client tool get_current_time to get the current time. Do not answer from your own knowledge — you must use the tool.',
+          },
+        ],
+        tools: [
+          {
+            type: 'function',
+            function: {
+              name: 'get_current_time',
+              description:
+                'Returns the current wall-clock time. Runs on the client.',
+              parameters: {
+                type: 'object',
+                properties: {
+                  timezone: {
+                    type: 'string',
+                    description: 'IANA timezone, e.g. Europe/Kyiv',
+                  },
+                },
+                required: [],
+              },
+            },
+          },
+        ],
+      }),
+      signal: AbortSignal.timeout(590_000),
+    });
+
+    assert.equal(res.status, 200, `expected HTTP 200, got ${res.status}`);
+    const body = (await res.json()) as {
+      choices?: Array<{
+        finish_reason?: string;
+        message?: {
+          tool_calls?: Array<{ id?: string; function?: { name?: string } }>;
+        };
+      }>;
+    };
+
+    const choice = body.choices?.[0];
+    const toolCalls = choice?.message?.tool_calls ?? [];
+    assert.ok(
+      toolCalls.length > 0,
+      `expected the response to surface tool_calls, got finish_reason=${choice?.finish_reason}`,
+    );
+    assert.equal(
+      choice?.finish_reason,
+      'tool_calls',
+      `expected finish_reason=tool_calls, got ${choice?.finish_reason}`,
+    );
+
+    const extCall = toolCalls.find((c) => c.id?.startsWith('ext:'));
+    assert.ok(
+      extCall,
+      `expected a surfaced tool_call with an ext: id (consumer-executed), got ids: ${toolCalls
+        .map((c) => c.id)
+        .join(', ')}`,
+    );
+    assert.equal(
+      extCall.function?.name,
+      'get_current_time',
+      'surfaced external call must name the client tool',
+    );
+
+    // eslint-disable-next-line no-console
+    console.error(
+      `[#171] PASS — surfaced external call id=${extCall.id} name=${extCall.function?.name}`,
+    );
+  });
 });

--- a/packages/llm-agent-server-libs/src/__tests__/dag-coordinator-mcp.integration.test.ts
+++ b/packages/llm-agent-server-libs/src/__tests__/dag-coordinator-mcp.integration.test.ts
@@ -33,8 +33,9 @@
  * process with its own process group, rather than importing SmartServer
  * in-process. Spawning mirrors the manual check exactly, exercises the real CLI
  * config + env-substitution path, and gives a clean kill (process group) on
- * teardown. The child's cwd is a fresh temp dir so the yaml's cwd-relative
- * `logDir: ./.run/sessions` lands at a path the test fully controls.
+ * teardown. The child runs from REPO_ROOT (so `tsx/esm` + workspace packages
+ * resolve); the yaml's cwd-relative `logDir: ./.run/sessions` therefore lands at
+ * `<repo>/.run/sessions`, which the test cleans before the run and reads after.
  */
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';

--- a/packages/llm-agent-server-libs/src/smart-agent/smart-server.ts
+++ b/packages/llm-agent-server-libs/src/smart-agent/smart-server.ts
@@ -30,6 +30,7 @@ import type {
 import {
   AdapterValidationError,
   artifactIdentityKey,
+  buildExternalResults,
   type ExternalToolValidationCode,
   type IRag,
   normalizeAndValidateExternalTools,
@@ -2852,6 +2853,16 @@ export class SmartServer {
         return normalizedMessage;
       })
       .filter((m): m is Message => m !== null);
+
+    // #171 (review#11): consume external (client-executed) tool result turns
+    // from the incoming history into a validated `extId → result` map and strip
+    // those raw turns from the messages forwarded to the agent (so no internal
+    // LLM call ever sees an unmatched assistant tool_calls). On a normal request
+    // with no external history this returns the messages unchanged + an empty
+    // map — a safe no-op. The map is threaded via options.externalResults.
+    const { results: externalResults, sanitizedMessages } =
+      buildExternalResults(normalizedMessages);
+
     const invalidToolsHeader =
       externalToolsValidation.errors.length > 0
         ? {
@@ -2871,7 +2882,10 @@ export class SmartServer {
       const id = `chatcmpl-${randomUUID()}`;
       const created = Math.floor(Date.now() / 1000);
 
-      const stream = smartAgent.streamProcess(normalizedMessages, opts);
+      const stream = smartAgent.streamProcess(sanitizedMessages, {
+        ...opts,
+        externalResults,
+      });
       let firstChunk = true;
       let finishReasonSent = false;
       let lastUsage: {
@@ -3002,7 +3016,10 @@ export class SmartServer {
       return;
     }
 
-    const result = await smartAgent.process(normalizedMessages, opts);
+    const result = await smartAgent.process(sanitizedMessages, {
+      ...opts,
+      externalResults,
+    });
     log({ event: 'request_done', ok: result.ok, durationMs: Date.now() - t0 });
     const finalContent = result.ok
       ? result.value.content ||

--- a/packages/llm-agent-server-libs/src/smart-agent/smart-server.ts
+++ b/packages/llm-agent-server-libs/src/smart-agent/smart-server.ts
@@ -2590,6 +2590,15 @@ export class SmartServer {
       throw err;
     }
 
+    // #171 (review#8): the adapter has already normalized Anthropic
+    // tool_use/tool_result blocks into the OpenAI-shaped Message[]
+    // (assistant.tool_calls + role:'tool' with tool_call_id). Run the same
+    // external-results extraction the OpenAI path uses so Anthropic clients get
+    // identical stateless-resume behaviour: consumed external turns are stripped
+    // and their results threaded to the agent keyed by deterministic `ext:` id.
+    const { results: externalResults, sanitizedMessages } =
+      buildExternalResults(normalized.messages);
+
     const augmentedOptions = session
       ? {
           ...normalized.options,
@@ -2597,8 +2606,9 @@ export class SmartServer {
           trace: { traceId: session.traceId },
           toolAvailability: session.graph.toolAvailability,
           pendingToolResults: session.graph.pendingToolResults,
+          externalResults,
         }
-      : normalized.options;
+      : { ...normalized.options, externalResults };
 
     if (normalized.stream) {
       res.writeHead(200, {
@@ -2608,7 +2618,7 @@ export class SmartServer {
       });
 
       for await (const event of adapter.transformStream(
-        agent.streamProcess(normalized.messages, augmentedOptions),
+        agent.streamProcess(sanitizedMessages, augmentedOptions),
         normalized.context,
       )) {
         const eventLine = event.event ? `event: ${event.event}\n` : '';
@@ -2619,7 +2629,7 @@ export class SmartServer {
     }
 
     // Non-streaming
-    const result = await agent.process(normalized.messages, augmentedOptions);
+    const result = await agent.process(sanitizedMessages, augmentedOptions);
     res.setHeader('Content-Type', 'application/json');
     if (!result.ok) {
       res.writeHead(500);

--- a/packages/llm-agent/src/__tests__/external-results.test.ts
+++ b/packages/llm-agent/src/__tests__/external-results.test.ts
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { buildExternalResults } from '../external-results.js';
+import type { Message } from '../types.js';
+
+function extCall(id: string, name = 'fn') {
+  return { id, type: 'function' as const, function: { name, arguments: '{}' } };
+}
+
+test('(a) adjacent result accepted and consumed', () => {
+  const messages: Message[] = [
+    { role: 'assistant', content: null, tool_calls: [extCall('ext:aaa')] },
+    { role: 'tool', content: 'R', tool_call_id: 'ext:aaa' },
+  ];
+  const { results, sanitizedMessages } = buildExternalResults(messages);
+  assert.equal(results.get('ext:aaa'), 'R');
+  assert.equal(sanitizedMessages.length, 0);
+});
+
+test('(b) orphan ext tool result rejected and dropped', () => {
+  const messages: Message[] = [
+    { role: 'user', content: 'hi' },
+    { role: 'tool', content: 'R', tool_call_id: 'ext:bbb' },
+  ];
+  const { results, sanitizedMessages } = buildExternalResults(messages);
+  assert.equal(results.has('ext:bbb'), false);
+  // orphan ext tool result is dropped from sanitized, user message remains
+  assert.deepEqual(sanitizedMessages, [{ role: 'user', content: 'hi' }]);
+});
+
+test('(c) partial set — only matched id in map, whole group stripped', () => {
+  const messages: Message[] = [
+    {
+      role: 'assistant',
+      content: null,
+      tool_calls: [extCall('ext:a'), extCall('ext:b')],
+    },
+    { role: 'tool', content: 'RA', tool_call_id: 'ext:a' },
+  ];
+  const { results, sanitizedMessages } = buildExternalResults(messages);
+  assert.equal(results.get('ext:a'), 'RA');
+  assert.equal(results.has('ext:b'), false);
+  assert.equal(sanitizedMessages.filter((m) => m.role === 'tool').length, 0);
+  assert.equal(
+    sanitizedMessages.filter(
+      (m) =>
+        m.role === 'assistant' &&
+        (m.tool_calls ?? []).some((c) => c.id.startsWith('ext:')),
+    ).length,
+    0,
+  );
+});
+
+test('(d) multi-tool-per-turn — whole consecutive run consumed', () => {
+  const messages: Message[] = [
+    {
+      role: 'assistant',
+      content: null,
+      tool_calls: [extCall('ext:a'), extCall('ext:b')],
+    },
+    { role: 'tool', content: 'RA', tool_call_id: 'ext:a' },
+    { role: 'tool', content: 'RB', tool_call_id: 'ext:b' },
+  ];
+  const { results, sanitizedMessages } = buildExternalResults(messages);
+  assert.equal(results.get('ext:a'), 'RA');
+  assert.equal(results.get('ext:b'), 'RB');
+  assert.equal(sanitizedMessages.length, 0);
+});
+
+test('(e) non-external messages and internal tool_calls untouched', () => {
+  const messages: Message[] = [
+    { role: 'system', content: 'sys' },
+    { role: 'user', content: 'q' },
+    { role: 'assistant', content: 'an answer' },
+    {
+      role: 'assistant',
+      content: null,
+      tool_calls: [extCall('call_internal_1')],
+    },
+    { role: 'tool', content: 'IR', tool_call_id: 'call_internal_1' },
+  ];
+  const { results, sanitizedMessages } = buildExternalResults(messages);
+  assert.equal(results.size, 0);
+  assert.deepEqual(sanitizedMessages, messages);
+});

--- a/packages/llm-agent/src/__tests__/external-tool-id.test.ts
+++ b/packages/llm-agent/src/__tests__/external-tool-id.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { deepStableArgsKey, externalToolCallId } from '../artifact-identity.js';
+
+test('deepStableArgsKey: nested key order is canonical (same key)', () => {
+  assert.equal(
+    deepStableArgsKey({ filter: { a: 1, b: 2 } }),
+    deepStableArgsKey({ filter: { b: 2, a: 1 } }),
+  );
+});
+test('deepStableArgsKey: arrays preserve order (different key)', () => {
+  assert.notEqual(
+    deepStableArgsKey({ x: [1, 2] }),
+    deepStableArgsKey({ x: [2, 1] }),
+  );
+});
+test('externalToolCallId: case-distinct args → distinct id', () => {
+  assert.notEqual(
+    externalToolCallId('rag_add', { content: 'Hello' }),
+    externalToolCallId('rag_add', { content: 'hello' }),
+  );
+});
+test('externalToolCallId: same tool+args → same id; shape ext:<16hex>', () => {
+  const id = externalToolCallId('rag_add', {
+    collection: 'context',
+    content: 'x',
+  });
+  assert.equal(
+    id,
+    externalToolCallId('rag_add', { collection: 'context', content: 'x' }),
+  );
+  assert.match(id, /^ext:[0-9a-f]{16}$/);
+});
+test('externalToolCallId: known vector pins the NUL separator (regression guard)', () => {
+  // If the separator silently regresses to a space the hash changes → this fails.
+  assert.equal(externalToolCallId('rag_add', { a: 1 }), 'ext:e99d19aab4a77c50');
+});

--- a/packages/llm-agent/src/api-adapters/__tests__/anthropic-adapter.test.ts
+++ b/packages/llm-agent/src/api-adapters/__tests__/anthropic-adapter.test.ts
@@ -8,6 +8,7 @@ import type {
   Result,
   SmartAgentResponse,
 } from '@mcp-abap-adt/llm-agent';
+import { buildExternalResults } from '../../external-results.js';
 import type {
   ApiRequestContext,
   ApiSseEvent,
@@ -592,5 +593,82 @@ describe('AnthropicApiAdapter.transformStream', () => {
     for (const e of events) {
       assert.ok(e.event, `Expected event field to be set, got: ${e.event}`);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// External-tool round-trip normalization (#171, review#8)
+//
+// An Anthropic tool round-trip (assistant tool_use -> user tool_result) must,
+// after adapter normalization, look identical to the OpenAI-normalized shape
+// that buildExternalResults consumes: assistant.tool_calls[{id}] followed by a
+// role:'tool' message carrying tool_call_id. The deterministic `ext:` id then
+// lets a stateless re-run correlate the client-executed result by id.
+// ---------------------------------------------------------------------------
+
+describe('AnthropicApiAdapter external-tool normalization', () => {
+  const adapter = new AnthropicApiAdapter();
+
+  it('normalizes a tool_use/tool_result round-trip into the OpenAI shape that buildExternalResults consumes', () => {
+    const extId = 'ext:abc123';
+    const request = {
+      model: 'claude-test',
+      messages: [
+        { role: 'user', content: 'call the weather tool' },
+        {
+          role: 'assistant',
+          content: [
+            { type: 'text', text: 'Let me check.' },
+            {
+              type: 'tool_use',
+              id: extId,
+              name: 'get_weather',
+              input: { city: 'Kyiv' },
+            },
+          ],
+        },
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: extId,
+              content: 'sunny, 21C',
+            },
+          ],
+        },
+      ],
+    };
+
+    const normalized = adapter.normalizeRequest(request);
+
+    // Adapter produced the internal OpenAI shape.
+    const assistant = normalized.messages.find((m) => m.role === 'assistant');
+    assert.ok(assistant, 'expected an assistant message');
+    assert.equal(assistant.tool_calls?.[0]?.id, extId);
+    assert.equal(assistant.tool_calls?.[0]?.type, 'function');
+    assert.equal(assistant.tool_calls?.[0]?.function.name, 'get_weather');
+
+    const toolMsg = normalized.messages.find((m) => m.role === 'tool');
+    assert.ok(toolMsg, 'expected a role:tool message');
+    assert.equal(toolMsg.tool_call_id, extId);
+    assert.equal(toolMsg.content, 'sunny, 21C');
+
+    // buildExternalResults consumes those turns and keys the result by ext id.
+    const { results, sanitizedMessages } = buildExternalResults(
+      normalized.messages,
+    );
+    assert.equal(results.get(extId), 'sunny, 21C');
+    // The consumed external assistant/tool turns are stripped from history.
+    assert.equal(
+      sanitizedMessages.some((m) => m.role === 'tool'),
+      false,
+    );
+    assert.equal(
+      sanitizedMessages.some(
+        (m) => m.role === 'assistant' && (m.tool_calls?.length ?? 0) > 0,
+      ),
+      false,
+    );
   });
 });

--- a/packages/llm-agent/src/artifact-identity.ts
+++ b/packages/llm-agent/src/artifact-identity.ts
@@ -6,6 +6,8 @@
  * the same object (the redundant-read problem in the 2026-06-01 live matrix).
  */
 
+import { createHash } from 'node:crypto';
+
 /** Canonical, order-independent serialization of tool arguments so that
  *  `{a:1,b:2}` and `{b:2,a:1}` produce the SAME key. */
 export function stableArgsKey(args: unknown): string {
@@ -28,4 +30,31 @@ export function stableArgsKey(args: unknown): string {
  *  dedup heuristic (returns a stored value), and identifiers dominate. */
 export function artifactIdentityKey(toolName: string, args: unknown): string {
   return `${toolName}:${stableArgsKey(args)}`.toLowerCase();
+}
+
+/** DEEP canonical JSON: recursively sort object keys at every depth; arrays keep
+ *  order; case-PRESERVING. Used for external tool-call identity (NOT lowercased). */
+export function deepStableArgsKey(args: unknown): string {
+  const canon = (v: unknown): unknown => {
+    if (v === null || typeof v !== 'object') return v;
+    if (Array.isArray(v)) return v.map(canon);
+    const o = v as Record<string, unknown>;
+    const out: Record<string, unknown> = {};
+    for (const k of Object.keys(o).sort()) out[k] = canon(o[k]);
+    return out;
+  };
+  return JSON.stringify(canon(args));
+}
+
+/** First 16 hex chars of sha256. */
+export function shortHash(s: string): string {
+  return createHash('sha256').update(s).digest('hex').slice(0, 16);
+}
+
+/** Deterministic, content-addressed id for a client-provided external tool call
+ *  (spec D1). The toolName/args boundary uses a NUL separator (\x00). A space
+ *  would let ('a b','c') and ('a','b c') collide. */
+const EXT_SEP = '\x00';
+export function externalToolCallId(toolName: string, args: unknown): string {
+  return `ext:${shortHash(`${toolName}${EXT_SEP}${deepStableArgsKey(args)}`)}`;
 }

--- a/packages/llm-agent/src/external-results.ts
+++ b/packages/llm-agent/src/external-results.ts
@@ -1,0 +1,79 @@
+import type { Message } from './types.js';
+
+const EXT_PREFIX = 'ext:';
+
+export interface ExternalResults {
+  /** Validated external-tool results keyed by deterministic `ext:` id. */
+  results: Map<string, string>;
+  /** History with consumed external assistant/tool turns removed, order preserved. */
+  sanitizedMessages: Message[];
+}
+
+function isExternalId(id: string): boolean {
+  return id.startsWith(EXT_PREFIX);
+}
+
+function declaresExternalCall(msg: Message): boolean {
+  return (
+    msg.role === 'assistant' &&
+    (msg.tool_calls ?? []).some((c) => isExternalId(c.id))
+  );
+}
+
+/**
+ * Extract validated external-tool RESULTS from request history into a map keyed
+ * by the deterministic `ext:` id, and return the history with the consumed
+ * external assistant/tool turns removed. Operates ONLY on the OpenAI-normalized
+ * `Message[]` shape (the adapter normalizes Anthropic `tool_result` blocks to
+ * `role:'tool'` upstream).
+ */
+export function buildExternalResults(
+  messages: readonly Message[],
+): ExternalResults {
+  const results = new Map<string, string>();
+  const remove = new Array<boolean>(messages.length).fill(false);
+
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+
+    if (declaresExternalCall(msg)) {
+      // Declared external ids on this assistant turn.
+      const declared = new Set(
+        (msg.tool_calls ?? [])
+          .map((c) => c.id)
+          .filter((id) => isExternalId(id)),
+      );
+      remove[i] = true;
+
+      // Consume the IMMEDIATELY-following consecutive run of role:'tool'
+      // messages whose tool_call_id is one of the declared ext ids.
+      let j = i + 1;
+      while (j < messages.length && messages[j].role === 'tool') {
+        const id = messages[j].tool_call_id;
+        if (id === undefined || !declared.has(id)) break;
+        results.set(id, messages[j].content ?? '');
+        remove[j] = true;
+        j++;
+      }
+      i = j - 1;
+      continue;
+    }
+
+    // A stray role:'tool' with an ext: id that does not immediately follow a
+    // declaring assistant external turn is malformed → drop it.
+    if (
+      msg.role === 'tool' &&
+      msg.tool_call_id !== undefined &&
+      isExternalId(msg.tool_call_id)
+    ) {
+      remove[i] = true;
+    }
+  }
+
+  const sanitizedMessages: Message[] = [];
+  for (let i = 0; i < messages.length; i++) {
+    if (!remove[i]) sanitizedMessages.push(messages[i]);
+  }
+
+  return { results, sanitizedMessages };
+}

--- a/packages/llm-agent/src/index.ts
+++ b/packages/llm-agent/src/index.ts
@@ -1,6 +1,9 @@
 // Re-export everything from core subtrees.
 export {
   artifactIdentityKey,
+  deepStableArgsKey,
+  externalToolCallId,
+  shortHash,
   stableArgsKey,
 } from './artifact-identity.js';
 export { ClarifySignal, NeedInfoSignal } from './coordinator-signals.js';

--- a/packages/llm-agent/src/index.ts
+++ b/packages/llm-agent/src/index.ts
@@ -5,6 +5,7 @@ export {
 } from './artifact-identity.js';
 export { ClarifySignal, NeedInfoSignal } from './coordinator-signals.js';
 export * from './errors/index.js';
+export * from './external-results.js';
 export * from './interfaces/index.js';
 export { BaseLLMProvider, type LLMProvider } from './llm/base-llm-provider.js';
 export { NeedsDecompositionError } from './needs-decomposition-error.js';

--- a/packages/llm-agent/src/interfaces/__tests__/awaiting-external.test.ts
+++ b/packages/llm-agent/src/interfaces/__tests__/awaiting-external.test.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import type { InterpretResult, NodeResult } from '../interpreter.js';
+import type { ISubAgentResult } from '../subagent.js';
+
+test('awaiting-external types compile + round-trip', () => {
+  const nr: NodeResult = {
+    nodeId: 'n0',
+    output: '',
+    status: 'awaiting-external',
+    durationMs: 0,
+  };
+  const r: ISubAgentResult = {
+    output: '',
+    status: 'awaiting-external',
+    pendingExternalToolCalls: [
+      { id: 'ext:0123456789abcdef', name: 'rag_add', arguments: {} },
+    ],
+  };
+  const ir: InterpretResult = {
+    nodeResults: { n0: nr },
+    ok: true,
+    output: '',
+    executionOrder: ['n0'],
+    pendingExternalToolCalls: r.pendingExternalToolCalls,
+  };
+  assert.equal(ir.pendingExternalToolCalls?.length, 1);
+  assert.equal(nr.status, 'awaiting-external');
+  assert.equal(r.status, 'awaiting-external');
+});

--- a/packages/llm-agent/src/interfaces/agent-contracts.ts
+++ b/packages/llm-agent/src/interfaces/agent-contracts.ts
@@ -37,6 +37,11 @@ export interface SmartAgentResponse {
 
 export interface AgentCallOptions extends CallOptions {
   externalTools?: unknown[];
+  /** Validated `extId → result` map built at the server boundary from the
+   *  incoming history's external tool results (#171, review#7). Threaded down
+   *  to the worker pipeline context so a re-surfaced external call resolves
+   *  from history instead of pausing again on stateless resume. */
+  externalResults?: Map<string, string>;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/llm-agent/src/interfaces/interpreter.ts
+++ b/packages/llm-agent/src/interfaces/interpreter.ts
@@ -36,6 +36,10 @@ export interface InterpretContext {
    *  dispatch so a worker can emit a tool call the client fulfils (issue #167).
    *  Absent → workers see only their own MCP tools. */
   externalTools?: readonly LlmTool[];
+  /** Validated `extId → result` map from the incoming history (#171,
+   *  review#7). Threaded into each worker dispatch so a re-surfaced external
+   *  call resolves from history on stateless resume. */
+  externalResults?: Map<string, string>;
 }
 
 export interface NodeResult {

--- a/packages/llm-agent/src/interfaces/interpreter.ts
+++ b/packages/llm-agent/src/interfaces/interpreter.ts
@@ -3,7 +3,7 @@ import type { DagPlan } from './dag-plan.js';
 import type { IErrorStrategy } from './error-strategy.js';
 import type { OnPartial } from './streaming.js';
 import type { ISubAgent } from './subagent.js';
-import type { LlmTool } from './types.js';
+import type { LlmTool, LlmToolCall } from './types.js';
 
 export interface IInterpreter<TInput, TOutput> {
   readonly name: string;
@@ -41,7 +41,7 @@ export interface InterpretContext {
 export interface NodeResult {
   nodeId: string;
   output: string;
-  status: 'done' | 'failed' | 'skipped';
+  status: 'done' | 'failed' | 'skipped' | 'awaiting-external';
   /** Populated by convention when `status === 'failed'` (the failure reason). */
   error?: string;
   durationMs: number;
@@ -59,4 +59,7 @@ export interface InterpretResult {
   executedPlan?: DagPlan;
   /** Topological execution order of node ids in actual run order. */
   executionOrder: readonly string[];
+  /** The external tool calls surfaced during the run (deterministic `ext:` ids).
+   *  Present iff at least one node reached status 'awaiting-external' (#171). */
+  pendingExternalToolCalls?: LlmToolCall[];
 }

--- a/packages/llm-agent/src/interfaces/subagent.ts
+++ b/packages/llm-agent/src/interfaces/subagent.ts
@@ -63,6 +63,13 @@ export interface ISubAgentResult {
   errorClass?: 'epicfail';
   /** Diagnostic trace populated when errorClass === 'epicfail'. */
   epicFailTrace?: EpicFailTrace;
+  /** Set to 'awaiting-external' when the worker emitted a client-provided
+   *  (consumer-executed) external tool call and is waiting for its result
+   *  (#171). Default/absent = 'complete'. */
+  status?: 'complete' | 'awaiting-external';
+  /** The external tool calls the worker surfaced (deterministic `ext:` ids).
+   *  Present iff status === 'awaiting-external'. */
+  pendingExternalToolCalls?: LlmToolCall[];
 }
 
 /**

--- a/packages/llm-agent/src/interfaces/subagent.ts
+++ b/packages/llm-agent/src/interfaces/subagent.ts
@@ -49,6 +49,11 @@ export interface ISubAgentInput {
    *  nested pipeline so the worker can emit a tool call the client fulfils
    *  (issue #167). Absent → the worker sees only its own MCP tools. */
   externalTools?: readonly LlmTool[];
+  /** Validated `extId → result` map from the incoming history (#171,
+   *  review#7). Threaded from the coordinator into the worker's nested
+   *  pipeline context so a re-surfaced external call resolves from history
+   *  on stateless resume instead of pausing again. */
+  externalResults?: Map<string, string>;
 }
 
 export interface ISubAgentResult {


### PR DESCRIPTION
## #171 — client-provided external tools under the DAG coordinator

Implements `docs/superpowers/specs/2026-06-03-dag-external-tools.md` (5 review rounds) via `docs/superpowers/plans/2026-06-03-dag-external-tools.md` (11 review rounds).

### Contract
- **External (client) tools are mode-independent** — always offered; `mode` governs only the worker's INTERNAL (MCP) execution. The `hard`-mode drop is removed in BOTH the pipeline tool-loop and the flat SmartAgent path (D4).
- **Consumer-executed** — the worker never runs an external tool; it surfaces a standard `tool_call` (OpenAI `finish_reason:tool_calls` / Anthropic `stop_reason:tool_use`), the client executes it and returns the result via the standard round-trip. No custom transport.
- **Deterministic content-addressed ids** — `ext:${shortHash(toolName + NUL + deepStableArgsKey(args))}` (case-preserving, deep-canonical) so a stateless re-run correlates the returned result by id, not the LLM's random id.
- **Parallel workers** — the DAG interpreter collects all awaiting-external nodes' calls FIFO (collect-all-at-settle) into ONE terminal assistant turn; the coordinator takes a no-finalizer path when calls are pending.
- **Stateless + protocol-safe** — incoming external results are validated by strict adjacency (a result is accepted only if it immediately follows the assistant turn that declared its id; orphans rejected) and the consumed external turns are STRIPPED from internal LLM message lists, so no provider call ever sees an unmatched `tool_calls`.

### Commits (11)
contracts (id helpers, awaiting-external types, buildExternalResults) → tool-loop surfacing (buffer deltas, matched-pair resume inject) → SmartAgentSubAgent bridge → flat hard-mode fix → interpreter collect-all-at-settle → externalResults threading end-to-end + no-finalizer branch → planner external-node → docs (D4) + Anthropic normalization + env-gated integration case.

### Tests
`npm test` → 1494 tests, 0 failures. `npm run build` exit 0; `lint:check` clean (1 pre-existing warning). New required tests: id known-vector + case/deep canonicalization, adjacency/sanitization/multi-tool, tool-loop surface+resume no-leak, subagent awaiting-external, flat hard-mode, interpreter collect, threading chain, no-finalizer branch, planner fallback node, Anthropic normalization.

### Not in this PR
- Live external-tool round-trip against a real MCP (env-gated integration case skips in CI).
- Version bump (intended next minor, e.g. 18.2.0) — separate release step.
- The spec/plan are still in-tree; per repo convention they should be deleted on merge (now implemented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
