### PR TITLE
docs: remediate v19 stale examples + docs (removed coordinator:/structured-pipeline)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -750,7 +750,7 @@ Consumers extend the agent by implementing `IPipeline` directly and injecting it
 Key components:
 - **`PipelineExecutor`** (`packages/llm-agent-libs/src/pipeline/executor.ts`) — walks the stage tree, handles `parallel`/`repeat` control flow, evaluates `when` conditions, creates tracer spans.
 - **`PipelineContext`** (`packages/llm-agent/src/pipeline/context.ts`) — mutable state bag threaded through all stages. Contains immutable input, injected dependencies, mutable state (RAG results, tools, messages), and a `yield()` callback for streaming.
-- **`IStageHandler`** (`packages/llm-agent/src/pipeline/stage-handler.ts`) — single-method interface: `execute(ctx, config, span): Promise<boolean>`.
+- **`IStageHandler`** (`packages/llm-agent/src/interfaces/plugin.ts`) — single-method interface: `execute(ctx, config, span): Promise<boolean>`. Used internally by built-in handlers and by plugin authors (exported via `PluginExports.stageHandlers`).
 - **Condition evaluator** (`packages/llm-agent/src/pipeline/condition-evaluator.ts`) — safe expression evaluator for `when`/`until` fields. Supports dot-path property access, negation, `&&`/`||`, comparisons. No `eval()`.
 
 ### Stage Types
@@ -811,33 +811,27 @@ builder
   .build();
 ```
 
-### Custom Stage Handlers
+### Customising Orchestration (v19+)
 
-Consumers can register custom stage handlers via the builder:
+Three mechanisms are available to end-users and integrators:
 
-```ts
-import type { IStageHandler, PipelineContext } from '@mcp-abap-adt/llm-agent';
+1. **Select a built-in pipeline by name** (YAML, recommended):
+   ```yaml
+   pipeline:
+     name: flat    # flat | linear | dag | stepper | controller | controller-weak
+     config: {}    # pipeline-specific options (see PIPELINES.md)
+   ```
+   Omit `pipeline:` entirely to get the default `flat` pipeline.
 
-class AuditLogHandler implements IStageHandler {
-  async execute(ctx: PipelineContext, config: Record<string, unknown>, span: ISpan): Promise<boolean> {
-    console.log(`[audit] Processing: ${ctx.inputText.slice(0, 100)}`);
-    return true; // continue pipeline
-  }
-}
+2. **Inject a custom `IPipeline`** (programmatic):
+   ```ts
+   builder.setPipeline(new MyPipeline());
+   ```
+   The custom implementation receives `PipelineDeps` via `initialize()` and owns the full orchestration. See the [Custom pipeline example](#custom-pipeline-example-with-consumer-defined-stores) above.
 
-builder.withStageHandler('audit-log', new AuditLogHandler());
-```
+3. **Register a pipeline plugin** — implement `IPipelinePlugin`, export it as `pipelinePlugins` from a plugin module, and select it by `pipeline.name`. See [INTEGRATION.md](INTEGRATION.md) for the Plugin System.
 
-Then reference in YAML:
-
-```yaml
-stages:
-  - id: audit
-    type: audit-log
-  - id: classify
-    type: classify
-  # ...
-```
+> **Removed in v19:** `builder.withStageHandler()`, `builder.withStageHandlers()`, `getDefaultStages()`, and the structured `pipeline: { version: "1", stages: [...] }` YAML DSL have been removed and will fail at startup. Use the mechanisms above instead.
 
 ### Backwards Compatibility
 
@@ -852,8 +846,9 @@ packages/llm-agent/src/
   pipeline/
     types.ts              # StageDefinition, BuiltInStageType, ControlFlowType
     context.ts            # PipelineContext interface
-    stage-handler.ts      # IStageHandler interface
     condition-evaluator.ts # Safe expression evaluator for when/until
+  interfaces/
+    plugin.ts             # IStageHandler interface (also PluginExports, IPluginLoader)
 
 packages/llm-agent-libs/src/
   pipeline/
@@ -912,7 +907,7 @@ A plugin module can export any subset of:
 
 | Export name          | Type                              | Registers as            |
 |----------------------|-----------------------------------|-------------------------|
-| `stageHandlers`      | `Record<string, IStageHandler>`   | Pipeline stage handlers |
+| `stageHandlers`      | `Record<string, IStageHandler>`   | Stage handler implementations (plugin-author use; no YAML/builder wiring — use `pipelinePlugins` to expose them to end-users) |
 | `embedderFactories`  | `Record<string, EmbedderFactory>` | Embedder factories      |
 | `reranker`           | `IReranker`                       | RAG reranker            |
 | `queryExpander`      | `IQueryExpander`                  | Query expander          |
@@ -949,7 +944,7 @@ For custom loader authors:
 SmartServer.start() / builder.build()
   → IPluginLoader.load()           # discover & import plugins
   → merge embedderFactories        # plugins + config (config wins)
-  → apply stageHandlers to builder # plugin handlers available in YAML
+  → register stageHandlers          # available to internal pipeline implementations
   → apply reranker, expander, validator
   → resolve mcpClients             # config > plugin > YAML fallback
   → build agent

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -179,36 +179,36 @@ const handle = await new SmartAgentBuilder()
   .build();
 ```
 
-### Custom pipeline implementation with stage handler
+### Custom pipeline implementation
 
-```ts
-import { SmartAgentBuilder } from '@mcp-abap-adt/llm-agent-libs';
-import type { IStageHandler, PipelineContext } from '@mcp-abap-adt/llm-agent-libs';
-import type { ISpan } from '@mcp-abap-adt/llm-agent';
+Three ways to customise orchestration (v19+):
 
-class AuditLogHandler implements IStageHandler {
-  async execute(ctx: PipelineContext, config: Record<string, unknown>, span: ISpan): Promise<boolean> {
-    const level = (config.level as string) ?? 'info';
-    console.log(`[${level}] Processing: ${ctx.inputText.slice(0, 100)}`);
-    return true;
-  }
-}
+1. **Select a built-in pipeline by name** (YAML):
+   ```yaml
+   pipeline:
+     name: flat          # flat | linear | dag | stepper | controller | controller-weak
+     config: {}          # pipeline-specific options
+   ```
 
-const handle = await new SmartAgentBuilder()
-  .withConfigPath('smart-server.yaml')
-  .withStageHandlers({ 'audit-log': new AuditLogHandler() })
-  .build();
-```
+2. **Inject a custom `IPipeline`** (programmatic):
+   ```ts
+   import type { IPipeline, PipelineDeps, PipelineResult, LlmStreamChunk } from '@mcp-abap-adt/llm-agent';
+   import { SmartAgentBuilder } from '@mcp-abap-adt/llm-agent-libs';
 
-Register the handler in YAML by selecting a named pipeline and passing the custom stage in `pipeline.config`:
+   class MyPipeline implements IPipeline {
+     initialize(deps: PipelineDeps): void { /* wire deps */ }
+     async execute(input, history, options, yieldChunk): Promise<PipelineResult> {
+       // fully custom orchestration
+     }
+   }
 
-```yaml
-pipeline:
-  name: flat
-  config:
-    stageHandlers:
-      audit-log: {}  # resolved from the withStageHandlers() registry
-```
+   const handle = await new SmartAgentBuilder()
+     .withConfigPath('smart-server.yaml')
+     .setPipeline(new MyPipeline())
+     .build();
+   ```
+
+3. **Register a pipeline plugin** — implement `IPipelinePlugin`, export it as `pipelinePlugins` from a plugin module, and select it by name via `pipeline.name`. See [INTEGRATION.md](INTEGRATION.md) for the Plugin System details.
 
 ### Skills — programmatic setup
 

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -56,16 +56,16 @@ PER REQUEST (DefaultPipeline)
 | [`01-minimal-inmemory.yaml`](examples/01-minimal-inmemory.yaml) | Minimal start — DeepSeek + in-memory RAG, no MCP |
 | [`02-ollama-mcp.yaml`](examples/02-ollama-mcp.yaml) | Ollama embeddings + MCP tools |
 | [`03-multi-model.yaml`](examples/03-multi-model.yaml) | Separate classifier/helper models + Qdrant RAG |
-| [`12-deepseek-mcp.yaml`](examples/12-deepseek-mcp.yaml) | **Full options reference** — DeepSeek + Ollama embeddings + MCP with all agent knobs and commented advanced sections (multi-model pipeline, structured stages, custom prompts) |
+| [`12-deepseek-mcp.yaml`](examples/12-deepseek-mcp.yaml) | **Full options reference** — DeepSeek + Ollama embeddings + MCP with all agent knobs and commented advanced sections (multi-model pipeline, named pipeline config, custom prompts) |
 
-### Structured pipeline configs — YAML-defined stage tree
+### Named pipeline configs
 
 | File | Description |
 |---|---|
 | [`04-structured-default.yaml`](examples/04-structured-default.yaml) | DefaultPipeline flow as explicit YAML (tools + history stores) |
 | [`05-structured-minimal.yaml`](examples/05-structured-minimal.yaml) | Minimal pipeline — no RAG, just classify + assemble + tool-loop |
 | [`06-structured-multi-model.yaml`](examples/06-structured-multi-model.yaml) | Multi-model + Qdrant tools store + higher tool limits |
-| [`07-structured-sap-ai-core.yaml`](examples/07-structured-sap-ai-core.yaml) | SAP AI Core provider with structured pipeline |
+| [`07-structured-sap-ai-core.yaml`](examples/07-structured-sap-ai-core.yaml) | SAP AI Core provider |
 | [`08-real-world-scenario.yaml`](examples/08-real-world-scenario.yaml) | **Full real-world scenario** with detailed comments explaining tool vectorization, classification, and tool selection |
 | [`09-parallel-optimized.yaml`](examples/09-parallel-optimized.yaml) | **Parallel-optimized** — summarize ‖ RAG queries run in parallel |
 | [`10-plugins.yaml`](examples/10-plugins.yaml) | **Plugin-extended** — loads custom stage handlers from a plugin directory |
@@ -80,25 +80,7 @@ npm run dev -- --config docs/examples/04-structured-default.yaml
 
 OpenAI-compatible endpoint: `http://localhost:4004/v1/chat/completions`
 
-## Simple vs structured pipeline — comparison
-
-| Feature | Simple (flat YAML) | Structured pipeline |
-|---|---|---|
-| Config location | `llm:`, `rag:`, `mcp:`, `agent:` top-level keys | `pipeline:` section with `version` + `stages` |
-| Orchestration flow | DefaultPipeline (tools + history stores) | YAML-defined stage tree |
-| Stage ordering | Fixed | Fully customizable |
-| Parallel stages | Fixed internal parallelism | Explicit `parallel` type with `after` |
-| Custom stages | Not possible | `withStageHandler()` + YAML reference |
-| Conditional stages | `agent.classificationEnabled` | `when` expressions on any stage |
-| Loops | Fixed tool loop | `repeat` type with `until` + `maxIterations` |
-| Custom RAG stores | Not possible | Implement custom `IPipeline` |
-| Best for | Simple setups, quick start | Complex orchestration, consumer-defined pipelines |
-
-**Without `pipeline.stages`** — `DefaultPipeline` runs (tools + history stores only).
-
-**With `pipeline.stages`** — the executor replaces DefaultPipeline entirely.
-
-**With custom `IPipeline`** — inject via `.setPipeline(myPipeline)` for full control.
+The pipeline is selected by name (`pipeline: { name, config }`); omit it for the default `flat` flow. See [PIPELINES.md](PIPELINES.md).
 
 ## Programmatic Examples
 
@@ -197,7 +179,7 @@ const handle = await new SmartAgentBuilder()
   .build();
 ```
 
-### Structured pipeline with custom stage handler
+### Custom pipeline implementation with stage handler
 
 ```ts
 import { SmartAgentBuilder } from '@mcp-abap-adt/llm-agent-libs';
@@ -218,18 +200,14 @@ const handle = await new SmartAgentBuilder()
   .build();
 ```
 
-Then reference in YAML (see [`04-structured-default.yaml`](examples/04-structured-default.yaml) and add):
+Register the handler in YAML by selecting a named pipeline and passing the custom stage in `pipeline.config`:
 
 ```yaml
 pipeline:
-  version: "1"
-  stages:
-    - id: audit
-      type: audit-log
-      config: { level: info }
-    - id: classify
-      type: classify
-    # ... rest of stages
+  name: flat
+  config:
+    stageHandlers:
+      audit-log: {}  # resolved from the withStageHandlers() registry
 ```
 
 ### Skills — programmatic setup

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -2005,220 +2005,71 @@ const handle = await new SmartAgentBuilder()
   .build();
 ```
 
-## Structured Pipeline (YAML DSL)
+## Custom Pipelines & Plugins
 
-The structured pipeline replaces the hardcoded orchestration flow with a YAML-defined stage tree. This enables reordering, skipping, or adding custom stages without modifying agent code.
+> For the full list of built-in pipeline variants and their YAML config options, see [`docs/PIPELINES.md`](PIPELINES.md).
 
-### Enabling via YAML
+In v19 the YAML `pipeline.version` / `pipeline.stages` DSL and the builder methods `withPipeline(stageTree)` / `withStageHandler()` / `getDefaultStages()` were removed and fail loud at startup. The current extension model has three levels:
 
-Add `pipeline.version` and `pipeline.stages` to your config:
+1. **Select a built-in pipeline by name** — zero code, just YAML config.
+2. **Register a pipeline plugin** (`IPipelinePlugin` / `pipelinePlugins`) — ship a named agent variant as a plugin module; SmartServer selects it via `pipeline: { name: <plugin> }`.
+3. **Inject a custom `IPipeline` programmatically** — full control via `builder.setPipeline(myPipeline)`.
+
+### Built-in pipeline selection
+
+Select a pipeline in `smart-server.yaml` with the `pipeline.name` key (default: `flat`):
 
 ```yaml
-llm:
-  main:
-    provider: openai
-    apiKey: ${OPENAI_API_KEY}
-    model: gpt-4o
-
 pipeline:
-  version: "1"
-  stages:
-    - id: classify
-      type: classify
-    - id: summarize
-      type: summarize
-    - id: rag-retrieval
-      type: parallel
-      when: "shouldRetrieve"
-      stages:
-        - { id: translate, type: translate }
-        - { id: expand, type: expand }
-      after:
-        - id: rag-queries
-          type: parallel
-          stages:
-            - { id: facts, type: rag-query, config: { store: facts, k: 10 } }
-            - { id: feedback, type: rag-query, config: { store: feedback, k: 5 } }
-            - { id: state, type: rag-query, config: { store: state, k: 5 } }
-        - { id: rerank, type: rerank }
-        - { id: tool-select, type: tool-select }
-    - id: assemble
-      type: assemble
-    - id: tool-loop
-      type: tool-loop
+  name: stepper        # flat | linear | dag | stepper | controller | controller-weak
+  config:
+    maxDepth: 4        # pipeline-specific config passed to the plugin's parseConfig()
 ```
 
-### Enabling via Builder (programmatic)
+Omit `pipeline:` entirely (or omit `name`) to use the `flat` default.
+
+### Custom `IPipeline` via `setPipeline()`
+
+For programmatic setups where you need full control over orchestration, implement `IPipeline` and inject it via the builder:
 
 ```ts
-import {
-  SmartAgentBuilder,
-  type StructuredPipelineDefinition,
-  getDefaultStages,
-} from '@mcp-abap-adt/llm-agent-libs';
+import type { IPipeline } from '@mcp-abap-adt/llm-agent-libs';
+import { SmartAgentBuilder } from '@mcp-abap-adt/llm-agent-libs';
 
-const pipeline: StructuredPipelineDefinition = {
-  version: '1',
-  stages: getDefaultStages(), // or your custom stage tree
-};
+class MyCustomPipeline implements IPipeline {
+  // implement initialize() and run() according to IPipeline contract
+}
 
 const handle = await new SmartAgentBuilder({ mcp: { type: 'http', url: '...' } })
   .withMainLlm(myLlm)
-  .withPipeline(pipeline)
+  .setPipeline(new MyCustomPipeline())
   .build();
 ```
 
-### Stage Definition Reference
-
-Each stage has the following fields:
-
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `id` | `string` | yes | Unique identifier for logging/tracing |
-| `type` | `string` | yes | Built-in type or custom handler name |
-| `config` | `object` | no | Arbitrary config passed to the handler |
-| `when` | `string` | no | Condition expression — stage skipped if falsy |
-| `stages` | `StageDefinition[]` | no | Child stages (for `parallel`/`repeat`) |
-| `after` | `StageDefinition[]` | no | Sequential follow-up stages (for `parallel` only) |
-| `maxIterations` | `number` | no | Max loop iterations (for `repeat`, default: 10) |
-| `until` | `string` | no | Stop condition (for `repeat`) |
-
-### Condition Expressions
-
-The `when` and `until` fields use a safe expression evaluator (no `eval()`):
-
-```yaml
-# Simple property check (truthy)
-when: "shouldRetrieve"
-
-# Negation
-when: "!isAscii"
-
-# Dot-path access
-when: "config.classificationEnabled"
-
-# Boolean operators
-when: "shouldRetrieve && !isAscii"
-
-# Comparisons
-until: "state.iterationCount >= 5"
-```
-
-Supported operators: `!`, `&&`, `||`, `>`, `<`, `>=`, `<=`, `==`, `!=`
-
-### Custom Stage Handlers
-
-Register custom handlers for domain-specific pipeline stages:
-
-```ts
-import type { IStageHandler, PipelineContext } from '@mcp-abap-adt/llm-agent-libs';
-import type { ISpan } from '@mcp-abap-adt/llm-agent';
-
-class ContentFilterHandler implements IStageHandler {
-  async execute(
-    ctx: PipelineContext,
-    config: Record<string, unknown>,
-    span: ISpan,
-  ): Promise<boolean> {
-    const blockedPatterns = (config.patterns as string[]) ?? [];
-    for (const pattern of blockedPatterns) {
-      if (new RegExp(pattern, 'i').test(ctx.inputText)) {
-        ctx.error = `Input matched blocked pattern: ${pattern}`;
-        return false; // abort pipeline
-      }
-    }
-    return true; // continue
-  }
-}
-
-// Register via builder
-builder.withStageHandler('content-filter', new ContentFilterHandler());
-```
-
-Then use in YAML:
-
-```yaml
-stages:
-  - id: filter
-    type: content-filter
-    config:
-      patterns: ["DROP TABLE", "rm -rf"]
-  - id: classify
-    type: classify
-  # ...
-```
-
-### Parallel Execution with Sequential Follow-up
-
-The `parallel` type runs `stages` concurrently, then runs `after` stages sequentially:
-
-```yaml
-- id: rag-retrieval
-  type: parallel
-  stages:
-    # These run concurrently
-    - { id: translate, type: translate }
-    - { id: expand, type: expand }
-  after:
-    # These run sequentially after all parallel stages complete
-    - id: queries
-      type: parallel
-      stages:
-        - { id: facts, type: rag-query, config: { store: facts } }
-        - { id: state, type: rag-query, config: { store: state } }
-    - { id: rerank, type: rerank }
-```
-
-### Repeat (Loop) Stages
-
-The `repeat` type loops child stages until a condition or max iterations:
-
-```yaml
-- id: retry-loop
-  type: repeat
-  maxIterations: 3
-  until: "state.validationPassed"
-  stages:
-    - { id: tool-loop, type: tool-loop }
-    - { id: validate, type: my-validator }
-```
-
-### Minimal Pipeline (Skip RAG)
-
-For simple LLM-only use cases, define a minimal pipeline:
-
-```yaml
-pipeline:
-  version: "1"
-  stages:
-    - id: classify
-      type: classify
-    - id: assemble
-      type: assemble
-    - id: tool-loop
-      type: tool-loop
-```
-
-### Using Default Stages as Base
-
-```ts
-import { getDefaultStages } from '@mcp-abap-adt/llm-agent-libs';
-
-// Get default stages and insert a custom stage before tool-loop
-const stages = getDefaultStages();
-const toolLoopIndex = stages.findIndex(s => s.id === 'tool-loop');
-stages.splice(toolLoopIndex, 0, {
-  id: 'audit',
-  type: 'audit-log',
-  config: { level: 'info' },
-});
-
-builder.withPipeline({ version: '1', stages });
-```
+`setPipeline()` bypasses the plugin registry entirely — `pipeline.name` in YAML is ignored when a pipeline is injected this way. Use it when you need a one-off custom pipeline for a single deployment rather than a reusable named variant.
 
 ### Plugin System
 
-The library provides a plugin system for loading custom implementations from external sources. It uses the same DI pattern as the rest of the library: an interface with a default implementation.
+The plugin system is the canonical way to ship a reusable named pipeline (or other components such as embedder factories, rerankers, and output validators). A plugin module exports a `PluginExports` object; SmartServer merges all plugin registrations at startup before accepting requests.
+
+#### IPipelinePlugin contract
+
+```ts
+import type { IPipelinePlugin, IPipelineContext, IPipelineInstance } from '@mcp-abap-adt/llm-agent';
+
+interface IPipelinePlugin<Config = unknown> {
+  readonly name: string;
+  parseConfig(raw: unknown): Config;               // validates + parses pipeline.config
+  build(config: Config, ctx: IPipelineContext): Promise<IPipelineInstance>;
+}
+
+interface IPipelineInstance {
+  readonly agent: ISmartAgent;
+  close(): Promise<void>;                          // release MCP / RAG / session resources
+}
+```
+
+`IPipelineContext` gives a plugin opaque access to per-role LLMs (`resolveLlm(role)`), the session-scoped knowledge RAG, the tools RAG handle, and MCP clients — without importing server-internal types.
 
 #### IPluginLoader interface
 
@@ -2228,21 +2079,22 @@ interface IPluginLoader {
 }
 ```
 
-The loader discovers plugins and returns merged registrations. The library ships `FileSystemPluginLoader` as the default — consumers can replace it with their own implementation.
+The loader discovers plugin modules and returns merged registrations. The library ships `FileSystemPluginLoader` as the default — consumers can replace it with their own implementation.
 
 #### PluginExports — what a plugin provides
 
 All fields are optional — a plugin can register any subset:
 
-| Export               | Type                              | Effect                          |
-|----------------------|-----------------------------------|---------------------------------|
-| `stageHandlers`      | `Record<string, IStageHandler>`   | Available in YAML `type:`       |
-| `embedderFactories`  | `Record<string, EmbedderFactory>` | Available in YAML `rag.embedder:` |
-| `reranker`           | `IReranker`                       | Replaces default reranker       |
-| `queryExpander`      | `IQueryExpander`                  | Replaces default query expander |
-| `outputValidator`    | `IOutputValidator`                | Replaces default validator      |
-| `skillManager`       | `ISkillManager`                   | Replaces default skill manager  |
-| `mcpClients`         | `IMcpClient[]`                    | Accumulated MCP clients         |
+| Export               | Type                                   | Effect                                    |
+|----------------------|----------------------------------------|-------------------------------------------|
+| `pipelinePlugins`    | `Record<string, IPipelinePlugin>`      | Named pipeline variants (selected by YAML `pipeline.name`) |
+| `embedderFactories`  | `Record<string, EmbedderFactory>`      | Available in YAML `rag.embedder:`         |
+| `reranker`           | `IReranker`                            | Replaces default reranker                 |
+| `queryExpander`      | `IQueryExpander`                       | Replaces default query expander           |
+| `outputValidator`    | `IOutputValidator`                     | Replaces default validator                |
+| `skillManager`       | `ISkillManager`                        | Replaces default skill manager            |
+| `mcpClients`         | `IMcpClient[]`                         | Accumulated MCP clients                   |
+| `stageHandlers`      | `Record<string, IStageHandler>`        | Internal stage handlers (used by stepper/DAG pipelines) |
 
 #### Option 1: FileSystemPluginLoader (default)
 
@@ -2254,21 +2106,39 @@ Drop plugin files into a directory. SmartServer scans and loads them at startup.
 2. `./plugins/` — project-level (relative to cwd)
 3. `--plugin-dir <path>` CLI flag or `pluginDir` in YAML config
 
-**Example plugin file** (`~/.config/llm-agent/plugins/audit-log.ts`):
+**Example pipeline plugin file** (`~/.config/llm-agent/plugins/my-pipeline.ts`):
 
 ```ts
-import type { IStageHandler, PipelineContext } from '@mcp-abap-adt/llm-agent-libs';
-import type { ISpan } from '@mcp-abap-adt/llm-agent';
+import type {
+  IPipelinePlugin,
+  IPipelineContext,
+  IPipelineInstance,
+} from '@mcp-abap-adt/llm-agent';
 
-class AuditLogHandler implements IStageHandler {
-  async execute(ctx: PipelineContext, config: Record<string, unknown>, span: ISpan) {
-    console.log(`[audit] ${ctx.inputText.slice(0, 100)}`);
-    return true;
-  }
+interface MyConfig {
+  maxRetries: number;
 }
 
-export const stageHandlers = {
-  'audit-log': new AuditLogHandler(),
+const myPlugin: IPipelinePlugin<MyConfig> = {
+  name: 'my-pipeline',
+
+  parseConfig(raw: unknown): MyConfig {
+    const cfg = (raw ?? {}) as Record<string, unknown>;
+    return { maxRetries: typeof cfg.maxRetries === 'number' ? cfg.maxRetries : 3 };
+  },
+
+  async build(config: MyConfig, ctx: IPipelineContext): Promise<IPipelineInstance> {
+    const llm = await ctx.resolveLlm('main');
+    // ... build and return your agent instance
+    return {
+      agent: myAgent,
+      close: async () => { /* release resources */ },
+    };
+  },
+};
+
+export const pipelinePlugins = {
+  'my-pipeline': myPlugin,
 };
 ```
 
@@ -2278,13 +2148,9 @@ export const stageHandlers = {
 pluginDir: ./my-plugins
 
 pipeline:
-  version: "1"
-  stages:
-    - id: audit
-      type: audit-log      # resolved from plugin
-    - id: classify
-      type: classify
-    # ...
+  name: my-pipeline    # resolved from plugin
+  config:
+    maxRetries: 5
 ```
 
 **Programmatic usage:**
@@ -2334,14 +2200,14 @@ class NpmPluginLoader implements IPluginLoader {
 
 // Use via builder
 builder.withPluginLoader(new NpmPluginLoader([
-  '@my-org/llm-plugin-audit',
+  '@my-org/llm-plugin-my-pipeline',
   '@my-org/llm-plugin-cohere-embedder',
 ]));
 
 // Or via SmartServer config
 const server = new SmartServer({
   ...config,
-  pluginLoader: new NpmPluginLoader(['@my-org/llm-plugin-audit']),
+  pluginLoader: new NpmPluginLoader(['@my-org/llm-plugin-my-pipeline']),
 });
 ```
 
@@ -2357,9 +2223,9 @@ class CompositePluginLoader implements IPluginLoader {
     const result = emptyLoadedPlugins();
     for (const loader of this.loaders) {
       const plugins = await loader.load();
-      // Merge each loader's results (later wins)
-      for (const [type, handler] of plugins.stageHandlers) {
-        result.stageHandlers.set(type, handler);
+      // Merge each loader's results (later wins for single-valued fields)
+      for (const [name, plugin] of plugins.pipelinePlugins) {
+        result.pipelinePlugins.set(name, plugin);
       }
       Object.assign(result.embedderFactories, plugins.embedderFactories);
       if (plugins.reranker) result.reranker = plugins.reranker;
@@ -2375,7 +2241,7 @@ class CompositePluginLoader implements IPluginLoader {
 
 builder.withPluginLoader(new CompositePluginLoader([
   new FileSystemPluginLoader({ dirs: getDefaultPluginDirs() }),
-  new NpmPluginLoader(['@my-org/llm-plugin-audit']),
+  new NpmPluginLoader(['@my-org/llm-plugin-my-pipeline']),
 ]));
 ```
 
@@ -2385,7 +2251,7 @@ builder.withPluginLoader(new CompositePluginLoader([
 builder.withXxx()  >  plugin loader  >  built-in defaults
 ```
 
-Explicit builder calls (`withReranker()`, `withStageHandler()`, etc.) always take precedence over plugin-loaded registrations. This allows consumers to override individual plugin components without replacing the entire loader.
+Explicit builder calls (`withReranker()`, `withOutputValidator()`, etc.) always take precedence over plugin-loaded registrations. This allows consumers to override individual plugin components without replacing the entire loader.
 
 #### Helper utilities for custom loaders
 
@@ -2398,8 +2264,6 @@ Explicit builder calls (`withReranker()`, `withStageHandler()`, etc.) always tak
 #### Performance note
 
 Plugin loading happens **once at startup** (during `builder.build()` or `SmartServer.start()`), not per request. Loaded handlers are plain objects in memory — zero runtime overhead compared to direct builder wiring.
-
-See [`docs/examples/plugins/`](examples/plugins/) for 6 complete plugin examples covering all export types.
 
 ## Test Doubles
 

--- a/docs/examples/04-structured-default.yaml
+++ b/docs/examples/04-structured-default.yaml
@@ -1,5 +1,13 @@
-# Structured pipeline — reproduces the DefaultPipeline flow as explicit YAML.
+# Flat pipeline (v19+) — reproduces the DefaultPipeline flow without explicit stage YAML.
 # Good starting point for understanding the built-in stage sequence.
+#
+# The flat pipeline (default when no `pipeline:` is specified) runs the full
+# DefaultPipeline flow: classify → summarize → rag-retrieval(parallel) → rerank
+# → skill-select → tool-select → assemble → tool-loop → history-upsert.
+#
+# The structured-stages DSL (`pipeline: { version, stages }`) was removed in v19.
+# Omitting `pipeline:` (or setting `pipeline: { name: flat }`) selects flat, which
+# is identical to what the old structured default demo described.
 #
 # DefaultPipeline uses only two RAG stores:
 #   - tools:   MCP tool descriptions + skill descriptions (for tool/skill selection)
@@ -16,6 +24,7 @@ host: 0.0.0.0
 mode: smart
 
 llm:
+  provider: deepseek
   apiKey: ${DEEPSEEK_API_KEY}
   model: deepseek-chat
   temperature: 0.7
@@ -29,51 +38,3 @@ rag:
 mcp:
   type: http
   url: http://localhost:3001/mcp/stream/http
-
-pipeline:
-  version: "1"
-  stages:
-    # 1. Classify user input into typed subprompts (action/chat)
-    - id: classify
-      type: classify
-
-    # 2. Condense conversation history if too long
-    - id: summarize
-      type: summarize
-
-    # 3. RAG retrieval block — query tools and history stores in parallel
-    - id: rag-retrieval
-      type: parallel
-      stages:
-        # Query tools store: MCP tool descriptions + skill descriptions
-        - id: rag-tools
-          type: rag-query
-          config: { store: tools, k: 10 }
-        # Query history store: semantic conversation history (if configured)
-        - id: rag-history
-          type: rag-query
-          config: { store: history, k: 5 }
-      after:
-        # Re-score RAG results
-        - id: rerank
-          type: rerank
-
-    # 4. Select skills based on tools RAG matches
-    - id: skill-select
-      type: skill-select
-
-    # 5. Select MCP tools based on RAG matches
-    - id: tool-select
-      type: tool-select
-
-    # 6. Build final LLM context from subprompts + RAG + tools
-    - id: assemble
-      type: assemble
-
-    # 7. Streaming LLM call + tool execution loop
-    - id: tool-loop
-      type: tool-loop
-
-    # 8. Summarize turn and upsert to history RAG (if historyRag is set)
-    - id: history-upsert
-      type: history-upsert

--- a/docs/examples/05-structured-minimal.yaml
+++ b/docs/examples/05-structured-minimal.yaml
@@ -14,9 +14,9 @@ host: 0.0.0.0
 mode: smart
 
 llm:
-  provider: deepseek
-  apiKey: ${DEEPSEEK_API_KEY}
-  model: deepseek-chat
+  provider: openai
+  apiKey: ${OPENAI_API_KEY}
+  model: gpt-4o
   temperature: 0.7
 
 mcp:

--- a/docs/examples/05-structured-minimal.yaml
+++ b/docs/examples/05-structured-minimal.yaml
@@ -1,29 +1,27 @@
-# Structured pipeline — minimal (no RAG).
+# Flat pipeline (v19+) — minimal (no RAG, no classification).
 # For simple LLM + MCP tools setups where RAG retrieval is not needed.
-# Skips: summarize, rag-query, rerank, skill-select, history-upsert.
+#
+# The old structured-stages DSL (`pipeline: { version, stages }`) was removed in v19.
+# This example previously demonstrated skipping classify/summarize/rag/history stages.
+# The equivalent in v19 is the flat pipeline with classificationEnabled: false, which
+# skips classification and the RAG/summarize/history stages when RAG is not configured.
 #
 # Usage:
-#   OPENAI_API_KEY=sk-xxx npm run dev -- --config docs/examples/05-structured-minimal.yaml
+#   DEEPSEEK_API_KEY=sk-xxx npm run dev -- --config docs/examples/05-structured-minimal.yaml
 
 port: 4004
 host: 0.0.0.0
 mode: smart
 
 llm:
-  apiKey: ${OPENAI_API_KEY}
-  model: gpt-4o
+  provider: deepseek
+  apiKey: ${DEEPSEEK_API_KEY}
+  model: deepseek-chat
   temperature: 0.7
 
 mcp:
   type: http
   url: http://localhost:3001/mcp/stream/http
 
-pipeline:
-  version: "1"
-  stages:
-    - id: classify
-      type: classify
-    - id: assemble
-      type: assemble
-    - id: tool-loop
-      type: tool-loop
+agent:
+  classificationEnabled: false

--- a/docs/examples/06-structured-multi-model.yaml
+++ b/docs/examples/06-structured-multi-model.yaml
@@ -1,88 +1,54 @@
-# Structured pipeline — multi-model with Qdrant RAG.
-# Combines separate LLM models for different tasks with explicit stage control.
+# Flat pipeline (v19+) — multi-model LLM with Qdrant RAG.
+# Combines separate LLM providers for different roles with the flat (default) pipeline.
 #
-# - Main LLM: OpenAI GPT-4o (creative, high temperature)
+# The structured-stages DSL (`pipeline: { version, stages }`) was removed in v19.
+# Multi-role LLM config and RAG config now live at the top level (no nesting under
+# `pipeline:`). The named per-store RAG (`pipeline.rag.{name}`) was also removed;
+# use the top-level flat `rag:` block. The flat pipeline runs the full
+# DefaultPipeline flow automatically.
+#
+# - Main LLM: SAP AI Core gpt-4o (capable, high temperature)
 # - Classifier/Helper: DeepSeek (cheap, low temperature)
-# - Tools RAG: Qdrant + OpenAI embeddings (for tool/skill selection)
-# - Custom tool-loop config: higher iteration/tool limits
+# - Tools RAG: Qdrant + Ollama embeddings (for tool/skill selection)
+# - tool-loop / maxIterations / maxToolCalls tunable via agent:
 #
 # Usage:
-#   OPENAI_API_KEY=sk-xxx DEEPSEEK_API_KEY=sk-xxx \
+#   AICORE_SERVICE_KEY='...' DEEPSEEK_API_KEY=sk-xxx \
 #     npm run dev -- --config docs/examples/06-structured-multi-model.yaml
 
 port: 4004
 host: 0.0.0.0
 mode: smart
 
-pipeline:
-  llm:
-    main:
-      provider: openai
-      apiKey: ${OPENAI_API_KEY}
-      model: gpt-4o
-      temperature: 0.7
-    classifier:
-      provider: deepseek
-      apiKey: ${DEEPSEEK_API_KEY}
-      model: deepseek-chat
-      temperature: 0.1
-    helper:
-      provider: deepseek
-      apiKey: ${DEEPSEEK_API_KEY}
-      model: deepseek-chat
-      temperature: 0.1
+llm:
+  main:
+    provider: sap-ai-sdk
+    model: ${SAP_AI_MODEL:-gpt-4o}
+    resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
+    temperature: 0.7
+  classifier:
+    provider: deepseek
+    apiKey: ${DEEPSEEK_API_KEY}
+    model: deepseek-chat
+    temperature: 0.1
+  helper:
+    provider: deepseek
+    apiKey: ${DEEPSEEK_API_KEY}
+    model: deepseek-chat
+    temperature: 0.1
 
-  rag:
-    tools:
-      type: qdrant
-      url: http://qdrant:6333
-      collectionName: llm-agent-tools
-      embedder: openai
-      model: text-embedding-3-small
-      apiKey: ${OPENAI_API_KEY}
+rag:
+  type: qdrant
+  url: ${QDRANT_URL:-http://qdrant:6333}
+  collectionName: llm-agent-tools
+  embedder: ollama
+  model: bge-m3
 
-  mcp:
-    - type: http
-      url: http://localhost:3001/mcp/stream/http
+mcp:
+  - type: http
+    url: http://localhost:3001/mcp/stream/http
 
-  version: "1"
-  # Two-phase tool retrieval: first query RAG stores (skills/facts), then
-  # build an enriched query from those results + selected skills, and use
-  # it to hit the tools store. Skills and domain knowledge thus steer
-  # MCP tool discovery instead of the raw user prompt alone.
-  stages:
-    - id: classify
-      type: classify
-    - id: summarize
-      type: summarize
-    # First phase — non-tool stores. Add rag-query children here for any
-    # dedicated skills/facts stores you have. Example:
-    #   - id: rag-retrieval
-    #     type: parallel
-    #     stages:
-    #       - id: rag-facts
-    #         type: rag-query
-    #         config: { store: facts, k: 10 }
-    #     after:
-    #       - id: rerank
-    #         type: rerank
-    - id: skill-select
-      type: skill-select
-    # Compose enriched query from ragText + prior RAG snippets + skills.
-    - id: build-tool-query
-      type: build-tool-query
-      config: { topK: 5, maxChars: 2000 }
-    # Second phase — drive tools retrieval with the enriched query.
-    - id: rag-tools
-      type: rag-query
-      config: { store: tools, k: 15, queryText: toolQueryText }
-    - id: tool-select
-      type: tool-select
-      config: { queryText: toolQueryText }
-    - id: assemble
-      type: assemble
-    - id: tool-loop
-      type: tool-loop
-      config: { maxIterations: 15, maxToolCalls: 50 }
-    - id: history-upsert
-      type: history-upsert
+agent:
+  maxIterations: 15
+  maxToolCalls: 50
+  ragQueryK: 15

--- a/docs/examples/06-structured-multi-model.yaml
+++ b/docs/examples/06-structured-multi-model.yaml
@@ -22,9 +22,9 @@ mode: smart
 
 llm:
   main:
-    provider: sap-ai-sdk
-    model: ${SAP_AI_MODEL:-gpt-4o}
-    resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
+    provider: openai
+    apiKey: ${OPENAI_API_KEY}
+    model: gpt-4o
     temperature: 0.7
   classifier:
     provider: deepseek
@@ -41,8 +41,8 @@ rag:
   type: qdrant
   url: ${QDRANT_URL:-http://qdrant:6333}
   collectionName: llm-agent-tools
-  embedder: ollama
-  model: bge-m3
+  embedder: openai
+  model: text-embedding-3-small
 
 mcp:
   - type: http

--- a/docs/examples/07-structured-sap-ai-core.yaml
+++ b/docs/examples/07-structured-sap-ai-core.yaml
@@ -1,5 +1,10 @@
-# Structured pipeline — SAP AI Core provider.
-# Uses SAP AI SDK for LLM and structured pipeline for orchestration.
+# Flat pipeline (v19+) — SAP AI Core provider.
+# Uses SAP AI SDK for LLM with the flat (default) pipeline.
+#
+# The structured-stages DSL (`pipeline: { version, stages }`) was removed in v19.
+# Multi-role LLM config and RAG/MCP config now live at the top level (no nesting
+# under `pipeline:`). The flat pipeline runs the full DefaultPipeline flow
+# automatically.
 #
 # Requires: AICORE_SERVICE_KEY env variable with SAP AI Core service key JSON.
 # See docs/SAP_AI_CORE.md for detailed setup instructions.
@@ -14,41 +19,21 @@ mode: smart
 agent:
   healthTimeoutMs: 15000   # SAP AI Core round-trips often exceed the default 5 s
 
-pipeline:
-  llm:
-    main:
-      provider: sap-ai-sdk
-      model: gpt-4o
-      resourceGroup: default
-      temperature: 0.7
-    classifier:
-      provider: sap-ai-sdk
-      model: gpt-4o
-      resourceGroup: default
-      temperature: 0.1
+llm:
+  main:
+    provider: sap-ai-sdk
+    model: gpt-4o
+    resourceGroup: default
+    temperature: 0.7
+  classifier:
+    provider: sap-ai-sdk
+    model: gpt-4o
+    resourceGroup: default
+    temperature: 0.1
 
-  rag:
-    tools:
-      type: in-memory
+rag:
+  type: in-memory
 
-  mcp:
-    - type: http
-      url: http://localhost:3001/mcp/stream/http
-
-  version: "1"
-  stages:
-    - id: classify
-      type: classify
-    - id: rag-retrieval
-      type: parallel
-      stages:
-        - id: rag-tools
-          type: rag-query
-          config: { store: tools, k: 10 }
-      after:
-        - id: tool-select
-          type: tool-select
-    - id: assemble
-      type: assemble
-    - id: tool-loop
-      type: tool-loop
+mcp:
+  - type: http
+    url: http://localhost:3001/mcp/stream/http

--- a/docs/examples/08-real-world-scenario.yaml
+++ b/docs/examples/08-real-world-scenario.yaml
@@ -9,7 +9,7 @@
 #   This allows the agent to select only relevant tools per request
 #   instead of flooding the LLM context with the entire tool catalog.
 #
-# PER REQUEST (DefaultPipeline):
+# PER REQUEST (flat / DefaultPipeline):
 #
 #   1. CLASSIFY — the classifier LLM decomposes the user message into
 #      typed subprompts:
@@ -39,6 +39,10 @@
 # NOTE: Domain knowledge, user corrections, and session state are consumer
 # responsibilities. Implement a custom IPipeline to add those stores.
 #
+# NOTE: The structured-stages DSL (`pipeline: { version, stages }`) was removed
+# in v19. This file now uses the flat pipeline (the default), which runs the same
+# DefaultPipeline flow. Omit the `pipeline:` key or set `pipeline: { name: flat }`.
+#
 # Usage:
 #   DEEPSEEK_API_KEY=sk-xxx npm run dev -- --config docs/examples/08-real-world-scenario.yaml
 
@@ -47,6 +51,7 @@ host: 0.0.0.0
 mode: smart
 
 llm:
+  provider: deepseek
   apiKey: ${DEEPSEEK_API_KEY}
   model: deepseek-chat
   temperature: 0.7
@@ -73,53 +78,3 @@ agent:
   queryExpansionEnabled: true
   showReasoning: false
   historyAutoSummarizeLimit: 10
-
-# Structured pipeline — same as DefaultPipeline flow, but explicit and customizable.
-# Remove or reorder stages as needed.
-pipeline:
-  version: "1"
-  stages:
-    # Decompose user message into typed subprompts (action/chat)
-    - id: classify
-      type: classify
-
-    # Condense old messages if conversation is long
-    - id: summarize
-      type: summarize
-
-    # Query tools and history RAG stores in parallel
-    - id: rag-retrieval
-      type: parallel
-      stages:
-        # tools: MCP tool descriptions + skill descriptions
-        - id: rag-tools
-          type: rag-query
-          config: { store: tools, k: 10 }
-        # history: semantic conversation history
-        - id: rag-history
-          type: rag-query
-          config: { store: history, k: 5 }
-      after:
-        # Re-score results by relevance to the query
-        - id: rerank
-          type: rerank
-
-    # Pick skills whose descriptions matched the query
-    - id: skill-select
-      type: skill-select
-
-    # Pick MCP tools whose descriptions matched the query
-    - id: tool-select
-      type: tool-select
-
-    # Build LLM context: actions + RAG results + selected tools + history
-    - id: assemble
-      type: assemble
-
-    # Stream LLM response, execute MCP tools, loop until done
-    - id: tool-loop
-      type: tool-loop
-
-    # Summarize turn and upsert to history RAG store
-    - id: history-upsert
-      type: history-upsert

--- a/docs/examples/09-parallel-optimized.yaml
+++ b/docs/examples/09-parallel-optimized.yaml
@@ -1,21 +1,15 @@
-# Parallel-optimized pipeline — maximizes concurrency.
+# Flat pipeline (v19+) — parallel-optimized tuning via agent: knobs.
 #
-# Key differences from the sequential default (04):
+# NOTE: The structured-stages DSL (`pipeline: { version, stages }`) was removed
+# in v19. The custom parallel stage arrangement (running summarize + RAG queries
+# simultaneously) is no longer expressible as explicit stage YAML. The flat
+# pipeline's DefaultPipeline already parallelizes the RAG queries internally.
+# Per-request tuning (ragQueryK, historyAutoSummarizeLimit, etc.) is done via
+# the top-level `agent:` block as shown below.
 #
-#   DEFAULT (04):  classify → summarize → [rag-tools, rag-history] → rerank → ...
-#   THIS (09):     classify → parallel { summarize | [rag-tools, rag-history] } → rerank → ...
-#
-# What runs in parallel:
-#
-#   After classification, summarize and RAG queries run SIMULTANEOUSLY.
-#   Summarize compresses old history (reads history, writes condensed history).
-#   RAG queries fetch tool/history matches for the current request.
-#   These two have zero data dependency on each other.
-#
-# Why this is faster:
-#   - summarize can take 1-3s (LLM call to condense history)
-#   - RAG queries can take 0.2-1s (embedding + vector search)
-#   - Running them in parallel saves the slower one's entire duration
+# What the flat pipeline does internally (equivalent to the old stage sequence):
+#   classify → summarize → [rag-tools, rag-history](parallel) → rerank
+#   → skill-select → tool-select → assemble → tool-loop → history-upsert
 #
 # Usage:
 #   DEEPSEEK_API_KEY=sk-xxx npm run dev -- --config docs/examples/09-parallel-optimized.yaml
@@ -25,6 +19,7 @@ host: 0.0.0.0
 mode: smart
 
 llm:
+  provider: deepseek
   apiKey: ${DEEPSEEK_API_KEY}
   model: deepseek-chat
   temperature: 0.7
@@ -48,57 +43,7 @@ logDir: sessions                      # session debug logs (RAG scores, tool sel
 agent:
   maxIterations: 10
   maxToolCalls: 30
-  ragQueryK: 10
+  ragQueryK: 20
   classificationEnabled: true
   queryExpansionEnabled: true
   historyAutoSummarizeLimit: 10
-
-pipeline:
-  version: "1"
-  stages:
-    # ── Step 1: classify (must run first — everything depends on subprompts)
-    - id: classify
-      type: classify
-
-    # ── Step 2: summarize + RAG queries IN PARALLEL
-    #    No data dependency between them:
-    #    - summarize reads history, writes condensed history
-    #    - RAG queries read from vector stores
-    - id: post-classify
-      type: parallel
-      stages:
-        - id: summarize
-          type: summarize
-        - id: rag-queries
-          type: parallel
-          stages:
-            - id: rag-tools
-              type: rag-query
-              config: { store: tools, k: 20 }
-            - id: rag-history
-              type: rag-query
-              config: { store: history, k: 5 }
-
-    # ── Step 3: rerank sequentially (depends on RAG query results)
-    - id: rerank
-      type: rerank
-
-    # ── Step 4: skill and tool discovery (uses reranked RAG results)
-    - id: skill-select
-      type: skill-select
-
-    - id: tool-select
-      type: tool-select
-      config: { k: 20 }
-
-    # ── Step 5: assemble LLM context
-    - id: assemble
-      type: assemble
-
-    # ── Step 6: streaming LLM + tool execution loop
-    - id: tool-loop
-      type: tool-loop
-
-    # ── Step 7: upsert turn to history RAG store
-    - id: history-upsert
-      type: history-upsert

--- a/docs/examples/10-plugins.yaml
+++ b/docs/examples/10-plugins.yaml
@@ -1,22 +1,44 @@
-# 10-plugins.yaml — Plugin-extended pipeline
+# 10-plugins.yaml — Plugin-extended pipeline (v19+)
 #
 # Demonstrates loading custom implementations from a plugin directory.
 # Plugin files are standard ES modules exporting named registrations.
+#
+# NOTE: The structured-stages DSL (`pipeline: { version, stages }`) was removed
+# in v19. Custom stage handlers (stageHandlers export) can still be registered
+# from plugins but are no longer invocable from a stages YAML block. Use the
+# `pipelinePlugins` export to register a fully custom IPipelinePlugin instead,
+# or use the supported plugin extension points (reranker, queryExpander,
+# outputValidator, embedderFactories, mcpClients).
 #
 # Plugin directories (load order, later wins):
 #   1. ~/.config/llm-agent/plugins/     (user-level)
 #   2. ./plugins/                       (project-level)
 #   3. pluginDir below                  (config-level)
 #
-# Example plugin file (./my-plugins/audit-log.js):
+# Example plugin file (./my-plugins/score-reranker.js):
 #
-#   class AuditLogHandler {
-#     async execute(ctx, config, span) {
-#       console.log(`[audit] ${ctx.inputText.slice(0, 100)}`);
-#       return true;
+#   class ScoreReranker {
+#     async rerank(results, query) {
+#       // re-score and re-sort results
+#       return results;
 #     }
 #   }
-#   export const stageHandlers = { 'audit-log': new AuditLogHandler() };
+#   export const reranker = new ScoreReranker();
+#
+# Example pipeline plugin (./my-plugins/my-pipeline.js):
+#
+#   class MyPipeline {
+#     get name() { return 'my-pipeline'; }
+#     parseConfig(raw) { return raw ?? {}; }
+#     async build(cfg, ctx) {
+#       const builder = await ctx.createAgentBuilder();
+#       const handle = await builder.build();
+#       return { agent: handle.agent, close: () => handle.close() };
+#     }
+#   }
+#   export const pipelinePlugins = { 'my-pipeline': new MyPipeline() };
+#
+# See docs/examples/plugins/ for full working examples of each plugin type.
 
 port: 4004
 host: 0.0.0.0
@@ -25,6 +47,7 @@ mode: smart
 pluginDir: ./my-plugins
 
 llm:
+  provider: deepseek
   apiKey: ${DEEPSEEK_API_KEY}
   model: deepseek-chat
   temperature: 0.7
@@ -38,43 +61,3 @@ rag:
 mcp:
   type: http
   url: http://localhost:3001/mcp/stream/http
-
-pipeline:
-  version: "1"
-  stages:
-    # Custom plugin stage — loaded from pluginDir
-    - id: audit
-      type: audit-log
-      config:
-        level: info
-
-    - id: classify
-      type: classify
-
-    - id: summarize-and-query
-      type: parallel
-      stages:
-        - { id: summarize, type: summarize }
-        - id: rag-queries
-          type: parallel
-          stages:
-            - { id: rag-tools, type: rag-query, config: { store: tools, k: 20 } }
-            - { id: rag-history, type: rag-query, config: { store: history, k: 5 } }
-
-    - id: rerank
-      type: rerank
-
-    - id: skill-select
-      type: skill-select
-
-    - id: tool-select
-      type: tool-select
-
-    - id: assemble
-      type: assemble
-
-    - id: tool-loop
-      type: tool-loop
-
-    - id: history-upsert
-      type: history-upsert

--- a/docs/examples/11-skills.yaml
+++ b/docs/examples/11-skills.yaml
@@ -1,4 +1,4 @@
-# 11-skills.yaml — Pipeline with Agent Skills support
+# 11-skills.yaml — Pipeline with Agent Skills support (v19+)
 #
 # Demonstrates using ISkillManager to discover and inject skills
 # into the LLM system prompt alongside MCP tools.
@@ -6,6 +6,11 @@
 # Skills are reusable instruction packages (SKILL.md files) that teach
 # the agent HOW to do something. Unlike MCP tools (which provide actions),
 # skills provide context, guidelines, and domain knowledge.
+#
+# NOTE: The structured-stages DSL (`pipeline: { version, stages }`) was removed
+# in v19. Skills are loaded and injected automatically by the flat (default)
+# pipeline. No explicit stages YAML is needed — just configure `skills:` and the
+# flat pipeline handles discover → RAG-index → per-request skill-select → inject.
 #
 # ── Skill discovery ──
 #
@@ -51,7 +56,7 @@
 #        "Skill: code-review\nGuidelines for reviewing pull requests"
 #        metadata: { id: "skill:code-review" }
 #
-#   2. PER REQUEST:
+#   2. PER REQUEST (flat pipeline):
 #        rag-query    → retrieves skill:* and tool:* entries from tools store
 #        skill-select → filters skills by RAG matches (skill: prefix)
 #                     → loads content via ISkill.getContent()
@@ -91,6 +96,7 @@ host: 0.0.0.0
 mode: smart
 
 llm:
+  provider: deepseek
   apiKey: ${DEEPSEEK_API_KEY}
   model: deepseek-chat
   temperature: 0.7
@@ -127,47 +133,3 @@ agent:
   maxToolCalls: 30
   ragQueryK: 15
   classificationEnabled: true
-
-pipeline:
-  version: "1"
-  stages:
-    # ── Step 1: classify user input into typed subprompts
-    - id: classify
-      type: classify
-
-    # ── Step 2: RAG retrieval
-    #    Queries tools store which contains both skill:* and tool:* entries.
-    #    In-memory RAG uses BM25 keyword matching (no embedder needed).
-    - id: rag-queries
-      type: parallel
-      stages:
-        - { id: rag-tools, type: rag-query, config: { store: tools, k: 15 } }
-
-    # ── Step 3: skill + tool discovery
-    #
-    #    skill-select: finds matching skills via RAG (skill:* IDs)
-    #                  → loads skill content → writes to ctx.skillContent
-    #    tool-select:  finds matching MCP tools via RAG (tool:* IDs)
-    #
-    #    Both use the same tools RAG store. At startup, tools are vectorized
-    #    as "tool:NAME" and skills as "skill:NAME". The RAG query returns
-    #    both types, and each handler filters by its own prefix.
-    - id: discovery
-      type: parallel
-      stages:
-        - id: skill-select
-          type: skill-select
-        - id: tool-select
-          type: tool-select
-          config: { k: 15 }
-
-    # ── Step 4: assemble LLM context
-    #    AssembleHandler builds messages from subprompts + RAG + history,
-    #    then appends ctx.skillContent as "## Active Skills" section
-    #    in the system message.
-    - id: assemble
-      type: assemble
-
-    # ── Step 5: streaming LLM + tool execution loop
-    - id: tool-loop
-      type: tool-loop

--- a/docs/examples/dag-coordinator/01-all-sonnet.yaml
+++ b/docs/examples/dag-coordinator/01-all-sonnet.yaml
@@ -24,15 +24,17 @@ rag:
   model: ${EMBEDDING_MODEL:-text-embedding-3-small}
   resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
 
-coordinator:
-  activation: explicit
-  planner:
-    type: llm
-    plannerLlm: main             # → llm.main (sonnet)
-  # reviewer / finalizer / stateOracle omitted → defaults:
-  #   reviewer    = unused (no per-node review)
-  #   finalizer   = PassthroughFinalizer (yields interpreter.output verbatim)
-  #   stateOracle = none (NeedInfoSignal would surface as OrchestratorError)
+pipeline:
+  name: dag
+  config:
+    activation: explicit
+    planner:
+      type: llm
+      plannerLlm: main             # → llm.main (sonnet)
+    # reviewer / finalizer / stateOracle omitted → defaults:
+    #   reviewer    = unused (no per-node review)
+    #   finalizer   = PassthroughFinalizer (yields interpreter.output verbatim)
+    #   stateOracle = none (NeedInfoSignal would surface as OrchestratorError)
 
 subagents:
   - name: abap-analyst

--- a/docs/examples/dag-coordinator/02-hybrid-sonnet-haiku.yaml
+++ b/docs/examples/dag-coordinator/02-hybrid-sonnet-haiku.yaml
@@ -27,13 +27,15 @@ rag:
   model: ${EMBEDDING_MODEL:-text-embedding-3-small}
   resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
 
-coordinator:
-  activation: explicit
-  planner:
-    type: llm
-    plannerLlm: planner          # → llm.planner (sonnet)
-  finalizer:
-    type: passthrough            # no LLM — yields worker output verbatim
+pipeline:
+  name: dag
+  config:
+    activation: explicit
+    planner:
+      type: llm
+      plannerLlm: planner          # → llm.planner (sonnet)
+    finalizer:
+      type: passthrough            # no LLM — yields worker output verbatim
 
 subagents:
   - name: abap-analyst

--- a/docs/examples/dag-coordinator/02b-hybrid-generic-worker.yaml
+++ b/docs/examples/dag-coordinator/02b-hybrid-generic-worker.yaml
@@ -19,10 +19,12 @@ rag:
   embedder: sap-ai-core
   model: ${EMBEDDING_MODEL:-text-embedding-3-small}
   resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
-coordinator:
-  activation: explicit
-  planner: { type: llm, plannerLlm: planner }
-  finalizer: { type: passthrough }
+pipeline:
+  name: dag
+  config:
+    activation: explicit
+    planner: { type: llm, plannerLlm: planner }
+    finalizer: { type: passthrough }
 subagents:
   - name: abap-analyst
     description: |

--- a/docs/examples/dag-coordinator/03-full-roles.yaml
+++ b/docs/examples/dag-coordinator/03-full-roles.yaml
@@ -43,26 +43,28 @@ rag:
   model: ${EMBEDDING_MODEL:-text-embedding-3-small}
   resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
 
-coordinator:
-  activation: explicit
-  planner:
-    type: llm
-    plannerLlm: planner          # → llm.planner
-  reviewer:
-    type: llm
-    reviewerLlm: reviewer        # → llm.reviewer (cheap per-node "good enough?")
-  finalizer:
-    type: llm                    # real synthesis pass over the execution trace
-    finalizerLlm: finalizer      # → llm.finalizer
-    systemPrompt: |
-      You are a synthesis assistant. Read the user prompt and the execution
-      trace of completed plan nodes. Produce ONE final answer in clean Markdown
-      that fulfills the user request. Do not invent facts beyond the trace.
-  errorStrategy:
-    type: replan                 # vs `abort` — retry a failing node by replanning
-    maxReplans: 2
-  stateOracle: abap-inspector    # name of a subagent below — auto-wrapped as IStateOracle
-  maxRoundTrips: 3                # NeedInfoSignal round-trip budget
+pipeline:
+  name: dag
+  config:
+    activation: explicit
+    planner:
+      type: llm
+      plannerLlm: planner          # → llm.planner
+    reviewer:
+      type: llm
+      reviewerLlm: reviewer        # → llm.reviewer (cheap per-node "good enough?")
+    finalizer:
+      type: llm                    # real synthesis pass over the execution trace
+      finalizerLlm: finalizer      # → llm.finalizer
+      systemPrompt: |
+        You are a synthesis assistant. Read the user prompt and the execution
+        trace of completed plan nodes. Produce ONE final answer in clean Markdown
+        that fulfills the user request. Do not invent facts beyond the trace.
+    errorStrategy:
+      type: replan                 # vs `abort` — retry a failing node by replanning
+      maxReplans: 2
+    stateOracle: abap-inspector    # name of a subagent below — auto-wrapped as IStateOracle
+    maxRoundTrips: 3                # NeedInfoSignal round-trip budget
 
 subagents:
   - name: abap-analyst                 # DAG worker (target of plan nodes)

--- a/docs/examples/dag-coordinator/inspector-haiku.yaml
+++ b/docs/examples/dag-coordinator/inspector-haiku.yaml
@@ -17,43 +17,30 @@ agent:
   ragQueryK: 5
   healthTimeoutMs: 15000
 
+llm:
+  main:
+    provider: sap-ai-sdk
+    model: ${SAP_AI_ORACLE_MODEL:-anthropic--claude-4.5-haiku}
+    resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
+    temperature: 0
+  classifier:
+    provider: sap-ai-sdk
+    model: ${SAP_AI_ORACLE_MODEL:-anthropic--claude-4.5-haiku}
+    resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
+    temperature: 0
+
 rag:
   type: in-memory
   embedder: sap-ai-core
   model: ${EMBEDDING_MODEL:-text-embedding-3-small}
   resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
 
+mcp:
+  - type: http
+    url: ${MCP_ENDPOINT:-http://localhost:3003/mcp/stream/http}
+
 systemPrompt: |
   You are an inspection-only ABAP oracle. Answer short factual questions about
   whether SAP repository objects exist and what type they are. Call ONE MCP
   tool per question (SearchObject or GetTypeInfo). Reply in ONE sentence,
   NO Markdown.
-
-pipeline:
-  llm:
-    main:
-      provider: sap-ai-sdk
-      model: ${SAP_AI_ORACLE_MODEL:-anthropic--claude-4.5-haiku}
-      resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
-      temperature: 0
-    classifier:
-      provider: sap-ai-sdk
-      model: ${SAP_AI_ORACLE_MODEL:-anthropic--claude-4.5-haiku}
-      resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
-      temperature: 0
-
-  mcp:
-    - type: http
-      url: ${MCP_ENDPOINT:-http://localhost:3003/mcp/stream/http}
-
-  version: "1"
-  stages:
-    - { id: classify, type: classify }
-    - id: rag-retrieval
-      type: parallel
-      stages:
-        - { id: rag-tools, type: rag-query, config: { store: tools, k: 5 } }
-      after:
-        - { id: tool-select, type: tool-select }
-    - { id: assemble, type: assemble }
-    - { id: tool-loop, type: tool-loop, config: { maxIterations: 6 } }

--- a/docs/examples/dag-coordinator/worker-generic.yaml
+++ b/docs/examples/dag-coordinator/worker-generic.yaml
@@ -5,39 +5,27 @@ agent:
   maxIterations: 25
   ragQueryK: 10
   healthTimeoutMs: 15000
+llm:
+  main:
+    provider: sap-ai-sdk
+    model: ${SAP_AI_WORKER_MODEL:-anthropic--claude-4.5-haiku}
+    resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
+    temperature: 0.2
+  classifier:
+    provider: sap-ai-sdk
+    model: ${SAP_AI_WORKER_MODEL:-anthropic--claude-4.5-haiku}
+    resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
+    temperature: 0.1
 rag:
   type: in-memory
   embedder: sap-ai-core
   model: ${EMBEDDING_MODEL:-text-embedding-3-small}
   resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
+mcp:
+  - type: http
+    url: ${MCP_ENDPOINT:-http://localhost:3001/mcp/stream/http}
 systemPrompt: |
   You complete the task by calling the available tools. If a tool call fails or
   returns an error / empty / "not found" result, do not guess or fabricate; try
   another available tool or state the capability you still need. Produce your
   final answer only once you actually have the data the task requires.
-pipeline:
-  llm:
-    main:
-      provider: sap-ai-sdk
-      model: ${SAP_AI_WORKER_MODEL:-anthropic--claude-4.5-haiku}
-      resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
-      temperature: 0.2
-    classifier:
-      provider: sap-ai-sdk
-      model: ${SAP_AI_WORKER_MODEL:-anthropic--claude-4.5-haiku}
-      resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
-      temperature: 0.1
-  mcp:
-    - type: http
-      url: ${MCP_ENDPOINT:-http://localhost:3001/mcp/stream/http}
-  version: "1"
-  stages:
-    - { id: classify, type: classify }
-    - id: rag-retrieval
-      type: parallel
-      stages:
-        - { id: rag-tools, type: rag-query, config: { store: tools, k: 10 } }
-      after:
-        - { id: tool-select, type: tool-select }
-    - { id: assemble, type: assemble }
-    - { id: tool-loop, type: tool-loop, config: { maxIterations: 25 } }

--- a/docs/examples/dag-coordinator/worker-haiku.yaml
+++ b/docs/examples/dag-coordinator/worker-haiku.yaml
@@ -8,42 +8,29 @@ agent:
   ragQueryK: 10
   healthTimeoutMs: 15000
 
+llm:
+  main:
+    provider: sap-ai-sdk
+    model: ${SAP_AI_WORKER_MODEL:-anthropic--claude-4.5-haiku}
+    resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
+    temperature: 0.2
+  classifier:
+    provider: sap-ai-sdk
+    model: ${SAP_AI_WORKER_MODEL:-anthropic--claude-4.5-haiku}
+    resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
+    temperature: 0.1
+
 rag:
   type: in-memory
   embedder: sap-ai-core
   model: ${EMBEDDING_MODEL:-text-embedding-3-small}
   resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
 
+mcp:
+  - type: http
+    url: ${MCP_ENDPOINT:-http://localhost:3003/mcp/stream/http}
+
 systemPrompt: |
   You are an ABAP repository worker. Use the available SAP MCP tools to fulfill
   the single task you are given. NEVER fabricate object contents — call the
   tools to get real data.
-
-pipeline:
-  llm:
-    main:
-      provider: sap-ai-sdk
-      model: ${SAP_AI_WORKER_MODEL:-anthropic--claude-4.5-haiku}
-      resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
-      temperature: 0.2
-    classifier:
-      provider: sap-ai-sdk
-      model: ${SAP_AI_WORKER_MODEL:-anthropic--claude-4.5-haiku}
-      resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
-      temperature: 0.1
-
-  mcp:
-    - type: http
-      url: ${MCP_ENDPOINT:-http://localhost:3003/mcp/stream/http}
-
-  version: "1"
-  stages:
-    - { id: classify, type: classify }
-    - id: rag-retrieval
-      type: parallel
-      stages:
-        - { id: rag-tools, type: rag-query, config: { store: tools, k: 10 } }
-      after:
-        - { id: tool-select, type: tool-select }
-    - { id: assemble, type: assemble }
-    - { id: tool-loop, type: tool-loop, config: { maxIterations: 25 } }

--- a/docs/examples/dag-coordinator/worker-sonnet.yaml
+++ b/docs/examples/dag-coordinator/worker-sonnet.yaml
@@ -8,42 +8,29 @@ agent:
   ragQueryK: 10
   healthTimeoutMs: 15000
 
+llm:
+  main:
+    provider: sap-ai-sdk
+    model: ${SAP_AI_WORKER_MODEL:-anthropic--claude-4.6-sonnet}
+    resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
+    temperature: 0.2
+  classifier:
+    provider: sap-ai-sdk
+    model: ${SAP_AI_WORKER_MODEL:-anthropic--claude-4.6-sonnet}
+    resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
+    temperature: 0.1
+
 rag:
   type: in-memory
   embedder: sap-ai-core
   model: ${EMBEDDING_MODEL:-text-embedding-3-small}
   resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
 
+mcp:
+  - type: http
+    url: ${MCP_ENDPOINT:-http://localhost:3003/mcp/stream/http}
+
 systemPrompt: |
   You are an ABAP repository worker. Use the available SAP MCP tools to fulfill
   the single task you are given. NEVER fabricate object contents — call the
   tools to get real data.
-
-pipeline:
-  llm:
-    main:
-      provider: sap-ai-sdk
-      model: ${SAP_AI_WORKER_MODEL:-anthropic--claude-4.6-sonnet}
-      resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
-      temperature: 0.2
-    classifier:
-      provider: sap-ai-sdk
-      model: ${SAP_AI_WORKER_MODEL:-anthropic--claude-4.6-sonnet}
-      resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
-      temperature: 0.1
-
-  mcp:
-    - type: http
-      url: ${MCP_ENDPOINT:-http://localhost:3003/mcp/stream/http}
-
-  version: "1"
-  stages:
-    - { id: classify, type: classify }
-    - id: rag-retrieval
-      type: parallel
-      stages:
-        - { id: rag-tools, type: rag-query, config: { store: tools, k: 10 } }
-      after:
-        - { id: tool-select, type: tool-select }
-    - { id: assemble, type: assemble }
-    - { id: tool-loop, type: tool-loop, config: { maxIterations: 25 } }

--- a/docs/examples/stepper/01-cyclic-react.yaml
+++ b/docs/examples/stepper/01-cyclic-react.yaml
@@ -58,54 +58,56 @@ rag:
   url: ${EMBEDDER_URL:-}
   resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
 
-coordinator:
-  mode: cyclic-react
+pipeline:
+  name: stepper
+  config:
+    mode: cyclic-react
 
-  # Stepper execution parameters
-  stepper:
-    maxParallelSteps: 4        # local fan-out cap per Stepper level
-    maxDepth: 3                # interpreter will not recurse deeper than this
-    tokenBudget: 200000        # soft token cap across the whole run
-    reviewer:
-      atDepths: [0]            # review only at the root depth (cheap gate)
+    # Stepper execution parameters
+    stepper:
+      maxParallelSteps: 4        # local fan-out cap per Stepper level
+      maxDepth: 3                # interpreter will not recurse deeper than this
+      tokenBudget: 200000        # soft token cap across the whole run
+      reviewer:
+        atDepths: [0]            # review only at the root depth (cheap gate)
 
-  # Tool permissioning is the MCP SERVER's responsibility — there is NO agent-side
-  # gate. The agent calls whatever the server exposes via tools/list; safety is the
-  # deployment's choice of server (e.g. a read-only MCP proxy / scoped tool set).
+    # Tool permissioning is the MCP SERVER's responsibility — there is NO agent-side
+    # gate. The agent calls whatever the server exposes via tools/list; safety is the
+    # deployment's choice of server (e.g. a read-only MCP proxy / scoped tool set).
 
-  # GNOSTIFICATION IS THE CONSUMER'S RESPONSIBILITY. cyclic-react has NO planner
-  # (single executor over the raw prompt), so thoroughness/“how” comes ONLY from
-  # the consumer's RAG skills here. The agent stays agnostic; YOU supply, per
-  # deployment, the procedural knowledge for YOUR MCP — e.g. "for a code review,
-  # work from the FULL source including all includes" (no tool names needed) or
-  # "to read an include body use <your tool>". Surfaced as facts + used to enrich
-  # the executor's tool-search. Left EMPTY = agnostic default (a bare "review
-  # program X" then satisfices on the main shell — see docs).
-  #   knowledgeSeed:
-  #     - content: "<how an operation is done on your MCP, as DATA>"
-  knowledgeSeed: []
+    # GNOSTIFICATION IS THE CONSUMER'S RESPONSIBILITY. cyclic-react has NO planner
+    # (single executor over the raw prompt), so thoroughness/”how” comes ONLY from
+    # the consumer's RAG skills here. The agent stays agnostic; YOU supply, per
+    # deployment, the procedural knowledge for YOUR MCP — e.g. “for a code review,
+    # work from the FULL source including all includes” (no tool names needed) or
+    # “to read an include body use <your tool>”. Surfaced as facts + used to enrich
+    # the executor's tool-search. Left EMPTY = agnostic default (a bare “review
+    # program X” then satisfices on the main shell — see docs).
+    #   knowledgeSeed:
+    #     - content: “<how an operation is done on your MCP, as DATA>”
+    knowledgeSeed: []
 
-  # SYSTEM-PROMPT OVERRIDE (optional). The second consumer lever besides
-  # knowledgeSeed: replace a role's built-in system prompt outright. The defaults
-  # are deliberately TASK-AGNOSTIC (the executor never self-assesses completeness
-  # — that is the planner's / the 18.1 Evaluator's job), so a bare cyclic run
-  # satisfices on the main object. If your deployment WANTS the cheap executor to
-  # carry a domain prerequisite, inject it here instead of editing engine code:
-  #
-  #   flow:
-  #     executor:
-  #       type: cyclic-react
-  #       systemPrompt: |
-  #         You complete the task by calling the available tools. Before
-  #         concluding an analysis or review of an object, ensure you have its
-  #         COMPLETE content — all of its parts/sub-parts, not only the top level.
-  #         If a capability is missing, state in ONE sentence what you still need.
-  #     planner:
-  #       systemPrompt: "<override STEPPER_PLANNER_SYSTEM>"   # planned modes
-  #
-  # Omit → the built-in agnostic defaults are used. (knowledgeSeed steers via RAG
-  # facts + tool-search; systemPrompt replaces the instruction text — use either
-  # or both.)
+    # SYSTEM-PROMPT OVERRIDE (optional). The second consumer lever besides
+    # knowledgeSeed: replace a role's built-in system prompt outright. The defaults
+    # are deliberately TASK-AGNOSTIC (the executor never self-assesses completeness
+    # — that is the planner's / the 18.1 Evaluator's job), so a bare cyclic run
+    # satisfices on the main object. If your deployment WANTS the cheap executor to
+    # carry a domain prerequisite, inject it here instead of editing engine code:
+    #
+    #   flow:
+    #     executor:
+    #       type: cyclic-react
+    #       systemPrompt: |
+    #         You complete the task by calling the available tools. Before
+    #         concluding an analysis or review of an object, ensure you have its
+    #         COMPLETE content — all of its parts/sub-parts, not only the top level.
+    #         If a capability is missing, state in ONE sentence what you still need.
+    #     planner:
+    #       systemPrompt: “<override STEPPER_PLANNER_SYSTEM>”   # planned modes
+    #
+    # Omit → the built-in agnostic defaults are used. (knowledgeSeed steers via RAG
+    # facts + tool-search; systemPrompt replaces the instruction text — use either
+    # or both.)
 
 mcp:
   - type: http

--- a/docs/examples/stepper/02-planned-react.yaml
+++ b/docs/examples/stepper/02-planned-react.yaml
@@ -72,25 +72,27 @@ rag:
   url: ${EMBEDDER_URL:-}
   resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
 
-coordinator:
-  mode: planned-react            # default; explicit here for documentation
+pipeline:
+  name: stepper
+  config:
+    mode: planned-react            # default; explicit here for documentation
 
-  stepper:
-    maxParallelSteps: 4          # local fan-out cap per Stepper level
-    maxDepth: 4                  # interpreter recursion limit
-    tokenBudget: 400000          # soft token cap (shared ledger, all branches)
-    reviewer:
-      atDepths: [0, 1]           # review at root + first child level
+    stepper:
+      maxParallelSteps: 4          # local fan-out cap per Stepper level
+      maxDepth: 4                  # interpreter recursion limit
+      tokenBudget: 400000          # soft token cap (shared ledger, all branches)
+      reviewer:
+        atDepths: [0, 1]           # review at root + first child level
 
-  # Tool permissioning is the MCP SERVER's job — there is NO agent-side gate. The
-  # agent calls whatever the server exposes via tools/list; safety is the
-  # deployment's choice of server (e.g. a read-only MCP proxy / scoped tool set).
+    # Tool permissioning is the MCP SERVER's job — there is NO agent-side gate. The
+    # agent calls whatever the server exposes via tools/list; safety is the
+    # deployment's choice of server (e.g. a read-only MCP proxy / scoped tool set).
 
-  # Session-scope guidance seeded into each NEW session's knowledge-RAG. Left
-  # EMPTY to stay MCP-agnostic — fill per deployment with rules for YOUR MCP's
-  # tools (the executor surfaces them as facts and prioritises the named tools
-  # over a bare-prompt tool search). Do NOT ship tool-specific rules here.
-  knowledgeSeed: []
+    # Session-scope guidance seeded into each NEW session's knowledge-RAG. Left
+    # EMPTY to stay MCP-agnostic — fill per deployment with rules for YOUR MCP's
+    # tools (the executor surfaces them as facts and prioritises the named tools
+    # over a bare-prompt tool search). Do NOT ship tool-specific rules here.
+    knowledgeSeed: []
 
 mcp:
   - type: http

--- a/docs/examples/stepper/03-deep-stepper.yaml
+++ b/docs/examples/stepper/03-deep-stepper.yaml
@@ -86,25 +86,27 @@ rag:
   url: ${EMBEDDER_URL:-}
   resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
 
-coordinator:
-  mode: deep-stepper             # recursive executor; Evaluator-fenced (required)
+pipeline:
+  name: stepper
+  config:
+    mode: deep-stepper             # recursive executor; Evaluator-fenced (required)
 
-  stepper:
-    maxParallelSteps: 4          # local fan-out cap per Stepper level
-    maxDepth: 3                  # keep SMALL — recursion multiplies cost
-    tokenBudget: 400000          # soft token cap (shared ledger, all branches)
-    reviewer:
-      atDepths: [0, 1]           # review at root + first child level
+    stepper:
+      maxParallelSteps: 4          # local fan-out cap per Stepper level
+      maxDepth: 3                  # keep SMALL — recursion multiplies cost
+      tokenBudget: 400000          # soft token cap (shared ledger, all branches)
+      reviewer:
+        atDepths: [0, 1]           # review at root + first child level
 
-  # Tool permissioning is the MCP SERVER's job — there is NO agent-side gate. The
-  # agent calls whatever the server exposes via tools/list; safety is the
-  # deployment's choice of server (e.g. a read-only MCP proxy / scoped tool set).
+    # Tool permissioning is the MCP SERVER's job — there is NO agent-side gate. The
+    # agent calls whatever the server exposes via tools/list; safety is the
+    # deployment's choice of server (e.g. a read-only MCP proxy / scoped tool set).
 
-  # Session-scope guidance seeded into each NEW session's knowledge-RAG. Left
-  # EMPTY to stay MCP-agnostic — fill per deployment with rules for YOUR MCP's
-  # tools (the executor surfaces them as facts and prioritises the named tools
-  # over a bare-prompt tool search). Do NOT ship tool-specific rules here.
-  knowledgeSeed: []
+    # Session-scope guidance seeded into each NEW session's knowledge-RAG. Left
+    # EMPTY to stay MCP-agnostic — fill per deployment with rules for YOUR MCP's
+    # tools (the executor surfaces them as facts and prioritises the named tools
+    # over a bare-prompt tool search). Do NOT ship tool-specific rules here.
+    knowledgeSeed: []
 
 mcp:
   - type: http

--- a/docs/examples/stepper/04-flow-composition.yaml
+++ b/docs/examples/stepper/04-flow-composition.yaml
@@ -64,49 +64,51 @@ rag:
   url: ${EMBEDDER_URL:-}
   resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
 
-coordinator:
-  # The composition is described here directly — no `mode` needed.
-  flow:
-    # interpreter is the same impl at every level; listed for completeness.
-    interpreter: { type: default }
-    # finalizer synthesizes the accumulated knowledge-RAG into the answer.
-    finalizer: { type: llm }
-    # review the plan/output at the root depth only (cheap gate).
-    reviewer: { atDepths: [0] }
+pipeline:
+  name: stepper
+  config:
+    # The composition is described here directly — no `mode` needed.
+    flow:
+      # interpreter is the same impl at every level; listed for completeness.
+      interpreter: { type: default }
+      # finalizer synthesizes the accumulated knowledge-RAG into the answer.
+      finalizer: { type: llm }
+      # review the plan/output at the root depth only (cheap gate).
+      reviewer: { atDepths: [0] }
 
-    # Declared composition TREE — FULLY static (the yaml controls everything; no
-    # LLM sub-planner that could emit redundant/wrong fetch steps). gather reads
-    # the source ONCE; analyze nests its own declared sub-cycle; the per-run MCP
-    # cache makes any re-reference of the source instant (no re-fetch).
-    nodes:
-      # information-GATHERING — the only step that reads (consumer RAG skills /
-      # the goal tell it to read the full source incl. all includes).
-      - id: gather
-        goal: "Retrieve the full source of ZDAZ_R_DELAYED_UPDATE including all of its includes"
-      # ANALYSIS — ONE step covering all dimensions in a single executor pass
-      # (one read of the source, all four dimensions). Splitting into per-dimension
-      # steps re-reads the source in each (until dependsOn dataflow lands in 18.1),
-      # so a single analyze step is faster here.
-      - id: analyze
-        goal: "Analyze the gathered source across security, performance, Clean Core, and maintainability"
-        dependsOn: [gather]
-      - id: synthesize
-        goal: "Synthesize the analysis into a structured review report"
-        dependsOn: [analyze]
+      # Declared composition TREE — FULLY static (the yaml controls everything; no
+      # LLM sub-planner that could emit redundant/wrong fetch steps). gather reads
+      # the source ONCE; analyze nests its own declared sub-cycle; the per-run MCP
+      # cache makes any re-reference of the source instant (no re-fetch).
+      nodes:
+        # information-GATHERING — the only step that reads (consumer RAG skills /
+        # the goal tell it to read the full source incl. all includes).
+        - id: gather
+          goal: "Retrieve the full source of ZDAZ_R_DELAYED_UPDATE including all of its includes"
+        # ANALYSIS — ONE step covering all dimensions in a single executor pass
+        # (one read of the source, all four dimensions). Splitting into per-dimension
+        # steps re-reads the source in each (until dependsOn dataflow lands in 18.1),
+        # so a single analyze step is faster here.
+        - id: analyze
+          goal: "Analyze the gathered source across security, performance, Clean Core, and maintainability"
+          dependsOn: [gather]
+        - id: synthesize
+          goal: "Synthesize the analysis into a structured review report"
+          dependsOn: [analyze]
 
-  # Bounds apply to the whole tree; nested flows inherit them.
-  stepper:
-    maxParallelSteps: 4
-    maxDepth: 4
-    tokenBudget: 400000
+    # Bounds apply to the whole tree; nested flows inherit them.
+    stepper:
+      maxParallelSteps: 4
+      maxDepth: 4
+      tokenBudget: 400000
 
-  # Tool permissioning is the MCP SERVER's responsibility — there is NO agent-side
-  # gate. The agent calls whatever the server exposes; wire it to a read-only/scoped server.
+    # Tool permissioning is the MCP SERVER's responsibility — there is NO agent-side
+    # gate. The agent calls whatever the server exposes; wire it to a read-only/scoped server.
 
-  # Consumer gnostifies the agnostic agent via RAG skills — fill per deployment
-  # with HOW-TO records for YOUR MCP's tools (e.g. which tool reads what, which
-  # checks make up a security analysis). Left empty here to stay MCP-agnostic.
-  knowledgeSeed: []
+    # Consumer gnostifies the agnostic agent via RAG skills — fill per deployment
+    # with HOW-TO records for YOUR MCP's tools (e.g. which tool reads what, which
+    # checks make up a security analysis). Left empty here to stay MCP-agnostic.
+    knowledgeSeed: []
 
 mcp:
   - type: http

--- a/docs/examples/stepper/05-gnostic-abap-review.yaml
+++ b/docs/examples/stepper/05-gnostic-abap-review.yaml
@@ -82,53 +82,55 @@ rag:
   url: ${EMBEDDER_URL:-}
   resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
 
-coordinator:
-  mode: planned-react            # default; explicit here for documentation
+pipeline:
+  name: stepper
+  config:
+    mode: planned-react            # default; explicit here for documentation
 
-  stepper:
-    maxParallelSteps: 4          # local fan-out cap per Stepper level
-    maxDepth: 4                  # interpreter recursion limit
-    tokenBudget: 400000          # soft token cap (shared ledger, all branches)
-    reviewer:
-      atDepths: [0, 1]           # review at root + first child level
+    stepper:
+      maxParallelSteps: 4          # local fan-out cap per Stepper level
+      maxDepth: 4                  # interpreter recursion limit
+      tokenBudget: 400000          # soft token cap (shared ledger, all branches)
+      reviewer:
+        atDepths: [0, 1]           # review at root + first child level
 
-  # Tool permissioning is the MCP SERVER's job — there is NO agent-side gate. The
-  # agent calls whatever the server exposes via tools/list; safety is the
-  # deployment's choice of server (e.g. a read-only MCP proxy / scoped tool set).
+    # Tool permissioning is the MCP SERVER's job — there is NO agent-side gate. The
+    # agent calls whatever the server exposes via tools/list; safety is the
+    # deployment's choice of server (e.g. a read-only MCP proxy / scoped tool set).
 
-  # Session-scope guidance seeded into each NEW session's knowledge-RAG. This
-  # GNOSTIC preset fills it with a few ABAP/mcp-abap-adt domain rules. They are
-  # surfaced to the planner/executor as "Known facts" AND enrich the tool-search
-  # query, so the right tool is ranked and the analysis is complete. Edit for
-  # your own MCP/domain; keep them principle-level (no brittle step recipes).
-  knowledgeSeed:
-    - artifactType: tool-rule
-      content: >-
-        To read or review the FULL source of an ABAP report/program you MUST read
-        ALL of its includes (e.g. *_TOP, *_O01, *_I01, *_F01 …), not only the main
-        program shell. The main shell only lists INCLUDE statements; the logic
-        lives in the includes.
-    - artifactType: tool-rule
-      content: >-
-        Read an include body with the dedicated include-reading tool. The
-        program-source tool returns only the main shell and does NOT resolve
-        include names into their bodies.
-    - artifactType: domain-rule
-      content: >-
-        A security review of ABAP code covers at least: authority-checks
-        (AUTHORITY-CHECK / missing checks), SQL injection via dynamic
-        WHERE/EXEC SQL, hardcoded credentials, and client handling (CLIENT
-        SPECIFIED). Report each with the offending location.
-    - artifactType: domain-rule
-      content: >-
-        A performance review covers at least: SELECT inside LOOP (nested
-        DB access), SELECT * vs field lists, missing index/WHERE coverage, and
-        internal-table reads without a sorted/hashed key.
-    - artifactType: domain-rule
-      content: >-
-        A CleanCore / maintainability review covers at least: use of released
-        APIs only (no direct table writes to SAP standard), modularization, and
-        avoidance of obsolete statements.
+    # Session-scope guidance seeded into each NEW session's knowledge-RAG. This
+    # GNOSTIC preset fills it with a few ABAP/mcp-abap-adt domain rules. They are
+    # surfaced to the planner/executor as "Known facts" AND enrich the tool-search
+    # query, so the right tool is ranked and the analysis is complete. Edit for
+    # your own MCP/domain; keep them principle-level (no brittle step recipes).
+    knowledgeSeed:
+      - artifactType: tool-rule
+        content: >-
+          To read or review the FULL source of an ABAP report/program you MUST read
+          ALL of its includes (e.g. *_TOP, *_O01, *_I01, *_F01 …), not only the main
+          program shell. The main shell only lists INCLUDE statements; the logic
+          lives in the includes.
+      - artifactType: tool-rule
+        content: >-
+          Read an include body with the dedicated include-reading tool. The
+          program-source tool returns only the main shell and does NOT resolve
+          include names into their bodies.
+      - artifactType: domain-rule
+        content: >-
+          A security review of ABAP code covers at least: authority-checks
+          (AUTHORITY-CHECK / missing checks), SQL injection via dynamic
+          WHERE/EXEC SQL, hardcoded credentials, and client handling (CLIENT
+          SPECIFIED). Report each with the offending location.
+      - artifactType: domain-rule
+        content: >-
+          A performance review covers at least: SELECT inside LOOP (nested
+          DB access), SELECT * vs field lists, missing index/WHERE coverage, and
+          internal-table reads without a sorted/hashed key.
+      - artifactType: domain-rule
+        content: >-
+          A CleanCore / maintainability review covers at least: use of released
+          APIs only (no direct table writes to SAP standard), modularization, and
+          avoidance of obsolete statements.
 
 mcp:
   - type: http

--- a/docs/examples/stepper/README.md
+++ b/docs/examples/stepper/README.md
@@ -1,8 +1,8 @@
 # Recursive Stepper — per-role configurations (18.0)
 
 Production-shaped examples for the Stepper coordinator introduced in release
-**18.0.0**. Every example sets `coordinator.mode` (or `coordinator.flow`) + a
-`coordinator.stepper.*` block.
+**18.0.0**. Every example sets `pipeline.config.mode` (or `pipeline.config.flow`) + a
+`pipeline.config.stepper.*` block.
 
 | File | Mode | Use it for |
 |---|---|---|
@@ -22,9 +22,9 @@ Production-shaped examples for the Stepper coordinator introduced in release
 It is a complete smart-agent config (`mode: smart` + `pipeline.*`) — exactly what a
 Stepper executor dispatches steps to.
 
-## `coordinator.flow` — composition over modes
+## `pipeline.config.flow` — composition over modes
 
-`mode` is a **preset** that expands to a `coordinator.flow`. Writing `flow` directly
+`mode` is a **preset** that expands to a `pipeline.config.flow`. Writing `flow` directly
 (see `04-flow-composition.yaml`) gives full control:
 
 - **`flow.planner`** — `{ type: none | llm | static, granularity: shallow | detailed }`.
@@ -217,7 +217,7 @@ it belongs in the tool-RAG layer (which tools are discoverable), not at executio
 ## Gnostification is the consumer's responsibility
 
 The engine is **agnostic** — it hardcodes no tool names and no domain procedures. Making it
-thorough for YOUR MCP/domain is **the consumer's job**, supplied as DATA via `coordinator.
+thorough for YOUR MCP/domain is **the consumer's job**, supplied as DATA via `pipeline.config.
 knowledgeSeed` (and/or skills): procedural "how an operation is done" records — e.g. *"for a code
 review, work from the full source including all includes"* (no tool names needed), or *"the
 security checks are X/Y/Z, else fetch them from resource R"*. These are surfaced to the
@@ -238,18 +238,20 @@ deliberately task-agnostic, and the executor never self-assesses completeness (t
 planner's / the 18.1 Evaluator's job):
 
 ```yaml
-coordinator:
-  mode: cyclic-react
-  flow:
-    executor:
-      type: cyclic-react
-      systemPrompt: |
-        You complete the task by calling the available tools. Before concluding an
-        analysis or review of an object, ensure you have its COMPLETE content — all
-        of its parts/sub-parts, not only the top level.
-    planner:                       # planned modes
-      type: llm
-      systemPrompt: "<override STEPPER_PLANNER_SYSTEM>"
+pipeline:
+  name: stepper
+  config:
+    mode: cyclic-react
+    flow:
+      executor:
+        type: cyclic-react
+        systemPrompt: |
+          You complete the task by calling the available tools. Before concluding an
+          analysis or review of an object, ensure you have its COMPLETE content — all
+          of its parts/sub-parts, not only the top level.
+      planner:                       # planned modes
+        type: llm
+        systemPrompt: "<override STEPPER_PLANNER_SYSTEM>"
 ```
 
 Omitted → the built-in agnostic defaults are used. Nested `flow.nodes[].flow` may carry its own
@@ -257,7 +259,7 @@ overrides per sub-Stepper. Use `knowledgeSeed`, `systemPrompt`, or both.
 
 ---
 
-## `coordinator.stepper.*` reference
+## `pipeline.config.stepper.*` reference
 
 | Key | Type | Default | Description |
 |---|---|---|---|

--- a/docs/examples/stepper/worker.yaml
+++ b/docs/examples/stepper/worker.yaml
@@ -13,42 +13,29 @@ agent:
   ragQueryK: 10
   healthTimeoutMs: 15000
 
+llm:
+  main:
+    provider: sap-ai-sdk
+    model: ${SAP_AI_WORKER_MODEL:-anthropic--claude-4.5-haiku}
+    resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
+    temperature: 0.2
+  classifier:
+    provider: sap-ai-sdk
+    model: ${SAP_AI_WORKER_MODEL:-anthropic--claude-4.5-haiku}
+    resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
+    temperature: 0.1
+
 rag:
   type: in-memory
   embedder: sap-ai-core
   model: ${EMBEDDING_MODEL:-text-embedding-3-small}
   resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
 
+mcp:
+  - type: http
+    url: ${MCP_ENDPOINT:-http://localhost:3003/mcp/stream/http}
+
 systemPrompt: |
   You are an ABAP repository worker. Use the available SAP MCP tools to fulfill
   the single task you are given. NEVER fabricate object contents — call the
   tools to get real data. Write concise, structured findings.
-
-pipeline:
-  llm:
-    main:
-      provider: sap-ai-sdk
-      model: ${SAP_AI_WORKER_MODEL:-anthropic--claude-4.5-haiku}
-      resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
-      temperature: 0.2
-    classifier:
-      provider: sap-ai-sdk
-      model: ${SAP_AI_WORKER_MODEL:-anthropic--claude-4.5-haiku}
-      resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
-      temperature: 0.1
-
-  mcp:
-    - type: http
-      url: ${MCP_ENDPOINT:-http://localhost:3003/mcp/stream/http}
-
-  version: '1'
-  stages:
-    - { id: classify, type: classify }
-    - id: rag-retrieval
-      type: parallel
-      stages:
-        - { id: rag-tools, type: rag-query, config: { store: tools, k: 10 } }
-      after:
-        - { id: tool-select, type: tool-select }
-    - { id: assemble, type: assemble }
-    - { id: tool-loop, type: tool-loop, config: { maxIterations: 25 } }

--- a/docs/examples/subagent-orchestration-deepseek.yaml
+++ b/docs/examples/subagent-orchestration-deepseek.yaml
@@ -2,6 +2,10 @@
 # Identical pipeline to subagent-orchestration.yaml but routes through DeepSeek
 # for parent and sub-agents (uses the DEEPSEEK_API_KEY from .env).
 #
+# NOTE: The structured-stages DSL (`pipeline: { version, stages }`) was removed
+# in v19. The old repeat/subagent stage loop is replaced by the linear pipeline's
+# plan→dispatch coordination.
+#
 # Usage:
 #   DEEPSEEK_API_KEY=sk-... npm run dev -- --config docs/examples/subagent-orchestration-deepseek.yaml
 
@@ -10,50 +14,30 @@ host: 0.0.0.0
 mode: smart
 
 llm:
+  provider: deepseek
   apiKey: ${DEEPSEEK_API_KEY}
   endpoint: ${DEEPSEEK_ENDPOINT:-https://api.deepseek.com/v1/chat/completions}
   model: ${DEEPSEEK_MODEL:-deepseek-chat}
   temperature: 0.7
 
+pipeline:
+  name: linear
+  config:
+    planning: replan-on-error
+    dispatch: subagent
+    maxSteps: 6
+    maxRetriesPerStep: 2
+    failPolicy: abort
+
 subagents:
   - name: abap-coder
+    description: |
+      Writes and refines ABAP source code: reports, classes, function modules.
+      Use for any task that asks to generate or modify ABAP code.
     config: ../../examples/subagents/abap-coder-deepseek.yaml
   - name: code-reviewer
+    description: |
+      Reviews ABAP code and returns a one-line JSON object
+      {"approved": boolean, "issues": string[]}. Use after code generation to
+      verify correctness; do not use for generating new code.
     config: ../../examples/subagents/code-reviewer-deepseek.yaml
-
-pipeline:
-  version: "1"
-  stages:
-    - id: assemble
-      type: assemble
-
-    - id: generate-and-review
-      type: repeat
-      maxIterations: 3
-      until: "ctx.subResults?.review?.includes('\"approved\": true')"
-      stages:
-        - id: generate-code
-          type: subagent
-          config:
-            agent: abap-coder
-            task: |
-              {{inputText}}
-
-              Previous attempt (if any):
-              {{subResults.code}}
-
-              Reviewer feedback (if any):
-              {{subResults.review}}
-            outputTo: subResults.code
-
-        - id: review-code
-          type: subagent
-          config:
-            agent: code-reviewer
-            task: "Review this ABAP code:\n{{subResults.code}}"
-            outputTo: subResults.review
-
-    - id: tool-loop
-      type: tool-loop
-      config:
-        maxIterations: 1

--- a/docs/examples/subagent-orchestration-sap-aicore.yaml
+++ b/docs/examples/subagent-orchestration-sap-aicore.yaml
@@ -2,6 +2,11 @@
 # Routes parent + sub-agents through SAP AI Core (gpt-4o by default).
 # Connects MCP via the local mcp-abap-adt-proxy on http://127.0.0.1:3001.
 #
+# NOTE: The structured-stages DSL (`pipeline: { version, stages }`) was removed
+# in v19. The old repeat/subagent stage loop is replaced by the linear pipeline's
+# plan→dispatch coordination. Multi-role LLM config and RAG/MCP config now live
+# at the top level (no nesting under `pipeline:`).
+#
 # Prerequisites:
 #   1. mcp-abap-adt-proxy running in background:
 #        mcp-abap-adt-proxy --config ~/.config/mcp-abap-adt/proxy/epam-sap-mcp.yaml
@@ -18,78 +23,43 @@ agent:
   healthTimeoutMs: 15000
   ragQueryK: 10
 
+llm:
+  main:
+    provider: sap-ai-sdk
+    model: ${SAP_AI_MODEL:-gpt-4o}
+    resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
+    temperature: 0.7
+  classifier:
+    provider: sap-ai-sdk
+    model: ${SAP_AI_MODEL:-gpt-4o}
+    resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
+    temperature: 0.1
+
+rag:
+  type: in-memory
+
+mcp:
+  - type: http
+    url: ${MCP_ENDPOINT:-http://127.0.0.1:3001/mcp/stream/http}
+
 pipeline:
-  llm:
-    main:
-      provider: sap-ai-sdk
-      model: ${SAP_AI_MODEL:-gpt-4o}
-      resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
-      temperature: 0.7
-    classifier:
-      provider: sap-ai-sdk
-      model: ${SAP_AI_MODEL:-gpt-4o}
-      resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
-      temperature: 0.1
-
-  rag:
-    tools:
-      type: in-memory
-
-  mcp:
-    - type: http
-      url: ${MCP_ENDPOINT:-http://127.0.0.1:3001/mcp/stream/http}
-
-  version: "1"
-  stages:
-    - id: classify
-      type: classify
-
-    - id: rag-retrieval
-      type: parallel
-      stages:
-        - id: rag-tools
-          type: rag-query
-          config: { store: tools, k: 10 }
-      after:
-        - id: tool-select
-          type: tool-select
-
-    - id: assemble
-      type: assemble
-
-    - id: generate-and-review
-      type: repeat
-      maxIterations: 3
-      until: "ctx.subResults?.review?.includes('\"approved\": true')"
-      stages:
-        - id: generate-code
-          type: subagent
-          config:
-            agent: abap-coder
-            task: |
-              {{inputText}}
-
-              Previous attempt (if any):
-              {{subResults.code}}
-
-              Reviewer feedback (if any):
-              {{subResults.review}}
-            outputTo: subResults.code
-
-        - id: review-code
-          type: subagent
-          config:
-            agent: code-reviewer
-            task: "Review this ABAP code:\n{{subResults.code}}"
-            outputTo: subResults.review
-
-    - id: tool-loop
-      type: tool-loop
-      config:
-        maxIterations: 1
+  name: linear
+  config:
+    planning: replan-on-error
+    dispatch: subagent
+    maxSteps: 6
+    maxRetriesPerStep: 2
+    failPolicy: abort
 
 subagents:
   - name: abap-coder
+    description: |
+      Writes and refines ABAP source code: reports, classes, function modules.
+      Use for any task that asks to generate or modify ABAP code.
     config: ../../examples/subagents/abap-coder-sap-aicore.yaml
   - name: code-reviewer
+    description: |
+      Reviews ABAP code and returns a one-line JSON object
+      {"approved": boolean, "issues": string[]}. Use after code generation to
+      verify correctness; do not use for generating new code.
     config: ../../examples/subagents/code-reviewer-sap-aicore.yaml

--- a/docs/examples/subagent-orchestration.yaml
+++ b/docs/examples/subagent-orchestration.yaml
@@ -1,63 +1,46 @@
 # Subagent orchestration — iterative ABAP code generation with review loop.
 #
-# Pipeline:
-#   1. assemble  — build LLM context from the user request
-#   2. repeat    — up to 3 iterations: generate code, review it, stop when approved
-#        a. subagent: abap-coder    — generate / refine ABAP code
-#        b. subagent: code-reviewer — review code, return {"approved":bool,"issues":[]}
-#   3. tool-loop — final pass (one iteration) for any follow-up tool calls
+# The linear pipeline (plan → dispatch to subagents) coordinates the generation
+# and review loop. The planner decomposes the request into steps; each step is
+# dispatched to the matching subagent (abap-coder or code-reviewer). The
+# coordinator retries on executor error and stops when the plan is fulfilled.
+#
+# NOTE: The structured-stages DSL (`pipeline: { version, stages }`) was removed
+# in v19. The old repeat/subagent stage loop is replaced by the linear pipeline's
+# plan→dispatch coordination. Use `pipeline: { name: linear }` with `subagents:`
+# for multi-agent orchestration.
 #
 # Usage:
-#   OPENAI_API_KEY=sk-xxx npm run dev -- --config docs/examples/subagent-orchestration.yaml
+#   DEEPSEEK_API_KEY=sk-xxx npm run dev -- --config docs/examples/subagent-orchestration.yaml
 
 port: 4004
 host: 0.0.0.0
 mode: smart
 
 llm:
-  apiKey: ${OPENAI_API_KEY}
-  model: ${OPENAI_MODEL:-gpt-4o-mini}
+  provider: deepseek
+  apiKey: ${DEEPSEEK_API_KEY}
+  model: ${DEEPSEEK_MODEL:-deepseek-chat}
   temperature: 0.7
+
+pipeline:
+  name: linear
+  config:
+    planning: replan-on-error
+    dispatch: subagent
+    maxSteps: 6
+    maxRetriesPerStep: 2
+    failPolicy: abort
 
 subagents:
   - name: abap-coder
-    config: ../../examples/subagents/abap-coder.yaml
+    description: |
+      Writes and refines ABAP source code: reports, classes, function modules.
+      Use for any task that asks to generate or modify ABAP code.
+    config: ../../examples/subagents/abap-coder-deepseek.yaml
   - name: code-reviewer
-    config: ../../examples/subagents/code-reviewer.yaml
-
-pipeline:
-  version: "1"
-  stages:
-    - id: assemble
-      type: assemble
-
-    - id: generate-and-review
-      type: repeat
-      maxIterations: 3
-      until: "ctx.subResults?.review?.includes('\"approved\": true')"
-      stages:
-        - id: generate-code
-          type: subagent
-          config:
-            agent: abap-coder
-            task: |
-              {{inputText}}
-
-              Previous attempt (if any):
-              {{subResults.code}}
-
-              Reviewer feedback (if any):
-              {{subResults.review}}
-            outputTo: subResults.code
-
-        - id: review-code
-          type: subagent
-          config:
-            agent: code-reviewer
-            task: "Review this ABAP code:\n{{subResults.code}}"
-            outputTo: subResults.review
-
-    - id: tool-loop
-      type: tool-loop
-      config:
-        maxIterations: 1
+    description: |
+      Reviews ABAP code and returns a one-line JSON object
+      {"approved": boolean, "issues": string[]}. Use after code generation to
+      verify correctness; do not use for generating new code.
+    config: ../../examples/subagents/code-reviewer-deepseek.yaml

--- a/docs/examples/subagent-orchestration.yaml
+++ b/docs/examples/subagent-orchestration.yaml
@@ -18,9 +18,9 @@ host: 0.0.0.0
 mode: smart
 
 llm:
-  provider: deepseek
-  apiKey: ${DEEPSEEK_API_KEY}
-  model: ${DEEPSEEK_MODEL:-deepseek-chat}
+  provider: openai
+  apiKey: ${OPENAI_API_KEY}
+  model: ${OPENAI_MODEL:-gpt-4o-mini}
   temperature: 0.7
 
 pipeline:
@@ -37,10 +37,10 @@ subagents:
     description: |
       Writes and refines ABAP source code: reports, classes, function modules.
       Use for any task that asks to generate or modify ABAP code.
-    config: ../../examples/subagents/abap-coder-deepseek.yaml
+    config: ../../examples/subagents/abap-coder.yaml
   - name: code-reviewer
     description: |
       Reviews ABAP code and returns a one-line JSON object
       {"approved": boolean, "issues": string[]}. Use after code generation to
       verify correctness; do not use for generating new code.
-    config: ../../examples/subagents/code-reviewer-deepseek.yaml
+    config: ../../examples/subagents/code-reviewer.yaml

--- a/examples/subagents/abap-coder-deepseek.yaml
+++ b/examples/subagents/abap-coder-deepseek.yaml
@@ -1,9 +1,13 @@
 # DeepSeek-backed ABAP coder sub-agent.
 # Used by docs/examples/subagent-orchestration-deepseek.yaml.
+#
+# NOTE: The structured-stages DSL (`pipeline: { version, stages }`) was removed
+# in v19. Sub-agents use the flat (default) pipeline.
 
 mode: smart
 
 llm:
+  provider: deepseek
   apiKey: ${DEEPSEEK_API_KEY}
   endpoint: ${DEEPSEEK_ENDPOINT:-https://api.deepseek.com/v1/chat/completions}
   model: ${DEEPSEEK_MODEL:-deepseek-chat}
@@ -15,13 +19,3 @@ agent:
 systemPrompt: |
   You are an expert ABAP developer. Produce concise, production-grade ABAP code
   for the given task. Do not explain unless asked.
-
-pipeline:
-  version: "1"
-  stages:
-    - id: assemble
-      type: assemble
-    - id: tool-loop
-      type: tool-loop
-      config:
-        maxIterations: 1

--- a/examples/subagents/abap-coder-sap-aicore.yaml
+++ b/examples/subagents/abap-coder-sap-aicore.yaml
@@ -1,6 +1,10 @@
 # SAP AI Core-backed ABAP coder sub-agent (with semantic tool-select).
 # Used by docs/examples/subagent-orchestration-sap-aicore.yaml.
 # Requires: AICORE_SERVICE_KEY env variable with SAP AI Core service key JSON.
+#
+# NOTE: The structured-stages DSL (`pipeline: { version, stages }`) was removed
+# in v19. Multi-role LLM and MCP config now live at the top level. The flat
+# (default) pipeline handles classify → RAG → tool-select → assemble → tool-loop.
 
 mode: smart
 
@@ -9,47 +13,26 @@ agent:
   maxIterations: 3
   ragQueryK: 10
 
+llm:
+  main:
+    provider: sap-ai-sdk
+    model: ${SAP_AI_MODEL:-gpt-4o}
+    resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
+    temperature: 0.2
+  classifier:
+    provider: sap-ai-sdk
+    model: ${SAP_AI_MODEL:-gpt-4o}
+    resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
+    temperature: 0.1
+
 rag:
   type: in-memory
+
+mcp:
+  - type: http
+    url: ${MCP_ENDPOINT:-http://127.0.0.1:3001/mcp/stream/http}
 
 systemPrompt: |
   You are an expert ABAP developer. Produce concise, production-grade ABAP code
   for the given task. Use the available SAP tools to verify or create code in the
   system when helpful. Do not explain unless asked.
-
-pipeline:
-  llm:
-    main:
-      provider: sap-ai-sdk
-      model: ${SAP_AI_MODEL:-gpt-4o}
-      resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
-      temperature: 0.2
-    classifier:
-      provider: sap-ai-sdk
-      model: ${SAP_AI_MODEL:-gpt-4o}
-      resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
-      temperature: 0.1
-
-  mcp:
-    - type: http
-      url: ${MCP_ENDPOINT:-http://127.0.0.1:3001/mcp/stream/http}
-
-  version: "1"
-  stages:
-    - id: classify
-      type: classify
-    - id: rag-retrieval
-      type: parallel
-      stages:
-        - id: rag-tools
-          type: rag-query
-          config: { store: tools, k: 10 }
-      after:
-        - id: tool-select
-          type: tool-select
-    - id: assemble
-      type: assemble
-    - id: tool-loop
-      type: tool-loop
-      config:
-        maxIterations: 3

--- a/examples/subagents/abap-coder.yaml
+++ b/examples/subagents/abap-coder.yaml
@@ -1,24 +1,20 @@
 # Sub-agent: ABAP code generator.
-# Invoked by an orchestrator via the `subagent` pipeline stage.
-# Must NOT contain: pluginDir, clientAdapter, circuitBreaker,
-#   pipeline.reranker, pipeline.queryExpander, pipeline.outputValidator,
-#   pipeline.rag (object), or subagents.
+# Invoked by the linear coordinator as a dispatch target.
+# Must NOT contain: pluginDir, clientAdapter, circuitBreaker, or subagents.
+#
+# NOTE: The structured-stages DSL (`pipeline: { version, stages }`) was removed
+# in v19. Sub-agents use the flat (default) pipeline; per-step iteration limits
+# are set via agent.maxIterations.
 
 mode: smart
 
 llm:
+  provider: openai
   apiKey: ${OPENAI_API_KEY}
   model: ${OPENAI_MODEL:-gpt-4o-mini}
   temperature: 0.2
 
 systemPrompt: "You are an expert ABAP developer. Produce concise, production-grade ABAP code for the given task. Do not explain unless asked."
 
-pipeline:
-  version: "1"
-  stages:
-    - id: assemble
-      type: assemble
-    - id: tool-loop
-      type: tool-loop
-      config:
-        maxIterations: 1
+agent:
+  maxIterations: 1

--- a/examples/subagents/code-reviewer-deepseek.yaml
+++ b/examples/subagents/code-reviewer-deepseek.yaml
@@ -1,9 +1,13 @@
 # DeepSeek-backed code reviewer sub-agent.
 # Used by docs/examples/subagent-orchestration-deepseek.yaml.
+#
+# NOTE: The structured-stages DSL (`pipeline: { version, stages }`) was removed
+# in v19. Sub-agents use the flat (default) pipeline.
 
 mode: smart
 
 llm:
+  provider: deepseek
   apiKey: ${DEEPSEEK_API_KEY}
   endpoint: ${DEEPSEEK_ENDPOINT:-https://api.deepseek.com/v1/chat/completions}
   model: ${DEEPSEEK_MODEL:-deepseek-chat}
@@ -16,13 +20,3 @@ systemPrompt: |
   You are a senior code reviewer. Read the code and respond with a single JSON
   object on one line: {"approved": boolean, "issues": string[]}. Approve only if
   the code is correct, idiomatic, and complete. No prose outside the JSON.
-
-pipeline:
-  version: "1"
-  stages:
-    - id: assemble
-      type: assemble
-    - id: tool-loop
-      type: tool-loop
-      config:
-        maxIterations: 1

--- a/examples/subagents/code-reviewer-sap-aicore.yaml
+++ b/examples/subagents/code-reviewer-sap-aicore.yaml
@@ -1,6 +1,10 @@
 # SAP AI Core-backed code reviewer sub-agent (with semantic tool-select).
 # Used by docs/examples/subagent-orchestration-sap-aicore.yaml.
 # Requires: AICORE_SERVICE_KEY env variable with SAP AI Core service key JSON.
+#
+# NOTE: The structured-stages DSL (`pipeline: { version, stages }`) was removed
+# in v19. Multi-role LLM and MCP config now live at the top level. The flat
+# (default) pipeline handles classify → RAG → tool-select → assemble → tool-loop.
 
 mode: smart
 
@@ -9,48 +13,27 @@ agent:
   maxIterations: 2
   ragQueryK: 10
 
+llm:
+  main:
+    provider: sap-ai-sdk
+    model: ${SAP_AI_MODEL:-gpt-4o}
+    resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
+    temperature: 0.1
+  classifier:
+    provider: sap-ai-sdk
+    model: ${SAP_AI_MODEL:-gpt-4o}
+    resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
+    temperature: 0.1
+
 rag:
   type: in-memory
+
+mcp:
+  - type: http
+    url: ${MCP_ENDPOINT:-http://127.0.0.1:3001/mcp/stream/http}
 
 systemPrompt: |
   You are a senior code reviewer. Read the code and respond with a single JSON
   object on one line: {"approved": boolean, "issues": string[]}. Approve only if
   the code is correct, idiomatic, and complete. No prose outside the JSON.
   You may use read-only SAP tools to verify cross-references when needed.
-
-pipeline:
-  llm:
-    main:
-      provider: sap-ai-sdk
-      model: ${SAP_AI_MODEL:-gpt-4o}
-      resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
-      temperature: 0.1
-    classifier:
-      provider: sap-ai-sdk
-      model: ${SAP_AI_MODEL:-gpt-4o}
-      resourceGroup: ${SAP_AI_RESOURCE_GROUP:-default}
-      temperature: 0.1
-
-  mcp:
-    - type: http
-      url: ${MCP_ENDPOINT:-http://127.0.0.1:3001/mcp/stream/http}
-
-  version: "1"
-  stages:
-    - id: classify
-      type: classify
-    - id: rag-retrieval
-      type: parallel
-      stages:
-        - id: rag-tools
-          type: rag-query
-          config: { store: tools, k: 10 }
-      after:
-        - id: tool-select
-          type: tool-select
-    - id: assemble
-      type: assemble
-    - id: tool-loop
-      type: tool-loop
-      config:
-        maxIterations: 2

--- a/examples/subagents/code-reviewer.yaml
+++ b/examples/subagents/code-reviewer.yaml
@@ -1,24 +1,19 @@
 # Sub-agent: code reviewer that returns structured JSON approval.
-# Invoked by an orchestrator via the `subagent` pipeline stage.
-# Must NOT contain: pluginDir, clientAdapter, circuitBreaker,
-#   pipeline.reranker, pipeline.queryExpander, pipeline.outputValidator,
-#   pipeline.rag (object), or subagents.
+# Invoked by the linear coordinator as a dispatch target.
+# Must NOT contain: pluginDir, clientAdapter, circuitBreaker, or subagents.
+#
+# NOTE: The structured-stages DSL (`pipeline: { version, stages }`) was removed
+# in v19. Sub-agents use the flat (default) pipeline.
 
 mode: smart
 
 llm:
+  provider: openai
   apiKey: ${OPENAI_API_KEY}
   model: ${OPENAI_MODEL:-gpt-4o-mini}
   temperature: 0.1
 
 systemPrompt: 'You are a senior code reviewer. Read the code and respond with a JSON object: {"approved": boolean, "issues": string[]}. Approve only if the code is correct, idiomatic, and complete.'
 
-pipeline:
-  version: "1"
-  stages:
-    - id: assemble
-      type: assemble
-    - id: tool-loop
-      type: tool-loop
-      config:
-        maxIterations: 1
+agent:
+  maxIterations: 1


### PR DESCRIPTION
## Summary

Pre-19.3.0 documentation-accuracy pass. Audit found that **~25 example YAMLs + several docs sections still used config shapes REMOVED in v19** (they fail-loud at startup), and docs presented removed APIs as current. This was pre-existing debt (shipped stale in 19.0/19.1/19.2), surfaced while verifying docs for the 19.3.0 release.

### Removed shapes that were still documented/used
- Top-level `coordinator:` block → removed; now `pipeline: { name: <stepper|dag>, config: {...} }`.
- Structured `pipeline: { version, stages }` YAML DSL → removed; now `pipeline: { name, config }` (omit → `flat`).
- Builder `withStageHandler()` / `withStageHandlers()` / `getDefaultStages()` → removed.

### Changes
- **Example YAMLs (verified to config-validate):** migrated all `docs/examples/stepper/*` + `dag-coordinator/*` (coordinator: → `pipeline:{name,config}`) and all structured `04`–`11` + `subagent-orchestration*` + worker/subagent configs (dropped the removed stages DSL → `flat`, or `linear` for plan→dispatch orchestration). Restored each example's INTENDED provider (a mid-migration step had swapped providers to the migration env — reverted; config validation is provider-agnostic, a missing key correctly surfaces at service-connect as the headers document).
- **Prose:** removed the "structured pipeline" / stage-handler how-tos from `EXAMPLES.md`, `INTEGRATION.md`, `ARCHITECTURE.md`, and the stepper/dag example READMEs; replaced with the 3 current mechanisms (built-in by name · custom `IPipeline` via `setPipeline()` · pipeline plugins). Kept accurate "removed in v19" migration notes (TROUBLESHOOTING/PIPELINES were already correct).

### Verification
- [x] No example YAML carries a removed shape (`coordinator:` / `pipeline:{version,stages}`) — audited across all 41.
- [x] No doc prose presents a removed API as current how-to (final grep clean).
- [x] Migrated configs verified to pass config-validation (reach service/provider, no fail-loud migration error).
- [x] Suite unaffected: 563 tests, 561 pass, 0 fail, 2 skip; lint 0 errors.

Net: 35 files, +745/−1315 (mostly removal of stale content).

🤖 Generated with [Claude Code](https://claude.com/claude-code)