### PR TITLE
docs(pipelines): linear behaviour & guidance + CHANGELOG (dag skill-wiring, marketplace import)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,13 +30,18 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
     serving. The compat wrapper checks embedding-space compatibility per revision
     (eager fail-fast vs runtime degrade), embeds last, and bounds recall by a
     deadline.
-  - **Consumption.** Implicit recall for assembler pipelines (flat/default, linear)
-    via an `IRag` adapter registered as a context-assembler source, and a dedicated
-    controller-planner recall hook (configured group, bounded block, byte-identical
-    when off). New `skillPlugins:` server config (distinct from the existing
-    `skills:` skill-manager key) with validation; built and `load()`ed at startup.
-    A `mode: explicit` (planner-driven per-step group selection), dag/stepper implicit
-    wiring, and live-DB retention guarantees remain follow-on work.
+  - **Consumption.** Implicit recall for assembler pipelines (flat/default, linear,
+    dag) via an `IRag` adapter registered as a context-assembler source, and a
+    dedicated controller-planner recall hook (configured group, bounded block,
+    byte-identical when off). New `skillPlugins:` server config (distinct from the
+    existing `skills:` skill-manager key) with validation; built and `load()`ed at
+    startup. **Skill import** is wired end-to-end: inline `records` sources and
+    **fetched marketplace sources** (`registry` + `enabled` → `GET /plugins` and
+    `GET /plugins/{plugin}/skills/{skill}`, placement via the `one-group-per-plugin`
+    or `single-collection` strategy). A `mode: explicit` (planner-driven per-step
+    group selection), `stepper` implicit wiring, the LIVE marketplace transport
+    (unit-tested only against a mock transport), and live-DB retention guarantees
+    remain follow-on work.
   - **Fail-fast config + safe activation (review hardening).** Present-but-malformed
     config keys now fail loud at parse instead of silently disabling behavior:
     `serveCollections` / `controllerSkillGroup` (must be a non-empty string array /

--- a/docs/PIPELINES.md
+++ b/docs/PIPELINES.md
@@ -102,6 +102,34 @@ pipeline:
   (sonnet deciders + light `gpt-4o-mini` executor, with an executor hint that
   scaffolds the smaller model).
 
+### `linear` planning/dispatch behaviour & guidance
+
+`linear` is a **plan → dispatch** coordinator. The plan is built ONCE by the
+`planning` strategy; each step is run by the `dispatch` strategy. Pick the
+combination to match the task:
+
+- **`planning`**: `one-shot` (plan once, never replan) · `replan-on-error`
+  (delegates the initial plan to one-shot; rebuilds the remaining plan ONLY when a
+  step fails) · `skill-steps` (plan comes from a skill's `steps:` block, no planner
+  LLM). None of them feed step RESULTS back to the planner — the plan is static
+  (one-shot) or reactive-on-failure (replan-on-error), never result-adaptive.
+- **`dispatch`**: `self` (the coordinator's own LLM runs each step) · `subagent`
+  (delegate the step to a named worker from `subagents:`) · `hybrid` (subagent,
+  fall back to self).
+
+**Known characteristics (so you choose the right config):**
+- **The planner is tool-blind** — it sees only the request, the `subagents:` list,
+  and selected skills, NOT the live system. For a task that needs material fetched
+  first (e.g. "review program X"), `planning: one-shot` + `dispatch: self` may
+  return a **clarification asking you to supply the material** instead of planning a
+  fetch step. For such tasks use `dispatch: subagent`/`hybrid` with a tool-capable
+  worker (which fetches the material itself), as in
+  [`coordinator-orchestration.yaml`](examples/coordinator-orchestration.yaml).
+- **Subagent dispatch is stateless across steps** — each step's worker is a fresh
+  full agent run with no carried-over context, so a multi-step plan re-fetches the
+  same material per step (additive latency, redundant work). For **result-aware,
+  context-accumulating** planning, use the `controller` pipeline instead.
+
 ## Adding a custom pipeline (plugin)
 
 A pipeline is an `IPipelinePlugin` (from `@mcp-abap-adt/llm-agent`): it names


### PR DESCRIPTION
## Summary
Folds the durable, eval-confirmed knowledge from the post-#184 pipeline live-eval into the **permanent docs** (not a spec — per the in-progress-only specs convention, the investigation notes live in memory + git history).

- **PIPELINES.md** — new `linear` planning/dispatch behaviour & guidance subsection:
  - `planning` (one-shot / replan-on-error / skill-steps) is never result-adaptive; `dispatch` (self / subagent / hybrid).
  - Known characteristics: the planner is **tool-blind** (one-shot + self can return a clarification asking for material on a fetch task → use subagent/hybrid with a worker); subagent dispatch is **stateless across steps** (multi-step re-fetch → use `controller` for result-aware planning).
- **CHANGELOG.md** — reflects what landed in #184: `dag` now recalls skills implicitly; **skill import wired end-to-end** (inline `records` + fetched **marketplace** sources via `registry`/`enabled`, `one-group-per-plugin`/`single-collection` strategies); narrowed the follow-on list (stepper wiring, `mode: explicit`, live marketplace transport, live-DB retention).

## Context
PR #184 (skill plugin-host) is already merged. This is docs-only catch-up: documentation of what's implemented, in `docs/`. No code changes.

## Test Plan
- [ ] Docs-only; no code. CI green (build + lint).