### PR TITLE
controller: extend scope-discipline to incremental planner + executor

### DIFF
--- a/packages/llm-agent-server-libs/src/smart-agent/controller/controller-coordinator-handler.ts
+++ b/packages/llm-agent-server-libs/src/smart-agent/controller/controller-coordinator-handler.ts
@@ -683,7 +683,11 @@ const EXECUTOR_SYSTEM =
   'status, or source — any current state) by CALLING the appropriate tool — ' +
   'never answer such facts from prior knowledge or memory. Emit a tool call ' +
   'when you need data; only return the step result as content once you have the ' +
-  'tool results.';
+  'tool results. ' +
+  'Do EXACTLY what the step asks, at the granularity it asks — do NOT broaden it: ' +
+  'if the step asks for a LIST or overview, return the list; do NOT then go and ' +
+  'fetch the full details of every listed item unless the step explicitly asks ' +
+  'for per-item details.';
 
 const TOOL_SELECT_K = 20;
 

--- a/packages/llm-agent-server-libs/src/smart-agent/controller/planner.ts
+++ b/packages/llm-agent-server-libs/src/smart-agent/controller/planner.ts
@@ -26,7 +26,11 @@ const PLANNER_SYSTEM =
   'be obtained by planning a step that fetches it with a tool — do NOT answer ' +
   'from prior knowledge, and do NOT mark the goal "done" until the required data ' +
   'has actually been fetched (fetched results appear under Progress). Until then, ' +
-  'return a concrete "next" fetch step.';
+  'return a concrete "next" fetch step. ' +
+  'Keep each step MINIMAL and do NOT broaden the scope beyond what the goal asks, ' +
+  'at the granularity it asks: a LIST/SHOW/find request is satisfied by the list ' +
+  'itself — do NOT plan a step that fetches the full details of every listed item ' +
+  'unless the goal explicitly asks for per-item details.';
 
 const RETRY_HINT =
   '\nIMPORTANT: your previous reply was NOT valid JSON. Reply with ONLY the raw ' +


### PR DESCRIPTION
## Summary

Follow-up to #178. The adaptive create-plan scope-discipline did not cover the **incremental** planner (`PLANNER_SYSTEM`) nor the **executor**, so incremental still blew up on large feeds: "show recent dumps" had the executor enumerate every dump's full details within a single step.

- `PLANNER_SYSTEM`: add the "do not broaden scope / a LIST/SHOW request is satisfied by the list" discipline.
- Executor prompt: do exactly what the step asks at the requested granularity; do not fetch per-item details unless the step asks.

## Test Plan

- [x] build clean, lint clean, controller suite 68/0
- [x] Live (E19): dumps incremental **172k→38k** (sonnet) / **211k→26k** (mixed); t100 incremental **46k→18k**. Executor no longer over-fetches the feed; adaptive unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)