### PR TITLE
controller: scope-discipline in create-plan + per-step tool selection

### DIFF
--- a/packages/llm-agent-server-libs/src/smart-agent/controller/__tests__/planner.test.ts
+++ b/packages/llm-agent-server-libs/src/smart-agent/controller/__tests__/planner.test.ts
@@ -55,6 +55,9 @@ describe('IncrementalPlanner', () => {
     });
     assert.doesNotMatch(sys, /SAP|ABAP/i);
     assert.match(sys, /Additional guidance: Keep the plan minimal\./);
+    // Contract: plan by intent, never name a tool; no dangling tool-list ref.
+    assert.match(sys, /do NOT (choose|name)/i);
+    assert.doesNotMatch(sys, /listed below/i);
   });
 
   it('non-content planner reply → null (format failure)', async () => {
@@ -353,6 +356,9 @@ describe('AdaptivePlanner', () => {
     assert.doesNotMatch(sys, /SAP|ABAP/i);
     assert.match(sys, /live target system/);
     assert.doesNotMatch(sys, /Additional guidance:/);
+    // Contract: plan by intent, never name a tool; no dangling tool-list ref.
+    assert.match(sys, /do NOT (choose|name)/i);
+    assert.doesNotMatch(sys, /available tools|listed below/i);
 
     // With a hint: it is appended as an "Additional guidance" preamble.
     await new AdaptivePlanner(recording, 'Call one tool at a time.').next({

--- a/packages/llm-agent-server-libs/src/smart-agent/controller/__tests__/planner.test.ts
+++ b/packages/llm-agent-server-libs/src/smart-agent/controller/__tests__/planner.test.ts
@@ -31,7 +31,6 @@ describe('IncrementalPlanner', () => {
     const next = await p.next({
       bundle: bundle(),
       prompt: 'req',
-      toolCatalog: '- GetX: read',
       retrying: false,
     });
     assert.equal(next?.kind, 'next');
@@ -52,7 +51,6 @@ describe('IncrementalPlanner', () => {
     await new IncrementalPlanner(recording, 'Keep the plan minimal.').next({
       bundle: bundle(),
       prompt: 'r',
-      toolCatalog: '',
       retrying: false,
     });
     assert.doesNotMatch(sys, /SAP|ABAP/i);
@@ -65,7 +63,6 @@ describe('IncrementalPlanner', () => {
       await p.next({
         bundle: bundle(),
         prompt: 'r',
-        toolCatalog: '',
         retrying: false,
       }),
       null,
@@ -92,7 +89,6 @@ describe('AdaptivePlanner', () => {
     const next = await p.next({
       bundle: b,
       prompt: 'r',
-      toolCatalog: '',
       retrying: false,
     });
     assert.equal(next?.kind, 'next');
@@ -116,7 +112,6 @@ describe('AdaptivePlanner', () => {
     const next = await p.next({
       bundle: b,
       prompt: 'r',
-      toolCatalog: '',
       retrying: false,
       lastOutcome: 'advanced',
     });
@@ -147,7 +142,6 @@ describe('AdaptivePlanner', () => {
     const next = await p.next({
       bundle: b,
       prompt: 'r',
-      toolCatalog: '',
       retrying: false,
       lastOutcome: 'advanced',
     });
@@ -168,7 +162,6 @@ describe('AdaptivePlanner', () => {
       await p.next({
         bundle: bundle(),
         prompt: 'r',
-        toolCatalog: '',
         retrying: false,
       }),
       null,
@@ -197,7 +190,6 @@ describe('AdaptivePlanner', () => {
     const next = await p.next({
       bundle: b,
       prompt: 'r',
-      toolCatalog: '',
       retrying: false,
       lastOutcome: 'failed',
     });
@@ -221,7 +213,6 @@ describe('AdaptivePlanner', () => {
     const next = await p.next({
       bundle: b,
       prompt: 'r',
-      toolCatalog: '',
       retrying: false,
       lastOutcome: 'failed',
     });
@@ -236,7 +227,6 @@ describe('AdaptivePlanner', () => {
       await p.next({
         bundle: bundle(),
         prompt: 'r',
-        toolCatalog: '',
         retrying: false,
       }),
       null,
@@ -252,7 +242,6 @@ describe('AdaptivePlanner', () => {
       await p.next({
         bundle: b,
         prompt: 'r',
-        toolCatalog: '',
         retrying: false,
       }),
       null,
@@ -272,7 +261,6 @@ describe('AdaptivePlanner', () => {
       await p.next({
         bundle: b,
         prompt: 'r',
-        toolCatalog: '',
         retrying: false,
       }),
       null,
@@ -299,7 +287,6 @@ describe('AdaptivePlanner', () => {
     const next = await p.next({
       bundle: b,
       prompt: 'r',
-      toolCatalog: '',
       retrying: false,
       lastOutcome: 'failed',
     });
@@ -334,7 +321,6 @@ describe('AdaptivePlanner', () => {
     await new AdaptivePlanner(recording).next({
       bundle: b,
       prompt: 'r',
-      toolCatalog: '',
       retrying: false,
       lastOutcome: 'failed',
     });
@@ -362,7 +348,6 @@ describe('AdaptivePlanner', () => {
     await new AdaptivePlanner(recording).next({
       bundle: bundle(),
       prompt: 'r',
-      toolCatalog: '',
       retrying: false,
     });
     assert.doesNotMatch(sys, /SAP|ABAP/i);
@@ -373,7 +358,6 @@ describe('AdaptivePlanner', () => {
     await new AdaptivePlanner(recording, 'Call one tool at a time.').next({
       bundle: bundle(),
       prompt: 'r',
-      toolCatalog: '',
       retrying: false,
     });
     assert.match(sys, /Additional guidance: Call one tool at a time\./);
@@ -398,7 +382,6 @@ describe('AdaptivePlanner', () => {
     const first = await p.next({
       bundle: b,
       prompt: 'r',
-      toolCatalog: '',
       retrying: false,
       lastOutcome: 'failed',
     });
@@ -408,7 +391,6 @@ describe('AdaptivePlanner', () => {
     const second = await p.next({
       bundle: b,
       prompt: 'r',
-      toolCatalog: '',
       retrying: true,
       lastOutcome: b.lastOutcome,
     });

--- a/packages/llm-agent-server-libs/src/smart-agent/controller/controller-coordinator-handler.ts
+++ b/packages/llm-agent-server-libs/src/smart-agent/controller/controller-coordinator-handler.ts
@@ -259,18 +259,13 @@ export class ControllerCoordinatorHandler implements IStageHandler {
     }
 
     // -- Main loop ----------------------------------------------------------
-    // Catalog of the tools relevant to THIS request, surfaced semantically from
-    // the vectorized MCP catalog (toolsRag) — bounded and relevant, not a full
-    // dump — so the planner plans tool-using steps instead of answering blind.
-    const relevantForGoal = await deps.selectTools(
-      `${bundle.goal}\n${prompt}`,
-      TOOL_SELECT_K,
-      ctx.options,
-    );
-    const toolCatalog = buildToolCatalog([
-      ...relevantForGoal,
-      ...(ctx.externalTools ?? []),
-    ]);
+    // The planner plans by INTENT — it is NOT shown a tool catalog. A prompt-level
+    // catalog (selected once from goal+prompt) was too coarse: it mis-surfaced
+    // tools, and the planner baked the wrong tool name into the step instructions,
+    // which then poisoned the executor's own per-step selection. Tool relevance is
+    // instead resolved PER STEP from the clean step instructions when the step
+    // runs (see runStep → selectTools). The agnostic planner prompt already tells
+    // it to plan fetch steps ("the executor picks the exact one").
     const cfg = deps.config.budgets;
     let planParseRetries = 0;
     const planner = makePlanner(
@@ -287,7 +282,6 @@ export class ControllerCoordinatorHandler implements IStageHandler {
       const next = await planner.next({
         bundle,
         prompt,
-        toolCatalog,
         lastOutcome: bundle.lastOutcome,
         resumedExternal,
         retrying: planParseRetries > 0,
@@ -692,30 +686,6 @@ const EXECUTOR_SYSTEM =
   'tool results.';
 
 const TOOL_SELECT_K = 20;
-
-/** Max characters of the tool catalog handed to the planner (safety bound; with
- *  top-K selection the relevant tools fit well under this). */
-const TOOL_CATALOG_MAX_CHARS = 4000;
-
-/** A bounded "name: description" list of the tools the executor can call,
- *  handed to the planner so it plans tool-using fetch steps. */
-function buildToolCatalog(tools: LlmTool[]): string {
-  if (tools.length === 0) return '(no tools available)';
-  const lines: string[] = [];
-  let total = 0;
-  for (let i = 0; i < tools.length; i++) {
-    const t = tools[i];
-    const desc = (t.description ?? '').split('\n')[0].slice(0, 100);
-    const line = `- ${t.name}: ${desc}`;
-    if (total + line.length + 1 > TOOL_CATALOG_MAX_CHARS) {
-      lines.push(`… (+${tools.length - i} more tools)`);
-      break;
-    }
-    lines.push(line);
-    total += line.length + 1;
-  }
-  return lines.join('\n');
-}
 
 /** Top-k recalled artifacts injected into the executor context per step. */
 const RECALL_K = 5;

--- a/packages/llm-agent-server-libs/src/smart-agent/controller/planner.ts
+++ b/packages/llm-agent-server-libs/src/smart-agent/controller/planner.ts
@@ -73,7 +73,13 @@ const CREATE_PLAN_SYSTEM =
   'with a tool — plan fetch steps; never answer from prior knowledge. ' +
   'Keep it MINIMAL: one step per distinct piece of information the goal asks for; ' +
   'do NOT add exploratory or enrichment steps (extra metadata, sample/preview ' +
-  'rows, recursive expansion) the goal did not request. Do NOT add a final step ' +
+  'rows, recursive expansion) the goal did not request. ' +
+  'Do NOT BROADEN the scope: answer exactly what the request asks, at the ' +
+  'granularity it asks. In particular, do NOT add a "for each item, fetch its ' +
+  'details" step unless the request explicitly asks for per-item details — a ' +
+  'request to LIST/SHOW/find items is satisfied by the list itself; fetching the ' +
+  'full details of every listed item is scope creep. ' +
+  'Do NOT add a final step ' +
   'that summarizes, formats, or answers the user — a separate finalizer composes ' +
   'the answer from the fetched results, so the last step must be the last ' +
   'data-fetch/action the goal needs. Output JSON only.';

--- a/packages/llm-agent-server-libs/src/smart-agent/controller/planner.ts
+++ b/packages/llm-agent-server-libs/src/smart-agent/controller/planner.ts
@@ -19,12 +19,14 @@ const PLANNER_SYSTEM =
   'object: {"kind":"next","step":{"name":...,"instructions":...}} to take the ' +
   'next step, {"kind":"done","result":...} when the goal is met, or ' +
   '{"kind":"rewind","reason":...} to discard the current path. Output JSON only.\n' +
-  'An executor carries out each step against the live target system using the ' +
-  'tools listed below. Any fact about the system MUST be obtained by planning a ' +
-  'step that fetches it with a tool — do NOT answer from prior knowledge, and do ' +
-  'NOT mark the goal "done" until the required data has actually been fetched ' +
-  '(fetched results appear under Progress). Until then, return a concrete ' +
-  '"next" fetch step.';
+  'An executor carries out each step against the live target system using tools. ' +
+  'Describe each step by INTENT — WHAT to fetch or do — in plain language. Do ' +
+  'NOT choose, name, or assume a specific tool (no tool names in the step); the ' +
+  'executor selects the right tool for the step. Any fact about the system MUST ' +
+  'be obtained by planning a step that fetches it with a tool — do NOT answer ' +
+  'from prior knowledge, and do NOT mark the goal "done" until the required data ' +
+  'has actually been fetched (fetched results appear under Progress). Until then, ' +
+  'return a concrete "next" fetch step.';
 
 const RETRY_HINT =
   '\nIMPORTANT: your previous reply was NOT valid JSON. Reply with ONLY the raw ' +
@@ -67,7 +69,10 @@ const CREATE_PLAN_SYSTEM =
   'multi-action request MUST yield multiple steps (never a single step that lumps ' +
   'them together). ' +
   'Each step is ONE concrete action an executor performs against the live target ' +
-  'system using the available tools. Any fact about the system MUST be fetched ' +
+  'system using tools. Describe each step by INTENT — WHAT to fetch or do — in ' +
+  'plain language. Do NOT choose, name, or assume a specific tool (no tool names ' +
+  'in the step instructions); the executor selects the right tool for the step. ' +
+  'Any fact about the system MUST be fetched ' +
   'with a tool — plan fetch steps; never answer from prior knowledge. ' +
   'Keep it MINIMAL: one step per distinct piece of information the goal asks for; ' +
   'do NOT add exploratory or enrichment steps (extra metadata, sample/preview ' +
@@ -86,7 +91,9 @@ const REPLAN_SYSTEM =
   'You are the planner. A step just FAILED. Given the goal, the progress so far ' +
   '(fetched results + the failure), produce a REVISED, MINIMAL plan for the ' +
   'REMAINING work as {"plan":[{"name":...,"instructions":...}, ...]}. Plan only ' +
-  'the data-fetch/action steps still required; do NOT add a final summarize/' +
+  'the data-fetch/action steps still required; describe each step by INTENT — do ' +
+  'NOT name or choose a specific tool, the executor selects it. Do NOT add a ' +
+  'final summarize/' +
   'answer step (a separate finalizer composes the answer). If the goal is ' +
   'already satisfied despite the failure, return {"plan":[]}. Output JSON only.';
 
@@ -95,7 +102,9 @@ const EXTERNAL_RESULT_REPLAN_SYSTEM =
   'this is NOT a failure. Given the goal and the progress (including the new ' +
   'result), produce a REVISED, MINIMAL plan for the REMAINING work as ' +
   '{"plan":[{"name":...,"instructions":...}, ...]}. Plan only the data-fetch/' +
-  'action steps still required; do NOT add a final summarize/answer step (a ' +
+  'action steps still required; describe each step by INTENT — do NOT name or ' +
+  'choose a specific tool, the executor selects it. Do NOT add a final summarize/' +
+  'answer step (a ' +
   'separate finalizer composes the answer). If the goal is already satisfied by ' +
   'the result, return {"plan":[]}. Output JSON only.';
 

--- a/packages/llm-agent-server-libs/src/smart-agent/controller/planner.ts
+++ b/packages/llm-agent-server-libs/src/smart-agent/controller/planner.ts
@@ -38,7 +38,7 @@ export class IncrementalPlanner implements IControllerPlanner {
   ) {}
 
   async next(input: PlannerNextInput): Promise<NextStep | null> {
-    const { bundle, prompt, toolCatalog, retrying, logUsage } = input;
+    const { bundle, prompt, retrying, logUsage } = input;
     const res = await this.planner.send([
       {
         role: 'system',
@@ -47,9 +47,7 @@ export class IncrementalPlanner implements IControllerPlanner {
       },
       {
         role: 'user',
-        content:
-          `Goal: ${bundle.goal}\nProgress:${bundle.plannerPrivate}\nRequest: ${prompt}\n` +
-          `Available tools (the executor picks the exact one):\n${toolCatalog}`,
+        content: `Goal: ${bundle.goal}\nProgress:${bundle.plannerPrivate}\nRequest: ${prompt}`,
       },
     ]);
     logUsage?.('planner', res.usage);
@@ -146,15 +144,8 @@ export class AdaptivePlanner implements IControllerPlanner {
   ) {}
 
   async next(input: PlannerNextInput): Promise<NextStep | null> {
-    const {
-      bundle,
-      prompt,
-      toolCatalog,
-      lastOutcome,
-      resumedExternal,
-      retrying,
-      logUsage,
-    } = input;
+    const { bundle, prompt, lastOutcome, resumedExternal, retrying, logUsage } =
+      input;
 
     // 1. No plan yet → create it.
     if (!bundle.plan) {
@@ -162,7 +153,6 @@ export class AdaptivePlanner implements IControllerPlanner {
         CREATE_PLAN_SYSTEM,
         bundle,
         prompt,
-        toolCatalog,
         retrying,
         logUsage,
       );
@@ -193,7 +183,6 @@ export class AdaptivePlanner implements IControllerPlanner {
         system,
         bundle,
         prompt,
-        toolCatalog,
         retrying,
         logUsage,
         completed,
@@ -257,7 +246,6 @@ export class AdaptivePlanner implements IControllerPlanner {
     system: string,
     bundle: SessionBundle,
     prompt: string,
-    toolCatalog: string,
     retrying: boolean,
     logUsage?: (role: string, u?: LlmUsage) => void,
     completed: Step[] = [],
@@ -279,9 +267,7 @@ export class AdaptivePlanner implements IControllerPlanner {
       },
       {
         role: 'user',
-        content:
-          `Goal: ${bundle.goal}\nProgress:${bundle.plannerPrivate}${completedBlock}\nRequest: ${prompt}\n` +
-          `Available tools (the executor picks the exact one):\n${toolCatalog}`,
+        content: `Goal: ${bundle.goal}\nProgress:${bundle.plannerPrivate}${completedBlock}\nRequest: ${prompt}`,
       },
     ]);
     logUsage?.('planner', res.usage);

--- a/packages/llm-agent-server-libs/src/smart-agent/controller/prompts.ts
+++ b/packages/llm-agent-server-libs/src/smart-agent/controller/prompts.ts
@@ -8,10 +8,10 @@
  * WEAKER models: a capable model (Opus / Sonnet) usually needs none, while a
  * smaller executor/planner model (e.g. gpt-4o-mini) may need the extra steering.
  *
- * A hint is NOT a domain description and must NOT name tools (the self-describing
- * tool catalog + the agnostic prompt cover those; richer per-situation
- * procedures belong to the skills RAG — a separate, dynamic mechanism). An absent
- * or blank hint leaves the agnostic prompt untouched.
+ * A hint is NOT a domain description and must NOT name tools: the planner plans
+ * by intent (no tool catalog) and the executor selects the right tool per step;
+ * richer per-situation procedures belong to the skills RAG — a separate, dynamic
+ * mechanism. An absent or blank hint leaves the agnostic prompt untouched.
  */
 export function appendHint(system: string, hint?: string): string {
   const h = hint?.trim();

--- a/packages/llm-agent-server-libs/src/smart-agent/controller/types.ts
+++ b/packages/llm-agent-server-libs/src/smart-agent/controller/types.ts
@@ -84,7 +84,6 @@ export type PlannerKind = 'incremental' | 'adaptive';
 export interface PlannerNextInput {
   bundle: SessionBundle;
   prompt: string;
-  toolCatalog: string;
   /** Outcome of the step run since the previous `next()` (undefined on the first
    *  call / after a rewind / on resume). The adaptive planner replans on 'failed';
    *  the incremental planner ignores it. Cursor advance on 'advanced' happens in

--- a/packages/llm-agent-server-libs/src/smart-agent/controller/types.ts
+++ b/packages/llm-agent-server-libs/src/smart-agent/controller/types.ts
@@ -54,9 +54,10 @@ export interface SessionBundle {
  *  purpose is to scaffold WEAKER models: a capable model (Opus / Sonnet) usually
  *  needs none, while a smaller executor/planner model (e.g. gpt-4o-mini) may
  *  need the extra steering. It is NOT a domain description and must NOT prescribe
- *  tool names (the self-describing tool catalog + the agnostic engine prompt
- *  cover those; richer per-situation procedures belong to the skills RAG).
- *  Absent hint → the role runs on the bare agnostic prompt. */
+ *  tool names: the planner plans by intent (it is shown no tool catalog) and the
+ *  executor selects the right tool per step; richer per-situation procedures
+ *  belong to the skills RAG. Absent hint → the role runs on the bare agnostic
+ *  prompt. */
 export type ControllerSubagentConfig = SmartServerLlmConfig & { hint?: string };
 
 export interface ControllerConfig {


### PR DESCRIPTION
## Summary

Two coupled planner fixes (re-submitted as one reviewable PR; they were briefly direct-merged to main then reverted so they can be reviewed together).

- **Scope-discipline in `CREATE_PLAN_SYSTEM`.** The adaptive planner over-expanded enumerable work: for "show recent dumps" it planned a "list" step PLUS a "fetch full details for EACH dump" step → 13 heavy executor fetches (~677k tokens). Strengthen the prompt: answer exactly what the request asks, at the granularity it asks; a LIST/SHOW/find request is satisfied by the list — no "for each item, fetch its details" step unless explicitly requested.
- **Per-step tool selection (planner plans by intent).** The planner was shown a tool catalog selected once from goal+prompt; that coarse selection mis-surfaced tools and the planner baked the wrong tool name into step instructions (e.g. "Use RuntimeRunProgram" to read source), poisoning the executor's own per-step selection. Removed the prompt-level catalog entirely — the planner plans by intent ("the executor picks the exact one"); tool relevance is resolved per step from the clean step instructions (executor's existing `selectTools`). Dropped the now-dead `buildToolCatalog` and `PlannerNextInput.toolCatalog`.

## Test Plan

- [x] `npm run build` clean
- [x] `npm run lint:check` clean (1 pre-existing warning)
- [x] controller suite green (68/0); full server-libs 325/0 (2 skipped)
- [x] Live (E19, all-sonnet, adaptive): dumps blowup 685k → ~21k (single "list" step, executor requests 13→2); t100 still correct (executor binds GetTable per step from pure-intent instruction); ZDAZ "analyze" no longer flails on wrong tools (207k → 64k); step instructions carry NO baked tool name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)