### PR TITLE
docs(server-context): fix stale serveCollections comment (controllerSkillGroup is independent)

### DIFF
--- a/packages/llm-agent-server-libs/src/pipelines/server-context.ts
+++ b/packages/llm-agent-server-libs/src/pipelines/server-context.ts
@@ -72,11 +72,13 @@ export interface IServerPipelineContext extends IPipelineContext {
     maxInjectChars?: number;
     /**
      * The operator-configured served collection subset
-     * (`skillPlugins.serveCollections`). When set, the implicit assembler wiring
-     * (B3) registers ONLY these groups (a compatible subset that may be read
-     * together), and the controller recall hook (B4) recalls a
-     * `controllerSkillGroup` only if it is within this set. When unset, all
-     * groups the host serves are registered.
+     * (`skillPlugins.serveCollections`). It gates ONLY the implicit assembler
+     * wiring (B3): when set, the assembler registers ONLY these groups (a
+     * compatible subset that may be read together); when unset, all groups the
+     * host serves are registered. It does NOT gate the controller recall hook
+     * (B4): `controllerSkillGroup` is an INDEPENDENT channel — the controller
+     * recalls its configured group regardless of `serveCollections` (the factory
+     * validates only that the group exists, not membership in this set).
      */
     serveCollections?: readonly string[];
   };


### PR DESCRIPTION
## Summary
Comment-only fix. The `serveCollections` JSDoc in `pipelines/server-context.ts` claimed the controller recall hook recalls `controllerSkillGroup` "only if it is within this set" — which contradicts the implementation and a test.

**Reality:** `skill-plugins-host-factory.validateServedGroups` treats `controllerSkillGroup` and `serveCollections` as **independent channels** (validates the group exists, not membership), and `skill-plugins-host-factory.test.ts` asserts *"controllerSkillGroup outside serveCollections is allowed (independent channels)"*. `serveCollections` gates only the implicit **assembler** wiring (B3); the controller recall hook (B4) recalls its group regardless.

Surfaced during the controller-planner spec review (the spec depends on the goal-level controller recall channel being independent).

## Test Plan
- [ ] Comment-only; no behavior change. CI (build + lint) green.