### PR TITLE
fix(rag): bound embed input in knowledge index (large MCP/step results)

### DIFF
--- a/packages/llm-agent-server-libs/src/smart-agent/__tests__/embedder-knowledge-index.test.ts
+++ b/packages/llm-agent-server-libs/src/smart-agent/__tests__/embedder-knowledge-index.test.ts
@@ -182,6 +182,63 @@ describe('makeKnowledgeSemanticIndex', () => {
   });
 });
 
+describe('makeKnowledgeSemanticIndex — bounded embed input (large-result guard)', () => {
+  it('truncates over-budget content to maxEmbedChars before embedding; stores full content', async () => {
+    let lastEmbedLen = -1;
+    const recording = {
+      embed: async (t: string) => {
+        lastEmbedLen = t.length;
+        return { vector: [1, 0, 0] };
+      },
+    } as never;
+    const idx = makeKnowledgeSemanticIndex(recording, undefined, 10);
+    const huge = 'x'.repeat(5000); // ≫ maxEmbedChars (10)
+    await idx.upsert('s', {
+      content: huge,
+      metadata: meta({ artifactType: 'mcp-result', runId: 'R' }),
+    });
+    // The embedder saw a bounded prefix, NOT the 5000-char blob.
+    assert.equal(lastEmbedLen, 10, 'embed input truncated to maxEmbedChars');
+    // The stored + recalled entry keeps the FULL content (only the vector is from a prefix).
+    const hits = await idx.query('s', 'q', 5, { runId: 'R' });
+    assert.equal(hits.length, 1);
+    assert.equal(
+      hits[0].content.length,
+      5000,
+      'full content preserved on recall',
+    );
+  });
+
+  it('does not truncate content within budget', async () => {
+    let lastEmbedLen = -1;
+    const recording = {
+      embed: async (t: string) => {
+        lastEmbedLen = t.length;
+        return { vector: [1, 0, 0] };
+      },
+    } as never;
+    const idx = makeKnowledgeSemanticIndex(recording, undefined, 100);
+    await idx.upsert('s', {
+      content: 'short',
+      metadata: meta({ artifactType: 'mcp-result', runId: 'R' }),
+    });
+    assert.equal(lastEmbedLen, 5, 'within-budget content embedded verbatim');
+  });
+
+  it('also bounds the query text', async () => {
+    let lastEmbedLen = -1;
+    const recording = {
+      embed: async (t: string) => {
+        lastEmbedLen = t.length;
+        return { vector: [1, 0, 0] };
+      },
+    } as never;
+    const idx = makeKnowledgeSemanticIndex(recording, undefined, 10);
+    await idx.query('s', 'y'.repeat(9999), 5);
+    assert.equal(lastEmbedLen, 10, 'query text truncated to maxEmbedChars');
+  });
+});
+
 describe('JsonlKnowledgeBackend index lifecycle', () => {
   const withDir = async (fn: (dir: string) => Promise<void>) => {
     const dir = await mkdtemp(join(tmpdir(), 'ctrl-idx-'));

--- a/packages/llm-agent-server-libs/src/smart-agent/embedder-knowledge-index.ts
+++ b/packages/llm-agent-server-libs/src/smart-agent/embedder-knowledge-index.ts
@@ -32,15 +32,30 @@ export function cosine(a: number[], b: number[]): number {
  *  Infrastructure artifact types (e.g. `controller-bundle`, `controller-terminal`)
  *  are skipped on upsert — they carry the full durable transcript and must NOT be
  *  embedded: they waste tokens and, once the bundle grows beyond the embedder's
- *  input limit, the JSONL rebuild fails permanently. */
+ *  input limit, the JSONL rebuild fails permanently.
+ *
+ *  Recallable content (a tool/step result) is embedded from a BOUNDED PREFIX
+ *  (`maxEmbedChars`): a large MCP result (e.g. a full dictionary dump) can exceed
+ *  the embedder's input limit (SAP AI Core text-embedding-3-small: 8192 tokens),
+ *  which would 400 on upsert and break the JSONL rebuild permanently — and, since
+ *  recall runs mid-run, stall the whole controller turn. Only the embedding VECTOR
+ *  uses the prefix; the STORED entry keeps the full content, so recall still
+ *  returns the complete result. The default (16000 chars ≈ ≤ 8000 tokens even at a
+ *  pessimistic 2 chars/token) stays safely under the limit with ample ranking
+ *  signal; override per deployment if needed. */
 export function makeKnowledgeSemanticIndex(
   embedder: IEmbedder,
   skipArtifactTypes: readonly string[] = [
     'controller-bundle',
     'controller-terminal',
   ],
+  maxEmbedChars = 16000,
 ) {
   const bySession = new Map<string, Indexed[]>();
+  // Bound the text handed to the embedder so an over-limit document never 400s
+  // (the full content is stored separately and returned by recall unchanged).
+  const embedInput = (text: string): string =>
+    text.length > maxEmbedChars ? text.slice(0, maxEmbedChars) : text;
   return {
     async upsert(
       sid: string,
@@ -49,7 +64,7 @@ export function makeKnowledgeSemanticIndex(
     ): Promise<void> {
       // Skip infrastructure artifact types — never embed, never index.
       if (skipArtifactTypes.includes(e.metadata.artifactType)) return;
-      const { vector } = await embedder.embed(e.content, options);
+      const { vector } = await embedder.embed(embedInput(e.content), options);
       const arr = bySession.get(sid);
       if (arr) arr.push({ entry: e, vector });
       else bySession.set(sid, [{ entry: e, vector }]);
@@ -65,7 +80,7 @@ export function makeKnowledgeSemanticIndex(
       const scoped = filter
         ? all.filter((x) => matchesKnowledgeFilter(x.entry.metadata, filter))
         : all; // PRE-cap
-      const { vector: q } = await embedder.embed(text, options);
+      const { vector: q } = await embedder.embed(embedInput(text), options);
       const ranked = scoped
         .map((x) => ({ e: x.entry, s: cosine(q, x.vector) }))
         .sort((a, b) => b.s - a.s)


### PR DESCRIPTION
## Summary

A large MCP/step result (e.g. a full ABAP dictionary dump, ~61KB from a `DD03L` query) exceeded the embedder's input limit (SAP AI Core `text-embedding-3-small`: **8192 tokens**), returning **400** on upsert. Because:
1. the failure broke the JSONL semantic-index rebuild **permanently** (`build()` re-embeds every entry and rethrows on the oversized one), and
2. run-scoped recall runs **mid-turn**,

…the whole controller run stalled — the step never reached the reviewer/finalizer and the HTTP request returned `(no response)`.

## Fix

`makeKnowledgeSemanticIndex` now embeds a **bounded prefix** (`maxEmbedChars`, default `16000` — safely under 8192 tokens even at a pessimistic 2 chars/token) for both the upsert content and the query text. Only the embedding **vector** uses the prefix; the **stored entry keeps the full content**, so recall still returns the complete result. This mirrors the existing infra-artifact skip-list philosophy (embedding is a best-effort ranking signal) already in this file.

## Verified live

Controller pipeline + SAP AI Core (LLM + embedder) + MCP via the local proxy on :3001, with the `skillPlugins` host loading the `sap-abap` skill from a marketplace shim over the [sap-skills](https://github.com/secondsky/sap-skills) repo (runtime-only; not bundled).

- **Before:** the "read VBAK structure" prompt → `(no response)`, run left `executing`, repeated embedder `400`.
- **After:** full `evaluator → planner → executor → reviewer → finalizer` cycle, a real structured answer (256 DD03L records → VBAK field table), **0 embedder 400s**. Artifacts written: `plan-decision` (Phase 2 board), `step-result` (stepId+digest), `controller-terminal` (finalize).

## Test plan
- [x] `npm run -w @mcp-abap-adt/llm-agent-server-libs test` — 561 tests, 559 pass, 0 fail, 2 skipped (pre-existing live-integration skips). Includes 3 new tests: prefix truncation on over-budget content, no truncation within budget, query-text bounding.
- [x] Build green; `npm run lint:check` — 0 errors.
- [x] Live end-to-end verification (above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)