### PR TITLE
feat(skills): GitHub self-fetch source for the skill plugin-host (zero-FS)

### DIFF
--- a/docs/examples/skill-plugins-github.yaml
+++ b/docs/examples/skill-plugins-github.yaml
@@ -1,21 +1,49 @@
-# Skill plugin-host that SELF-FETCHES skills from a GitHub Claude-plugin repo.
-# The host downloads marketplace.json + each SKILL.md over HTTPS into memory
-# (no git clone, no filesystem). marketplace.json + the Contents API are used to
-# enumerate skills; raw.githubusercontent.com fetches the bodies.
+# Controller pipeline + skill plugin-host that SELF-FETCHES skills from a GitHub
+# Claude-plugin repo. The host downloads marketplace.json + each SKILL.md over
+# HTTPS into memory (no git clone, no filesystem): marketplace.json + the GitHub
+# Contents API enumerate skills; raw.githubusercontent.com fetches the bodies.
+#
+# This is the validated ABAP-review composition: the `controller` pipeline recalls
+# the merged `sap` skill group while reviewing an ABAP program over MCP.
 #
 # Usage:
 #   npm run dev -- --config docs/examples/skill-plugins-github.yaml
+#   curl -s localhost:4004/v1/chat/completions -H 'content-type: application/json' \
+#     -d '{"messages":[{"role":"user",
+#          "content":"Review ABAP program ZDAZ_R_DELAYED_UPDATE, check security, performance, CleanCore, maintainability"}]}'
 port: 4004
 host: 0.0.0.0
 
+# Base llm block (config requires it even with pipeline: controller).
 llm:
   main:
     provider: sap-ai-sdk
     model: anthropic--claude-4.6-sonnet
+    temperature: 0.3
+    maxTokens: 32768
 
+# Controller pipeline — smart-executor (default since 20.0.0): plan-first board.
+# Each subagent role takes its own LLM config (here all the same provider/model).
 pipeline:
   name: controller
+  config:
+    subagents:
+      evaluator:
+        provider: sap-ai-sdk
+        model: anthropic--claude-4.6-sonnet
+      planner:
+        provider: sap-ai-sdk
+        model: anthropic--claude-4.6-sonnet
+      executor:
+        provider: sap-ai-sdk
+        model: anthropic--claude-4.6-sonnet
+    targetState:
+      strategy: auto
+      distanceThreshold: 0.7
+    sessionMemory: { collection: session-memory }
+    budgets: { maxSteps: 20, maxRetries: 3, maxRewinds: 5, maxToolCalls: 30 }
 
+# Results-RAG + MCP tool-RAG embedder — SAP AI Core (foundation-models).
 rag:
   type: in-memory
   embedder: sap-ai-core
@@ -23,15 +51,27 @@ rag:
   resourceGroup: default
   model: text-embedding-3-small
 
+# MCP via a local ABAP ADT approuter/proxy (adjust the URL to your endpoint).
+mcp:
+  type: http
+  url: http://localhost:3001/mcp/stream/http
+  headers:
+    Accept: "application/json, text/event-stream"
+
+# Skill plugin-host: SELF-FETCH the SAP skills directly from the GitHub repo
+# (no shim, no clone, zero-FS), merged into ONE collection `sap` so the controller
+# planner recalls from all enabled plugins at once.
 skillPlugins:
   store: { type: in-memory }
   embedder: { provider: sap-ai-core, model: text-embedding-3-small }
   controllerSkillGroup: sap
+  k: 4
+  threshold: 0.3
   sources:
     - id: sap-skills
       github: https://github.com/secondsky/sap-skills.git   # host self-fetches
-      # ref: main            # optional; default = repo default_branch
+      # ref: main               # optional; default = repo default_branch
       # token: ${GITHUB_TOKEN}  # optional; lifts rate limit + private repos
-      enabled: [sap-abap, sap-btp-developer-guide]
+      enabled: [sap-abap, sap-abap-cds, sap-btp-developer-guide, sap-btp-best-practices]
       strategy: single-collection
       strategyConfig: { collection: sap }

--- a/docs/examples/skill-plugins-github.yaml
+++ b/docs/examples/skill-plugins-github.yaml
@@ -1,0 +1,37 @@
+# Skill plugin-host that SELF-FETCHES skills from a GitHub Claude-plugin repo.
+# The host downloads marketplace.json + each SKILL.md over HTTPS into memory
+# (no git clone, no filesystem). marketplace.json + the Contents API are used to
+# enumerate skills; raw.githubusercontent.com fetches the bodies.
+#
+# Usage:
+#   npm run dev -- --config docs/examples/skill-plugins-github.yaml
+port: 4004
+host: 0.0.0.0
+
+llm:
+  main:
+    provider: sap-ai-sdk
+    model: anthropic--claude-4.6-sonnet
+
+pipeline:
+  name: controller
+
+rag:
+  type: in-memory
+  embedder: sap-ai-core
+  scenario: foundation-models
+  resourceGroup: default
+  model: text-embedding-3-small
+
+skillPlugins:
+  store: { type: in-memory }
+  embedder: { provider: sap-ai-core, model: text-embedding-3-small }
+  controllerSkillGroup: sap
+  sources:
+    - id: sap-skills
+      github: https://github.com/secondsky/sap-skills.git   # host self-fetches
+      # ref: main            # optional; default = repo default_branch
+      # token: ${GITHUB_TOKEN}  # optional; lifts rate limit + private repos
+      enabled: [sap-abap, sap-btp-developer-guide]
+      strategy: single-collection
+      strategyConfig: { collection: sap }

--- a/docs/superpowers/plans/2026-06-22-github-skill-source-strategy.md
+++ b/docs/superpowers/plans/2026-06-22-github-skill-source-strategy.md
@@ -1,0 +1,986 @@
+# GitHub Skill Source Strategy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the skill plugin-host self-fetch skills from a GitHub Claude-plugin repo (e.g. `https://github.com/secondsky/sap-skills.git`) over HTTPS into memory — no `git clone`, no filesystem.
+
+**Architecture:** Add a new `IMarketplaceTransport` implementation (`makeGitHubTransport`) that reads the standard Claude-plugin layout from GitHub: the marketplace manifest and each `SKILL.md` from `raw.githubusercontent.com`, and the per-plugin `skills/` directory listing from the GitHub Contents API. The existing `makeHttpMarketplaceSource`, both source strategies, the marketplace adapter, and the store are transport-agnostic and stay unchanged. Config grows a `github`/`ref`/`token` source variant; `buildSources` picks the transport by which field is present.
+
+**Tech Stack:** TypeScript (ESM, strict), `node:test` + `tsx`, global `fetch`. Packages: `@mcp-abap-adt/llm-agent-libs` (transport), `@mcp-abap-adt/llm-agent-server-libs` (config + wiring).
+
+**Spec:** `docs/superpowers/specs/2026-06-22-github-skill-source-strategy-design.md`
+
+---
+
+## File Structure
+
+- **Create** `packages/llm-agent-libs/src/skills/plugin-host/github-transport.ts` — `makeGitHubTransport` + the three pure helpers (`parseGitHubRepo`, `parseMarketplace`, `skillDirsFromContents`). One responsibility: turn a GitHub repo coordinate into an `IMarketplaceTransport`.
+- **Create** `packages/llm-agent-libs/src/skills/plugin-host/github-transport.test.ts` — unit tests (pure helpers + transport via injected fake `fetch`).
+- **Modify** `packages/llm-agent-libs/src/skills/plugin-host/index.ts` — re-export `makeGitHubTransport`, `parseGitHubRepo`. (Already flows up through `llm-agent-libs/src/index.ts:210` `export * from './skills/plugin-host/index.js'`.)
+- **Modify** `packages/llm-agent-server-libs/src/smart-agent/skill-plugins-config.ts` — extend `SkillPluginsFetchedSource` + parse `github`/`ref`/`token` with `github` XOR `registry` fail-loud.
+- **Modify** `packages/llm-agent-server-libs/src/smart-agent/skill-plugins-config.test.ts` — config-parse tests.
+- **Modify** `packages/llm-agent-server-libs/src/smart-agent/skill-plugins-host-factory.ts` — in `buildSources()`, pick `makeGitHubTransport` when `github` present.
+- **Modify** `packages/llm-agent-server-libs/src/smart-agent/skill-plugins-host-factory.test.ts` — wiring test (a `github` source builds a GitHub-backed source).
+
+### Conventions (match existing code)
+
+- ESM: import siblings with a `.js` extension even from `.ts` files.
+- Test header (copy from `source-strategies.test.ts`):
+  ```ts
+  import assert from 'node:assert/strict';
+  import { test } from 'node:test';
+  ```
+- Run one test file from the repo root:
+  ```bash
+  node --import tsx/esm --test --test-reporter=spec \
+    packages/llm-agent-libs/src/skills/plugin-host/github-transport.test.ts
+  ```
+- Run a whole package's tests:
+  ```bash
+  npm -w @mcp-abap-adt/llm-agent-libs run test
+  npm -w @mcp-abap-adt/llm-agent-server-libs run test
+  ```
+- Lint/build the touched packages before finishing:
+  ```bash
+  npm run lint && npm run build
+  ```
+
+---
+
+## Task 1: Pure helpers (`parseGitHubRepo`, `parseMarketplace`, `skillDirsFromContents`)
+
+**Files:**
+- Create: `packages/llm-agent-libs/src/skills/plugin-host/github-transport.ts`
+- Test: `packages/llm-agent-libs/src/skills/plugin-host/github-transport.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `github-transport.test.ts`:
+
+```ts
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  parseGitHubRepo,
+  parseMarketplace,
+  skillDirsFromContents,
+} from './github-transport.js';
+
+test('parseGitHubRepo accepts all URL forms', () => {
+  const expected = { owner: 'secondsky', repo: 'sap-skills' };
+  assert.deepEqual(
+    parseGitHubRepo('https://github.com/secondsky/sap-skills.git'),
+    expected,
+  );
+  assert.deepEqual(
+    parseGitHubRepo('https://github.com/secondsky/sap-skills'),
+    expected,
+  );
+  assert.deepEqual(parseGitHubRepo('github.com/secondsky/sap-skills'), expected);
+  assert.deepEqual(parseGitHubRepo('secondsky/sap-skills'), expected);
+  assert.deepEqual(
+    parseGitHubRepo('https://github.com/secondsky/sap-skills/'),
+    expected,
+  );
+});
+
+test('parseGitHubRepo throws on garbage', () => {
+  assert.throws(() => parseGitHubRepo('not a repo'), /cannot parse GitHub repo/);
+});
+
+test('parseMarketplace maps plugins[] and strips a leading ./', () => {
+  const out = parseMarketplace({
+    plugins: [
+      { name: 'sap-abap', version: '2.3.2', source: './plugins/sap-abap' },
+      { name: 'x', source: 'plugins/x' },
+    ],
+  });
+  assert.deepEqual(out, [
+    { plugin: 'sap-abap', version: '2.3.2', sourcePath: 'plugins/sap-abap' },
+    { plugin: 'x', version: '0.0.0', sourcePath: 'plugins/x' },
+  ]);
+});
+
+test('parseMarketplace throws when plugins[] is missing', () => {
+  assert.throws(() => parseMarketplace({}), /no plugins\[\] array/);
+});
+
+test('skillDirsFromContents returns only dir entries', () => {
+  const out = skillDirsFromContents([
+    { name: 'sap-abap', type: 'dir' },
+    { name: 'README.md', type: 'file' },
+    { name: 'extra', type: 'dir' },
+  ]);
+  assert.deepEqual(out, ['sap-abap', 'extra']);
+});
+
+test('skillDirsFromContents throws on a non-array', () => {
+  assert.throws(
+    () => skillDirsFromContents({ message: 'Not Found' }),
+    /expected a Contents-API directory array/,
+  );
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+node --import tsx/esm --test --test-reporter=spec \
+  packages/llm-agent-libs/src/skills/plugin-host/github-transport.test.ts
+```
+Expected: FAIL — cannot resolve `./github-transport.js` (module does not exist yet).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `github-transport.ts` with the helpers (transport added in Task 2):
+
+```ts
+import type { IMarketplaceTransport } from './http-marketplace-source.js';
+
+/** Parse `owner`/`repo` from a GitHub URL or bare `owner/repo`. */
+export function parseGitHubRepo(url: string): { owner: string; repo: string } {
+  const cleaned = url
+    .trim()
+    .replace(/\.git$/, '')
+    .replace(/\/+$/, '');
+  const m = cleaned.match(
+    /^(?:https?:\/\/)?(?:github\.com\/)?([^/\s]+)\/([^/\s]+)$/,
+  );
+  if (!m) {
+    throw new Error(`parseGitHubRepo: cannot parse GitHub repo from '${url}'`);
+  }
+  return { owner: m[1], repo: m[2] };
+}
+
+/** Map a parsed `.claude-plugin/marketplace.json` to plugin coordinates. */
+export function parseMarketplace(
+  json: unknown,
+): Array<{ plugin: string; version: string; sourcePath: string }> {
+  const plugins = (json as { plugins?: unknown } | null)?.plugins;
+  if (!Array.isArray(plugins)) {
+    throw new Error('parseMarketplace: marketplace.json has no plugins[] array');
+  }
+  return plugins.map((p) => {
+    const o = p as { name?: unknown; version?: unknown; source?: unknown };
+    if (typeof o.name !== 'string' || o.name.length === 0) {
+      throw new Error('parseMarketplace: a plugin entry is missing a string name');
+    }
+    const source =
+      typeof o.source === 'string' ? o.source : `./plugins/${o.name}`;
+    return {
+      plugin: o.name,
+      version: typeof o.version === 'string' ? o.version : '0.0.0',
+      sourcePath: source.replace(/^\.\//, '').replace(/\/+$/, ''),
+    };
+  });
+}
+
+/** Extract subdirectory names from a GitHub Contents-API directory response. */
+export function skillDirsFromContents(json: unknown): string[] {
+  if (!Array.isArray(json)) {
+    throw new Error(
+      'skillDirsFromContents: expected a Contents-API directory array',
+    );
+  }
+  return (json as Array<{ name?: unknown; type?: unknown }>)
+    .filter((e) => e.type === 'dir' && typeof e.name === 'string')
+    .map((e) => e.name as string);
+}
+```
+
+> Note: the unused `IMarketplaceTransport` import is consumed in Task 2. If the linter rejects an unused import between tasks, add the import in Task 2's step instead — but Task 2 follows immediately, so leaving it is fine.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+```bash
+node --import tsx/esm --test --test-reporter=spec \
+  packages/llm-agent-libs/src/skills/plugin-host/github-transport.test.ts
+```
+Expected: PASS — 6 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/llm-agent-libs/src/skills/plugin-host/github-transport.ts \
+        packages/llm-agent-libs/src/skills/plugin-host/github-transport.test.ts
+git commit -m "feat(skills): GitHub transport pure helpers (parse repo/manifest/contents)"
+```
+
+---
+
+## Task 2: `makeGitHubTransport` (listPlugins + fetchSkillMd)
+
+**Files:**
+- Modify: `packages/llm-agent-libs/src/skills/plugin-host/github-transport.ts`
+- Test: `packages/llm-agent-libs/src/skills/plugin-host/github-transport.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `github-transport.test.ts`:
+
+```ts
+import { makeGitHubTransport } from './github-transport.js';
+
+/** Build a fake `fetch` from a URL→response map. Each value is `{ status?, body }`
+ *  where body is an object (JSON) or string (raw text). Unmapped URL → 404. */
+function fakeFetch(routes: Record<string, { status?: number; body: unknown }>) {
+  const calls: string[] = [];
+  const impl = async (input: unknown) => {
+    const url = String(input);
+    calls.push(url);
+    const hit = routes[url];
+    const status = hit?.status ?? (hit ? 200 : 404);
+    const ok = status >= 200 && status < 300;
+    return {
+      ok,
+      status,
+      statusText: ok ? 'OK' : 'Not Found',
+      json: async () => hit?.body,
+      text: async () => String(hit?.body ?? ''),
+    } as unknown as Response;
+  };
+  return { impl: impl as unknown as typeof fetch, calls };
+}
+
+const RAW = 'https://raw.githubusercontent.com';
+const API = 'https://api.github.com';
+
+const MARKETPLACE = {
+  plugins: [
+    { name: 'sap-abap', version: '2.3.2', source: './plugins/sap-abap' },
+    { name: 'sap-btp', version: '1.0.0', source: './plugins/sap-btp' },
+    { name: 'unused', version: '9.9.9', source: './plugins/unused' },
+  ],
+};
+
+test('listPlugins resolves default branch and enumerates ONLY enabled plugins', async () => {
+  const { impl, calls } = fakeFetch({
+    [`${API}/repos/o/r`]: { body: { default_branch: 'main' } },
+    [`${RAW}/o/r/main/.claude-plugin/marketplace.json`]: { body: MARKETPLACE },
+    [`${API}/repos/o/r/contents/plugins/sap-abap/skills?ref=main`]: {
+      body: [{ name: 'sap-abap', type: 'dir' }],
+    },
+    [`${API}/repos/o/r/contents/plugins/sap-btp/skills?ref=main`]: {
+      body: [{ name: 'sap-btp', type: 'dir' }],
+    },
+  });
+  const t = makeGitHubTransport({
+    owner: 'o',
+    repo: 'r',
+    enabled: ['sap-abap', 'sap-btp'],
+    fetchImpl: impl,
+  });
+  const out = await t.listPlugins();
+  assert.deepEqual(out, [
+    { plugin: 'sap-abap', version: '2.3.2', skills: ['sap-abap'] },
+    { plugin: 'sap-btp', version: '1.0.0', skills: ['sap-btp'] },
+  ]);
+  // The 'unused' plugin must NOT be enumerated (no Contents-API call for it).
+  assert.ok(!calls.some((u) => u.includes('plugins/unused/skills')));
+});
+
+test('an explicit ref skips the default-branch metadata call', async () => {
+  const { impl, calls } = fakeFetch({
+    [`${RAW}/o/r/dev/.claude-plugin/marketplace.json`]: { body: MARKETPLACE },
+    [`${API}/repos/o/r/contents/plugins/sap-abap/skills?ref=dev`]: {
+      body: [{ name: 'sap-abap', type: 'dir' }],
+    },
+  });
+  const t = makeGitHubTransport({
+    owner: 'o',
+    repo: 'r',
+    ref: 'dev',
+    enabled: ['sap-abap'],
+    fetchImpl: impl,
+  });
+  await t.listPlugins();
+  assert.ok(!calls.some((u) => u === `${API}/repos/o/r`));
+});
+
+test('fetchSkillMd hits the raw SKILL.md URL and returns the body', async () => {
+  const { impl } = fakeFetch({
+    [`${API}/repos/o/r`]: { body: { default_branch: 'main' } },
+    [`${RAW}/o/r/main/.claude-plugin/marketplace.json`]: { body: MARKETPLACE },
+    [`${RAW}/o/r/main/plugins/sap-abap/skills/sap-abap/SKILL.md`]: {
+      body: '# ABAP skill',
+    },
+  });
+  const t = makeGitHubTransport({
+    owner: 'o',
+    repo: 'r',
+    enabled: ['sap-abap'],
+    fetchImpl: impl,
+  });
+  assert.equal(await t.fetchSkillMd('sap-abap', 'sap-abap'), '# ABAP skill');
+});
+
+test('a token attaches an Authorization header to every request', async () => {
+  const seen: Array<Record<string, string> | undefined> = [];
+  const impl = (async (_url: unknown, init?: { headers?: Record<string, string> }) => {
+    seen.push(init?.headers);
+    return {
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => MARKETPLACE,
+      text: async () => '',
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  const t = makeGitHubTransport({
+    owner: 'o',
+    repo: 'r',
+    ref: 'main',
+    token: 'gho_x',
+    enabled: ['*'],
+    fetchImpl: impl,
+  });
+  await t.listPlugins();
+  assert.ok(seen.length > 0);
+  for (const h of seen) {
+    assert.equal(h?.authorization, 'Bearer gho_x');
+  }
+});
+
+test('listPlugins throws with a token hint on a 403', async () => {
+  const { impl } = fakeFetch({
+    [`${RAW}/o/r/main/.claude-plugin/marketplace.json`]: { body: MARKETPLACE },
+    [`${API}/repos/o/r/contents/plugins/sap-abap/skills?ref=main`]: {
+      status: 403,
+      body: {},
+    },
+  });
+  const t = makeGitHubTransport({
+    owner: 'o',
+    repo: 'r',
+    ref: 'main',
+    enabled: ['sap-abap'],
+    fetchImpl: impl,
+  });
+  await assert.rejects(() => t.listPlugins(), /set a token/);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+node --import tsx/esm --test --test-reporter=spec \
+  packages/llm-agent-libs/src/skills/plugin-host/github-transport.test.ts
+```
+Expected: FAIL — `makeGitHubTransport` is not exported.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `github-transport.ts`:
+
+```ts
+const RAW_BASE = 'https://raw.githubusercontent.com';
+const API_BASE = 'https://api.github.com';
+
+export interface GitHubTransportOptions {
+  owner: string;
+  repo: string;
+  /** Branch/tag/sha; default = the repo's `default_branch`. */
+  ref?: string;
+  /** Optional auth token (lifts rate limit + enables private repos). */
+  token?: string;
+  /** Plugins to enumerate; `['*']` = all. Only these get a Contents-API call. */
+  enabled: readonly string[];
+  /** Injected for tests; default global `fetch`. */
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * An {@link IMarketplaceTransport} over a GitHub Claude-plugin repo. Reads the
+ * standard layout via HTTPS into memory (no clone, no FS): marketplace.json and
+ * each SKILL.md from `raw.githubusercontent.com`; per-plugin `skills/` listings
+ * from the GitHub Contents API. NOT unit-tested over a real network — the unit
+ * tests inject `fetchImpl`.
+ */
+export function makeGitHubTransport(
+  opts: GitHubTransportOptions,
+): IMarketplaceTransport {
+  const { owner, repo, token, enabled } = opts;
+  const doFetch = opts.fetchImpl ?? fetch;
+  const headers: Record<string, string> = token
+    ? { authorization: `Bearer ${token}` }
+    : {};
+  const wantAll = enabled.includes('*');
+  const enabledSet = new Set(enabled);
+
+  let ref = opts.ref;
+  let manifest:
+    | Array<{ plugin: string; version: string; sourcePath: string }>
+    | undefined;
+
+  async function resolveRef(): Promise<string> {
+    if (ref) return ref;
+    const res = await doFetch(`${API_BASE}/repos/${owner}/${repo}`, { headers });
+    if (!res.ok) {
+      throw new Error(`resolveRef ${res.status} ${res.statusText}`);
+    }
+    const meta = (await res.json()) as { default_branch?: string };
+    ref = meta.default_branch ?? 'main';
+    return ref;
+  }
+
+  async function loadManifest() {
+    if (manifest) return manifest;
+    const r = await resolveRef();
+    const url = `${RAW_BASE}/${owner}/${repo}/${r}/.claude-plugin/marketplace.json`;
+    const res = await doFetch(url, { headers });
+    if (!res.ok) {
+      throw new Error(`marketplace.json ${res.status} ${res.statusText}`);
+    }
+    manifest = parseMarketplace(await res.json());
+    return manifest;
+  }
+
+  function sourcePathOf(plugin: string): string {
+    const entry = manifest?.find((m) => m.plugin === plugin);
+    if (!entry) {
+      throw new Error(
+        `github transport: unknown plugin '${plugin}' (not in marketplace.json)`,
+      );
+    }
+    return entry.sourcePath;
+  }
+
+  return {
+    async listPlugins() {
+      const m = await loadManifest();
+      const r = await resolveRef();
+      const selected = wantAll ? m : m.filter((p) => enabledSet.has(p.plugin));
+      return Promise.all(
+        selected.map(async (p) => {
+          const url = `${API_BASE}/repos/${owner}/${repo}/contents/${p.sourcePath}/skills?ref=${encodeURIComponent(r)}`;
+          const res = await doFetch(url, { headers });
+          if (!res.ok) {
+            const hint = res.status === 403 ? ' (rate limit? set a token)' : '';
+            throw new Error(
+              `list skills(${p.plugin}) ${res.status} ${res.statusText}${hint}`,
+            );
+          }
+          return {
+            plugin: p.plugin,
+            version: p.version,
+            skills: skillDirsFromContents(await res.json()),
+          };
+        }),
+      );
+    },
+    async fetchSkillMd(plugin: string, skill: string) {
+      await loadManifest();
+      const r = await resolveRef();
+      const sp = sourcePathOf(plugin);
+      const url = `${RAW_BASE}/${owner}/${repo}/${r}/${sp}/skills/${skill}/SKILL.md`;
+      const res = await doFetch(url, { headers });
+      if (!res.ok) {
+        throw new Error(
+          `fetchSkillMd(${plugin}/${skill}) ${res.status} ${res.statusText}`,
+        );
+      }
+      return res.text();
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+```bash
+node --import tsx/esm --test --test-reporter=spec \
+  packages/llm-agent-libs/src/skills/plugin-host/github-transport.test.ts
+```
+Expected: PASS — all tests pass (11 total across Tasks 1+2).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/llm-agent-libs/src/skills/plugin-host/github-transport.ts \
+        packages/llm-agent-libs/src/skills/plugin-host/github-transport.test.ts
+git commit -m "feat(skills): makeGitHubTransport (self-fetch skills from a GitHub repo, zero-FS)"
+```
+
+---
+
+## Task 3: Export from the package index
+
+**Files:**
+- Modify: `packages/llm-agent-libs/src/skills/plugin-host/index.ts:11-15`
+
+- [ ] **Step 1: Add the exports**
+
+The current block re-exports the HTTP transport:
+```ts
+export {
+  type HttpMarketplaceSourceOptions,
+  type HttpTransportOptions,
+  type IMarketplaceTransport,
+  makeHttpMarketplaceSource,
+  makeHttpTransport,
+} from './http-marketplace-source.js';
+```
+
+Add a sibling re-export of the GitHub transport immediately after that block:
+```ts
+export {
+  type GitHubTransportOptions,
+  makeGitHubTransport,
+  parseGitHubRepo,
+} from './github-transport.js';
+```
+
+(`parseMarketplace`/`skillDirsFromContents` stay internal — only `makeGitHubTransport` + `parseGitHubRepo` are needed by the wiring layer.)
+
+- [ ] **Step 2: Verify the export builds and is reachable**
+
+Run:
+```bash
+npm -w @mcp-abap-adt/llm-agent-libs run build
+node --import tsx/esm -e "import('@mcp-abap-adt/llm-agent-libs').then(m => { if (typeof m.makeGitHubTransport !== 'function' || typeof m.parseGitHubRepo !== 'function') throw new Error('missing export'); console.log('exports OK'); })"
+```
+Expected: build succeeds; prints `exports OK`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/llm-agent-libs/src/skills/plugin-host/index.ts
+git commit -m "feat(skills): export makeGitHubTransport + parseGitHubRepo"
+```
+
+---
+
+## Task 4: Config schema + parse (`github` XOR `registry`, `ref`, `token`)
+
+**Files:**
+- Modify: `packages/llm-agent-server-libs/src/smart-agent/skill-plugins-config.ts:28-36` (interface), `:188-221` (fetched-source parse)
+- Test: `packages/llm-agent-server-libs/src/smart-agent/skill-plugins-config.test.ts`
+
+> Env expansion (`${GITHUB_TOKEN}`) happens UPSTREAM in the YAML loader, exactly like `registry`/`apiKey`. The parser reads `raw.token` verbatim — no env handling here.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `skill-plugins-config.test.ts` (match the file's existing import of `parseSkillPluginsConfig`; if it is not yet imported there, add `import { parseSkillPluginsConfig } from './skill-plugins-config.js';` with the other imports):
+
+```ts
+test('a github source parses with ref + token', () => {
+  const cfg = parseSkillPluginsConfig({
+    store: { type: 'in-memory' },
+    embedder: { provider: 'sap-ai-core', model: 'text-embedding-3-small' },
+    sources: [
+      {
+        id: 'sap-skills',
+        github: 'https://github.com/secondsky/sap-skills.git',
+        ref: 'main',
+        token: 'gho_x',
+        enabled: ['sap-abap'],
+        strategy: 'single-collection',
+        strategyConfig: { collection: 'sap' },
+      },
+    ],
+  });
+  const src = cfg.sources?.[0] as {
+    github?: string;
+    ref?: string;
+    token?: string;
+  };
+  assert.equal(src.github, 'https://github.com/secondsky/sap-skills.git');
+  assert.equal(src.ref, 'main');
+  assert.equal(src.token, 'gho_x');
+});
+
+test('a fetched source with BOTH github and registry fails loud', () => {
+  assert.throws(
+    () =>
+      parseSkillPluginsConfig({
+        store: { type: 'in-memory' },
+        embedder: { provider: 'sap-ai-core', model: 'm' },
+        sources: [
+          {
+            id: 'x',
+            github: 'secondsky/sap-skills',
+            registry: 'http://localhost:4100',
+            enabled: ['sap-abap'],
+          },
+        ],
+      }),
+    /exactly one of 'registry' or 'github'/,
+  );
+});
+
+test('a fetched source with NEITHER github nor registry fails loud', () => {
+  assert.throws(
+    () =>
+      parseSkillPluginsConfig({
+        store: { type: 'in-memory' },
+        embedder: { provider: 'sap-ai-core', model: 'm' },
+        sources: [{ id: 'x', enabled: ['sap-abap'] }],
+      }),
+    /exactly one of 'registry' or 'github'/,
+  );
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+node --import tsx/esm --test --test-reporter=spec \
+  packages/llm-agent-server-libs/src/smart-agent/skill-plugins-config.test.ts
+```
+Expected: FAIL — `github`/`ref`/`token` are dropped (not parsed) and the XOR check does not exist.
+
+- [ ] **Step 3: Extend the interface**
+
+In `skill-plugins-config.ts`, replace the `SkillPluginsFetchedSource` interface body (currently `id`, `registry?`, `enabled?`, `strategy?`, `strategyConfig?`) with:
+
+```ts
+/** A FETCHED source: a marketplace/registry pulled into memory. Requires a
+ *  non-empty `enabled` plugin list AND exactly one transport selector
+ *  (`registry` for an HTTP marketplace, or `github` for a GitHub repo). */
+export interface SkillPluginsFetchedSource {
+  id: string;
+  /** HTTP marketplace base URL. Mutually exclusive with `github`. */
+  registry?: string;
+  /** GitHub repo URL or bare `owner/repo`. Mutually exclusive with `registry`. */
+  github?: string;
+  /** Branch/tag/sha for a `github` source; default = repo `default_branch`. */
+  ref?: string;
+  /** Optional auth token for a `github` source (env-expanded upstream). */
+  token?: string;
+  enabled?: readonly string[];
+  /** Acquisition/materialisation strategy name (validated via the registry). */
+  strategy?: string;
+  /** Opaque, strategy-specific config (incl. any placement rules). */
+  strategyConfig?: Record<string, unknown>;
+}
+```
+
+- [ ] **Step 4: Parse the new fields + XOR check**
+
+In the fetched-source parse path, after the `enabled` validation and the existing line that conditionally copies `registry`:
+
+```ts
+const out: SkillPluginsFetchedSource = {
+  id,
+  enabled: enabled as readonly string[],
+  ...(typeof raw.registry === 'string' ? { registry: raw.registry } : {}),
+};
+```
+
+insert the github-field copies and the XOR validation:
+
+```ts
+if (raw.github !== undefined) {
+  if (typeof raw.github !== 'string') {
+    fail(`source '${id}': github must be a string`);
+  }
+  out.github = raw.github;
+}
+if (raw.ref !== undefined) {
+  if (typeof raw.ref !== 'string') {
+    fail(`source '${id}': ref must be a string`);
+  }
+  out.ref = raw.ref;
+}
+if (raw.token !== undefined) {
+  if (typeof raw.token !== 'string') {
+    fail(`source '${id}': token must be a string`);
+  }
+  out.token = raw.token;
+}
+if ((out.registry === undefined) === (out.github === undefined)) {
+  fail(
+    `source '${id}': a fetched source needs exactly one of 'registry' or 'github'`,
+  );
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run:
+```bash
+node --import tsx/esm --test --test-reporter=spec \
+  packages/llm-agent-server-libs/src/smart-agent/skill-plugins-config.test.ts
+```
+Expected: PASS — the three new tests pass and existing config tests still pass.
+
+> If any PRE-EXISTING config test now fails because it declared a fetched source with neither `registry` nor `github` (relying on the old silently-optional `registry`), that test was asserting the old loose behaviour. Update it to include a `registry` (or `github`) — the XOR rule is intended. Do NOT weaken the XOR check to keep a loose test green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/llm-agent-server-libs/src/smart-agent/skill-plugins-config.ts \
+        packages/llm-agent-server-libs/src/smart-agent/skill-plugins-config.test.ts
+git commit -m "feat(skills): config supports a github source (github XOR registry, ref, token)"
+```
+
+---
+
+## Task 5: Wire the transport in `buildSources`
+
+**Files:**
+- Modify: `packages/llm-agent-server-libs/src/smart-agent/skill-plugins-host-factory.ts:35-50` (imports), `:162-177` (fetched branch)
+- Test: `packages/llm-agent-server-libs/src/smart-agent/skill-plugins-host-factory.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `skill-plugins-host-factory.test.ts`. This test exercises the live `buildSources` path indirectly by building a host with a `github` source and a fake-fetch transport — but `buildSources` calls `makeGitHubTransport` with the real global `fetch`, which we cannot hit in a unit test. Instead, assert the WIRING decision directly with a focused export. Add a tiny exported helper to the factory so the choice is unit-testable without network:
+
+First, the test (it imports a helper we add in Step 3):
+
+```ts
+import { chooseTransportKind } from './skill-plugins-host-factory.js';
+
+test('chooseTransportKind picks github when a github field is present', () => {
+  assert.equal(
+    chooseTransportKind({ id: 'x', github: 'a/b', enabled: ['*'] }),
+    'github',
+  );
+});
+
+test('chooseTransportKind picks http when only registry is present', () => {
+  assert.equal(
+    chooseTransportKind({ id: 'x', registry: 'http://h', enabled: ['*'] }),
+    'http',
+  );
+});
+```
+
+(Match the existing import style at the top of the file; `assert` and `test` are already imported there.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+node --import tsx/esm --test --test-reporter=spec \
+  packages/llm-agent-server-libs/src/smart-agent/skill-plugins-host-factory.test.ts
+```
+Expected: FAIL — `chooseTransportKind` is not exported.
+
+- [ ] **Step 3: Add the helper, the import, and use it in `buildSources`**
+
+In `skill-plugins-host-factory.ts`, add `makeGitHubTransport` and `parseGitHubRepo` to the existing `@mcp-abap-adt/llm-agent-libs` import block (which already imports `makeHttpTransport`):
+
+```ts
+  makeGitHubTransport,
+  makeHttpTransport,
+  parseGitHubRepo,
+```
+
+Add the exported helper just above `buildSources`:
+
+```ts
+/** Which transport a fetched source selects. Exported for unit testing the
+ *  wiring decision without touching the network. */
+export function chooseTransportKind(
+  src: SkillPluginsFetchedSource,
+): 'github' | 'http' {
+  return src.github !== undefined ? 'github' : 'http';
+}
+```
+
+Add the type import for `SkillPluginsFetchedSource` to the existing config-type import:
+
+```ts
+import type {
+  SkillPluginsConfig,
+  SkillPluginsFetchedSource,
+  SkillPluginsRecordsSource,
+} from './skill-plugins-config.js';
+```
+
+Replace the fetched-branch transport construction (currently
+`transport: makeHttpTransport({ registry: src.registry ?? '' })`) with a
+kind-driven choice. The fetched branch becomes:
+
+```ts
+    // Fetched source → resolve the named strategy + pick a transport.
+    const strategy = resolveSkillSourceStrategy(
+      src.strategy ?? 'one-group-per-plugin',
+    );
+    const transport =
+      chooseTransportKind(src) === 'github'
+        ? makeGitHubTransport({
+            ...parseGitHubRepo(src.github as string),
+            ...(src.ref !== undefined ? { ref: src.ref } : {}),
+            ...(src.token !== undefined ? { token: src.token } : {}),
+            enabled: src.enabled ?? [],
+          })
+        : makeHttpTransport({ registry: src.registry ?? '' });
+    out.push({
+      id: src.id,
+      source: strategy({
+        source: src.id,
+        enabled: src.enabled ?? [],
+        transport,
+        chunk: cfg.chunk,
+        ...(src.strategyConfig !== undefined
+          ? { strategyConfig: src.strategyConfig }
+          : {}),
+      }),
+    });
+```
+
+> The `'records' in src` guard above this branch still narrows out the records
+> source, so `src` here is a `SkillPluginsFetchedSource` — `src.github`/`src.ref`/
+> `src.token` are all in scope.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+```bash
+node --import tsx/esm --test --test-reporter=spec \
+  packages/llm-agent-server-libs/src/smart-agent/skill-plugins-host-factory.test.ts
+```
+Expected: PASS — both `chooseTransportKind` tests pass; existing factory tests still pass.
+
+- [ ] **Step 5: Build the package to confirm types**
+
+Run:
+```bash
+npm -w @mcp-abap-adt/llm-agent-server-libs run build
+```
+Expected: build succeeds (the `src.github as string` cast is guarded by `chooseTransportKind`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/llm-agent-server-libs/src/smart-agent/skill-plugins-host-factory.ts \
+        packages/llm-agent-server-libs/src/smart-agent/skill-plugins-host-factory.test.ts
+git commit -m "feat(skills): wire github source transport in buildSources"
+```
+
+---
+
+## Task 6: Full build + lint + docs example
+
+**Files:**
+- Create: `docs/examples/skill-plugins-github.yaml`
+
+- [ ] **Step 1: Add a documented config example**
+
+Create `docs/examples/skill-plugins-github.yaml`:
+
+```yaml
+# Skill plugin-host that SELF-FETCHES skills from a GitHub Claude-plugin repo.
+# The host downloads marketplace.json + each SKILL.md over HTTPS into memory
+# (no git clone, no filesystem). marketplace.json + the Contents API are used to
+# enumerate skills; raw.githubusercontent.com fetches the bodies.
+#
+# Usage:
+#   npm run dev -- --config docs/examples/skill-plugins-github.yaml
+port: 4004
+host: 0.0.0.0
+
+llm:
+  main:
+    provider: sap-ai-sdk
+    model: anthropic--claude-4.6-sonnet
+
+pipeline:
+  name: controller
+
+rag:
+  type: in-memory
+  embedder: sap-ai-core
+  scenario: foundation-models
+  resourceGroup: default
+  model: text-embedding-3-small
+
+skillPlugins:
+  store: { type: in-memory }
+  embedder: { provider: sap-ai-core, model: text-embedding-3-small }
+  controllerSkillGroup: sap
+  sources:
+    - id: sap-skills
+      github: https://github.com/secondsky/sap-skills.git   # host self-fetches
+      # ref: main            # optional; default = repo default_branch
+      # token: ${GITHUB_TOKEN}  # optional; lifts rate limit + private repos
+      enabled: [sap-abap, sap-btp-developer-guide]
+      strategy: single-collection
+      strategyConfig: { collection: sap }
+```
+
+- [ ] **Step 2: Run the full test suite + lint + build**
+
+Run:
+```bash
+npm test
+npm run lint:check
+npm run build
+```
+Expected: all workspace tests pass; lint reports no errors; build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/examples/skill-plugins-github.yaml
+git commit -m "docs(examples): github skill-source config example"
+```
+
+---
+
+## Task 7: Live verification (manual — no shim)
+
+This is a manual smoke test, run only after Tasks 1–6 are green. It is the
+acceptance criterion the feature exists for: the host fetches the skills itself.
+
+- [ ] **Step 1: Point the review config at the GitHub repo**
+
+Edit `.run/skills-review.yaml`'s `skillPlugins.sources[0]` to drop `registry`
+and use `github` (no marketplace shim):
+
+```yaml
+  sources:
+    - id: sap-skills
+      github: https://github.com/secondsky/sap-skills.git
+      enabled: [sap-abap, sap-btp-developer-guide]
+      strategy: single-collection
+      strategyConfig: { collection: sap }
+```
+
+- [ ] **Step 2: Start the server (no local shim process)**
+
+```bash
+npm run build
+npm run dev -- --config .run/skills-review.yaml
+```
+Expected (in the server log): the host loads BOTH `sap-abap` and
+`sap-btp-developer-guide` — fetched directly from GitHub — and startup does not
+error on `controllerSkillGroup: sap`.
+
+- [ ] **Step 3: Run the review prompt and confirm skill use**
+
+Send the prompt `Review ABAP program zdms_upload_files, check security, performance, CleanCore, maintainability` to the running server (MCP on :3003). Confirm the controller recalls from the `sap` group and the run finalizes with no errors.
+
+> No commit — this is verification. Report the outcome to the user. If the host
+> cannot reach GitHub from the run environment, note it and fall back to
+> reporting the unit-test evidence (the transport is fully covered) rather than
+> re-introducing the shim.
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- No clone / zero-FS → Task 2 (HTTPS-only transport, in-memory manifest cache). ✓
+- Standard layout / `marketplace.json` + `skills/` listing → Tasks 1–2. ✓
+- Contents-API listing + raw bodies (hybrid) → Task 2 `listPlugins`/`fetchSkillMd`. ✓
+- Enumerate only enabled → Task 2 test "ONLY enabled". ✓
+- Optional token, public default → Task 2 token test; Task 4 config `token`. ✓
+- `github` XOR `registry` fail-loud → Task 4. ✓
+- Wiring picks transport → Task 5. ✓
+- Default-branch resolution + explicit ref skip → Task 2 tests. ✓
+- 403 token hint → Task 2 test. ✓
+- Index export → Task 3. ✓
+- Live verification → Task 7. ✓
+- Docs example → Task 6. ✓
+
+**2. Placeholder scan:** No TBD/TODO; every code step shows full code; every command has expected output. ✓
+
+**3. Type consistency:** `makeGitHubTransport`/`GitHubTransportOptions`/`parseGitHubRepo`/`parseMarketplace`/`skillDirsFromContents`/`chooseTransportKind` and the `{ owner, repo, ref?, token?, enabled, fetchImpl? }` option shape are used identically across Tasks 1, 2, 3, and 5. `SkillPluginsFetchedSource` field names (`github`/`ref`/`token`/`registry`/`enabled`) match between Task 4 (definition) and Task 5 (use). ✓

--- a/docs/superpowers/plans/2026-06-22-github-skill-source-strategy.md
+++ b/docs/superpowers/plans/2026-06-22-github-skill-source-strategy.md
@@ -227,9 +227,14 @@ import { makeGitHubTransport } from './github-transport.js';
  *  where body is an object (JSON) or string (raw text). Unmapped URL → 404. */
 function fakeFetch(routes: Record<string, { status?: number; body: unknown }>) {
   const calls: string[] = [];
-  const impl = async (input: unknown) => {
+  const headers: Array<Record<string, string> | undefined> = [];
+  const impl = async (
+    input: unknown,
+    init?: { headers?: Record<string, string> },
+  ) => {
     const url = String(input);
     calls.push(url);
+    headers.push(init?.headers);
     const hit = routes[url];
     const status = hit?.status ?? (hit ? 200 : 404);
     const ok = status >= 200 && status < 300;
@@ -241,7 +246,7 @@ function fakeFetch(routes: Record<string, { status?: number; body: unknown }>) {
       text: async () => String(hit?.body ?? ''),
     } as unknown as Response;
   };
-  return { impl: impl as unknown as typeof fetch, calls };
+  return { impl: impl as unknown as typeof fetch, calls, headers };
 }
 
 const RAW = 'https://raw.githubusercontent.com';
@@ -317,28 +322,26 @@ test('fetchSkillMd hits the raw SKILL.md URL and returns the body', async () => 
 });
 
 test('a token attaches an Authorization header to every request', async () => {
-  const seen: Array<Record<string, string> | undefined> = [];
-  const impl = (async (_url: unknown, init?: { headers?: Record<string, string> }) => {
-    seen.push(init?.headers);
-    return {
-      ok: true,
-      status: 200,
-      statusText: 'OK',
-      json: async () => MARKETPLACE,
-      text: async () => '',
-    } as unknown as Response;
-  }) as unknown as typeof fetch;
+  // Proper response sequence: marketplace JSON for the manifest URL, a directory
+  // array for the one enabled plugin's Contents URL. (ref is provided, so no
+  // default-branch metadata call.) Then assert EVERY captured call carried auth.
+  const { impl, headers } = fakeFetch({
+    [`${RAW}/o/r/main/.claude-plugin/marketplace.json`]: { body: MARKETPLACE },
+    [`${API}/repos/o/r/contents/plugins/sap-abap/skills?ref=main`]: {
+      body: [{ name: 'sap-abap', type: 'dir' }],
+    },
+  });
   const t = makeGitHubTransport({
     owner: 'o',
     repo: 'r',
     ref: 'main',
     token: 'gho_x',
-    enabled: ['*'],
+    enabled: ['sap-abap'],
     fetchImpl: impl,
   });
   await t.listPlugins();
-  assert.ok(seen.length > 0);
-  for (const h of seen) {
+  assert.ok(headers.length > 0);
+  for (const h of headers) {
     assert.equal(h?.authorization, 'Bearer gho_x');
   }
 });
@@ -623,6 +626,37 @@ test('a fetched source with NEITHER github nor registry fails loud', () => {
     /exactly one of 'registry' or 'github'/,
   );
 });
+
+test('a fetched source rejects an empty / non-string selector', () => {
+  const base = {
+    store: { type: 'in-memory' as const },
+    embedder: { provider: 'sap-ai-core', model: 'm' },
+  };
+  assert.throws(
+    () =>
+      parseSkillPluginsConfig({
+        ...base,
+        sources: [{ id: 'x', registry: '', enabled: ['a'] }],
+      }),
+    /registry must be a non-empty string/,
+  );
+  assert.throws(
+    () =>
+      parseSkillPluginsConfig({
+        ...base,
+        sources: [{ id: 'x', github: '', enabled: ['a'] }],
+      }),
+    /github must be a non-empty string/,
+  );
+  assert.throws(
+    () =>
+      parseSkillPluginsConfig({
+        ...base,
+        sources: [{ id: 'x', registry: 123, enabled: ['a'] }],
+      }),
+    /registry must be a non-empty string/,
+  );
+});
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
@@ -660,24 +694,29 @@ export interface SkillPluginsFetchedSource {
 }
 ```
 
-- [ ] **Step 4: Parse the new fields + XOR check**
+- [ ] **Step 4: Parse the new fields + non-empty validation + XOR check**
 
-In the fetched-source parse path, after the `enabled` validation and the existing line that conditionally copies `registry`:
+Currently the fetched-source path builds `out` with an inline conditional copy of
+`registry` (`...(typeof raw.registry === 'string' ? { registry: raw.registry } : {})`).
+**Replace that whole `out` construction** (the object literal plus the inline
+`registry` copy) with an explicit, validated build. Both selectors are validated
+as **non-empty strings** so `registry: ''` / `github: ''` / a non-string can no
+longer slip through the XOR check into `makeHttpTransport({ registry: '' })`:
 
 ```ts
 const out: SkillPluginsFetchedSource = {
   id,
   enabled: enabled as readonly string[],
-  ...(typeof raw.registry === 'string' ? { registry: raw.registry } : {}),
 };
-```
-
-insert the github-field copies and the XOR validation:
-
-```ts
+if (raw.registry !== undefined) {
+  if (typeof raw.registry !== 'string' || raw.registry.length === 0) {
+    fail(`source '${id}': registry must be a non-empty string`);
+  }
+  out.registry = raw.registry;
+}
 if (raw.github !== undefined) {
-  if (typeof raw.github !== 'string') {
-    fail(`source '${id}': github must be a string`);
+  if (typeof raw.github !== 'string' || raw.github.length === 0) {
+    fail(`source '${id}': github must be a non-empty string`);
   }
   out.github = raw.github;
 }
@@ -707,7 +746,7 @@ Run:
 node --import tsx/esm --test --test-reporter=spec \
   packages/llm-agent-server-libs/src/smart-agent/skill-plugins-config.test.ts
 ```
-Expected: PASS — the three new tests pass and existing config tests still pass.
+Expected: PASS — the four new tests pass and existing config tests still pass.
 
 > If any PRE-EXISTING config test now fails because it declared a fetched source with neither `registry` nor `github` (relying on the old silently-optional `registry`), that test was asserting the old loose behaviour. Update it to include a `registry` (or `github`) — the XOR rule is intended. Do NOT weaken the XOR check to keep a loose test green.
 
@@ -721,37 +760,100 @@ git commit -m "feat(skills): config supports a github source (github XOR registr
 
 ---
 
-## Task 5: Wire the transport in `buildSources`
+## Task 5: Wire the transport in `buildSources` (DI seam, real wiring tested)
 
 **Files:**
-- Modify: `packages/llm-agent-server-libs/src/smart-agent/skill-plugins-host-factory.ts:35-50` (imports), `:162-177` (fetched branch)
+- Modify: `packages/llm-agent-server-libs/src/smart-agent/skill-plugins-host-factory.ts:35-50` (imports), `:152-180` (`buildSources`)
 - Test: `packages/llm-agent-server-libs/src/smart-agent/skill-plugins-host-factory.test.ts`
+
+> The reviewer flagged that testing a `chooseTransportKind` predicate would not
+> catch a broken implementation that drops `ref`/`token`/`enabled` or skips
+> `parseGitHubRepo`. Instead, give `buildSources` a **transport-factory DI seam**
+> (defaulting to the real factories) and assert the GitHub source ACTUALLY
+> constructs `makeGitHubTransport` with the right options. No production export
+> exists solely for the test — the seam is a real, defaulted parameter.
 
 - [ ] **Step 1: Write the failing test**
 
-Append to `skill-plugins-host-factory.test.ts`. This test exercises the live `buildSources` path indirectly by building a host with a `github` source and a fake-fetch transport — but `buildSources` calls `makeGitHubTransport` with the real global `fetch`, which we cannot hit in a unit test. Instead, assert the WIRING decision directly with a focused export. Add a tiny exported helper to the factory so the choice is unit-testable without network:
-
-First, the test (it imports a helper we add in Step 3):
+Append to `skill-plugins-host-factory.test.ts`. (The file already imports `assert`
+and `test`; ensure `SkillPluginsConfig` is imported — if not, add
+`import type { SkillPluginsConfig } from './skill-plugins-config.js';`. Also add
+`import type { GitHubTransportOptions } from '@mcp-abap-adt/llm-agent-libs';`.)
 
 ```ts
-import { chooseTransportKind } from './skill-plugins-host-factory.js';
+import {
+  buildSources,
+  type TransportFactories,
+} from './skill-plugins-host-factory.js';
+import type { GitHubTransportOptions } from '@mcp-abap-adt/llm-agent-libs';
 
-test('chooseTransportKind picks github when a github field is present', () => {
-  assert.equal(
-    chooseTransportKind({ id: 'x', github: 'a/b', enabled: ['*'] }),
-    'github',
+const STUB_TRANSPORT = {
+  listPlugins: async () => [],
+  fetchSkillMd: async () => '',
+};
+
+test('buildSources builds a github source, threading repo/ref/token/enabled', () => {
+  let captured: GitHubTransportOptions | undefined;
+  const factories: TransportFactories = {
+    github: (opts) => {
+      captured = opts;
+      return STUB_TRANSPORT;
+    },
+    http: () => {
+      throw new Error('should not build an http transport for a github source');
+    },
+  };
+  const sources = buildSources(
+    {
+      chunk: { maxChars: 1000 },
+      sources: [
+        {
+          id: 'sap-skills',
+          github: 'https://github.com/secondsky/sap-skills.git',
+          ref: 'main',
+          token: 'gho_x',
+          enabled: ['sap-abap'],
+          strategy: 'single-collection',
+          strategyConfig: { collection: 'sap' },
+        },
+      ],
+    } as unknown as SkillPluginsConfig,
+    factories,
   );
+  assert.equal(sources.length, 1);
+  assert.equal(sources[0].id, 'sap-skills');
+  // parseGitHubRepo ran (URL → owner/repo) AND ref/token/enabled were threaded.
+  assert.deepEqual(captured, {
+    owner: 'secondsky',
+    repo: 'sap-skills',
+    ref: 'main',
+    token: 'gho_x',
+    enabled: ['sap-abap'],
+  });
 });
 
-test('chooseTransportKind picks http when only registry is present', () => {
-  assert.equal(
-    chooseTransportKind({ id: 'x', registry: 'http://h', enabled: ['*'] }),
-    'http',
+test('buildSources builds an http source from registry', () => {
+  let registry: string | undefined;
+  const factories: TransportFactories = {
+    github: () => {
+      throw new Error('should not build a github transport for a registry source');
+    },
+    http: (opts) => {
+      registry = opts.registry;
+      return STUB_TRANSPORT;
+    },
+  };
+  const sources = buildSources(
+    {
+      chunk: { maxChars: 1000 },
+      sources: [{ id: 'r', registry: 'http://h', enabled: ['*'] }],
+    } as unknown as SkillPluginsConfig,
+    factories,
   );
+  assert.equal(sources.length, 1);
+  assert.equal(registry, 'http://h');
 });
 ```
-
-(Match the existing import style at the top of the file; `assert` and `test` are already imported there.)
 
 - [ ] **Step 2: Run test to verify it fails**
 
@@ -760,58 +862,70 @@ Run:
 node --import tsx/esm --test --test-reporter=spec \
   packages/llm-agent-server-libs/src/smart-agent/skill-plugins-host-factory.test.ts
 ```
-Expected: FAIL — `chooseTransportKind` is not exported.
+Expected: FAIL — `buildSources` / `TransportFactories` are not exported, and
+`buildSources` does not yet accept a factories argument.
 
-- [ ] **Step 3: Add the helper, the import, and use it in `buildSources`**
+- [ ] **Step 3: Add the imports, the DI seam, and the github branch**
 
-In `skill-plugins-host-factory.ts`, add `makeGitHubTransport` and `parseGitHubRepo` to the existing `@mcp-abap-adt/llm-agent-libs` import block (which already imports `makeHttpTransport`):
+In `skill-plugins-host-factory.ts`, extend the existing
+`@mcp-abap-adt/llm-agent-libs` import block (which already imports
+`makeHttpTransport`) to also bring in the GitHub transport, the option/transport
+types, and `parseGitHubRepo`:
 
 ```ts
+  type GitHubTransportOptions,
+  type HttpTransportOptions,
+  type IMarketplaceTransport,
   makeGitHubTransport,
   makeHttpTransport,
   parseGitHubRepo,
 ```
 
-Add the exported helper just above `buildSources`:
+Define the DI seam + default just above `buildSources`:
 
 ```ts
-/** Which transport a fetched source selects. Exported for unit testing the
- *  wiring decision without touching the network. */
-export function chooseTransportKind(
-  src: SkillPluginsFetchedSource,
-): 'github' | 'http' {
-  return src.github !== undefined ? 'github' : 'http';
+/** Transport factories for {@link buildSources}. A DI seam: production uses the
+ *  defaults; unit tests inject capturing stubs to assert the wiring without
+ *  touching the network. */
+export interface TransportFactories {
+  github: (opts: GitHubTransportOptions) => IMarketplaceTransport;
+  http: (opts: HttpTransportOptions) => IMarketplaceTransport;
 }
+
+const defaultTransports: TransportFactories = {
+  github: makeGitHubTransport,
+  http: makeHttpTransport,
+};
 ```
 
-Add the type import for `SkillPluginsFetchedSource` to the existing config-type import:
+Change `buildSources` to be EXPORTED, take the factories (defaulted), and pick
+the transport by the present selector. The whole function becomes:
 
 ```ts
-import type {
-  SkillPluginsConfig,
-  SkillPluginsFetchedSource,
-  SkillPluginsRecordsSource,
-} from './skill-plugins-config.js';
-```
-
-Replace the fetched-branch transport construction (currently
-`transport: makeHttpTransport({ registry: src.registry ?? '' })`) with a
-kind-driven choice. The fetched branch becomes:
-
-```ts
-    // Fetched source → resolve the named strategy + pick a transport.
+/** Map every config source to a `{ id, source }` ingest entry. */
+export function buildSources(
+  cfg: SkillPluginsConfig,
+  transports: TransportFactories = defaultTransports,
+): ReadonlyArray<{ id: string; source: ISkillSource }> {
+  const out: { id: string; source: ISkillSource }[] = [];
+  for (const src of cfg.sources ?? []) {
+    if ('records' in src) {
+      out.push({ id: src.id, source: makeRecordsSource(src) });
+      continue;
+    }
+    // Fetched source → resolve the named strategy + pick a transport by selector.
     const strategy = resolveSkillSourceStrategy(
       src.strategy ?? 'one-group-per-plugin',
     );
     const transport =
-      chooseTransportKind(src) === 'github'
-        ? makeGitHubTransport({
-            ...parseGitHubRepo(src.github as string),
+      src.github !== undefined
+        ? transports.github({
+            ...parseGitHubRepo(src.github),
             ...(src.ref !== undefined ? { ref: src.ref } : {}),
             ...(src.token !== undefined ? { token: src.token } : {}),
             enabled: src.enabled ?? [],
           })
-        : makeHttpTransport({ registry: src.registry ?? '' });
+        : transports.http({ registry: src.registry ?? '' });
     out.push({
       id: src.id,
       source: strategy({
@@ -824,11 +938,16 @@ kind-driven choice. The fetched branch becomes:
           : {}),
       }),
     });
+  }
+  return out;
+}
 ```
 
-> The `'records' in src` guard above this branch still narrows out the records
-> source, so `src` here is a `SkillPluginsFetchedSource` — `src.github`/`src.ref`/
-> `src.token` are all in scope.
+> `buildSkillHostFromConfig` already calls `const sources = buildSources(cfg);` —
+> the new second parameter is defaulted, so that call is unchanged and uses the
+> real factories. The `'records' in src` guard narrows `src` to
+> `SkillPluginsFetchedSource`, so `src.github`/`src.ref`/`src.token` are in scope
+> with no cast (Task 4 added those fields to the type).
 
 - [ ] **Step 4: Run test to verify it passes**
 
@@ -837,7 +956,7 @@ Run:
 node --import tsx/esm --test --test-reporter=spec \
   packages/llm-agent-server-libs/src/smart-agent/skill-plugins-host-factory.test.ts
 ```
-Expected: PASS — both `chooseTransportKind` tests pass; existing factory tests still pass.
+Expected: PASS — both new wiring tests pass; existing factory tests still pass.
 
 - [ ] **Step 5: Build the package to confirm types**
 
@@ -845,14 +964,14 @@ Run:
 ```bash
 npm -w @mcp-abap-adt/llm-agent-server-libs run build
 ```
-Expected: build succeeds (the `src.github as string` cast is guarded by `chooseTransportKind`).
+Expected: build succeeds.
 
 - [ ] **Step 6: Commit**
 
 ```bash
 git add packages/llm-agent-server-libs/src/smart-agent/skill-plugins-host-factory.ts \
         packages/llm-agent-server-libs/src/smart-agent/skill-plugins-host-factory.test.ts
-git commit -m "feat(skills): wire github source transport in buildSources"
+git commit -m "feat(skills): wire github source transport in buildSources (DI seam)"
 ```
 
 ---
@@ -973,8 +1092,8 @@ Send the prompt `Review ABAP program zdms_upload_files, check security, performa
 - Contents-API listing + raw bodies (hybrid) → Task 2 `listPlugins`/`fetchSkillMd`. ✓
 - Enumerate only enabled → Task 2 test "ONLY enabled". ✓
 - Optional token, public default → Task 2 token test; Task 4 config `token`. ✓
-- `github` XOR `registry` fail-loud → Task 4. ✓
-- Wiring picks transport → Task 5. ✓
+- `github` XOR `registry` fail-loud + non-empty validation → Task 4 (+ empty/non-string tests). ✓
+- Wiring picks transport (real `buildSources` via DI seam) → Task 5. ✓
 - Default-branch resolution + explicit ref skip → Task 2 tests. ✓
 - 403 token hint → Task 2 test. ✓
 - Index export → Task 3. ✓
@@ -983,4 +1102,4 @@ Send the prompt `Review ABAP program zdms_upload_files, check security, performa
 
 **2. Placeholder scan:** No TBD/TODO; every code step shows full code; every command has expected output. ✓
 
-**3. Type consistency:** `makeGitHubTransport`/`GitHubTransportOptions`/`parseGitHubRepo`/`parseMarketplace`/`skillDirsFromContents`/`chooseTransportKind` and the `{ owner, repo, ref?, token?, enabled, fetchImpl? }` option shape are used identically across Tasks 1, 2, 3, and 5. `SkillPluginsFetchedSource` field names (`github`/`ref`/`token`/`registry`/`enabled`) match between Task 4 (definition) and Task 5 (use). ✓
+**3. Type consistency:** `makeGitHubTransport`/`GitHubTransportOptions`/`parseGitHubRepo`/`parseMarketplace`/`skillDirsFromContents` and the `{ owner, repo, ref?, token?, enabled, fetchImpl? }` option shape are used identically across Tasks 1, 2, 3, and 5. `TransportFactories` (`{ github, http }`) is defined and consumed in Task 5 only. `SkillPluginsFetchedSource` field names (`github`/`ref`/`token`/`registry`/`enabled`) match between Task 4 (definition) and Task 5 (use). The Task 5 test's `captured` deep-equal (`{owner,repo,ref,token,enabled}`) matches exactly what the `buildSources` github branch passes. ✓

--- a/docs/superpowers/specs/2026-06-22-github-skill-source-strategy-design.md
+++ b/docs/superpowers/specs/2026-06-22-github-skill-source-strategy-design.md
@@ -1,0 +1,225 @@
+# GitHub Skill Source Strategy — Design
+
+**Date:** 2026-06-22
+**Status:** Approved (design); pending implementation plan.
+
+## Problem
+
+The skill plugin-host is meant to **self-fetch** the skills a consumer declares
+in `skillPlugins.sources` — the consumer writes config and the host pulls. Today
+the host has exactly one fetched-source transport: `makeHttpTransport`, which
+talks to an **HTTP marketplace** (`GET {registry}/plugins` +
+`GET {registry}/plugins/{plugin}/skills/{skill}`). A raw git/GitHub Claude-plugin
+repo URL (e.g. `https://github.com/secondsky/sap-skills.git`) is **not** such a
+marketplace, so there is no way to point the host at a GitHub skills repo. The
+only workaround has been to hand-clone the repo and run a local marketplace shim
+— which defeats the purpose of a self-fetching host.
+
+This design adds a **GitHub source** so a consumer configures only the repo URL
+(plus the enabled plugins) and the host downloads the skills itself.
+
+## Constraints (decided)
+
+1. **No `git clone`, no filesystem.** The deployment may have no writable FS
+   (serverless/edge). The host fetches files over **HTTPS into memory** only.
+   This mirrors the existing in-memory store philosophy.
+2. **Standard Claude-plugin layout is fixed.** Every Claude-plugin repo places
+   files identically (this is how Anthropic's own loader finds them):
+   ```
+   .claude-plugin/marketplace.json            # lists plugins: name, source, version
+   plugins/<plugin>/.claude-plugin/plugin.json
+   plugins/<plugin>/skills/<skill>/SKILL.md   # the skills
+   ```
+   The transport relies on this fixed layout — no generic git-host abstraction,
+   no path guessing.
+3. **Skill discovery needs ONE directory listing.** `marketplace.json` lists
+   plugins but **not** skill names; the skills are the `skills/<skill>/`
+   subdirectories. `raw.githubusercontent.com` cannot list a directory, so the
+   transport uses the **GitHub Contents API** to list `plugins/<plugin>/skills/`
+   (the only HTTP way to enumerate a folder), then fetches each `SKILL.md` from
+   `raw` (unlimited, no base64). — hybrid, per design decision.
+4. **Auth: optional token, public default.** Public repos (e.g. `sap-skills`)
+   work with no token. An optional token lifts the Contents-API rate limit
+   (60/hr anon → 5000/hr) and enables private repos.
+
+## Architecture
+
+The existing `IMarketplaceTransport` (`listPlugins()` + `fetchSkillMd()`) is the
+seam. `makeHttpMarketplaceSource`, both source strategies
+(`one-group-per-plugin` / `single-collection`), the marketplace adapter, and the
+store are all transport-agnostic. **A GitHub source is therefore just a new
+transport** — zero changes to strategies, adapter, host, or store.
+
+```
+config github: → buildSources → makeGitHubTransport
+                                       │ (IMarketplaceTransport)
+                                       ▼
+                              makeHttpMarketplaceSource (placement = strategy)
+                                       │
+                              host.load() → acquire()
+                                       │
+   raw marketplace.json  +  Contents-API skills listing  +  raw SKILL.md
+                                       │
+                              buildIngestResult → store        (zero FS)
+```
+
+### Component 1 — `makeGitHubTransport`
+
+New file: `packages/llm-agent-libs/src/skills/plugin-host/github-transport.ts`.
+Implements `IMarketplaceTransport`.
+
+**Options:** `{ owner: string; repo: string; ref?: string; token?: string;
+enabled: readonly string[]; fetchImpl?: typeof fetch }`.
+`fetchImpl` defaults to global `fetch`; injected in unit tests (no real network).
+
+**Pure, separately unit-tested helpers (no network):**
+
+- `parseGitHubRepo(url: string): { owner: string; repo: string }` — accepts
+  `https://github.com/owner/repo`, the same with a trailing `.git`,
+  `github.com/owner/repo`, and bare `owner/repo`. Throws a clear error on an
+  unparseable URL.
+- `parseMarketplace(json: unknown): Array<{ plugin: string; version: string;
+  sourcePath: string }>` — reads `plugins[]` (`name`→plugin, `version`,
+  `source`→sourcePath, normalising a leading `./`). Throws if `plugins` is
+  missing or not an array.
+- `skillDirsFromContents(json: unknown): string[]` — from a Contents-API
+  directory response, returns entry `name`s where `type === 'dir'`.
+
+**`listPlugins()`:**
+
+1. Resolve `ref`: if `ref` is unset, `GET https://api.github.com/repos/{owner}/{repo}`
+   → use `default_branch`. (Cached on the instance after first resolution.)
+2. `GET https://raw.githubusercontent.com/{owner}/{repo}/{ref}/.claude-plugin/marketplace.json`
+   → `parseMarketplace` → cache a `plugin → sourcePath` map on the instance.
+3. Determine the plugins to enumerate: if `enabled` includes `'*'`, all plugins
+   from the manifest; otherwise only the manifest plugins whose name is in
+   `enabled`. (Enumerating skills for only the enabled subset avoids spending
+   one Contents-API call per unused plugin — 37 plugins in `sap-skills`.)
+4. For each such plugin:
+   `GET https://api.github.com/repos/{owner}/{repo}/contents/{sourcePath}/skills?ref={ref}`
+   → `skillDirsFromContents` → its skill names.
+5. Return `Array<{ plugin, version, skills }>` for the enumerated subset.
+
+**`fetchSkillMd(plugin, skill)`:** ensure the manifest is loaded (so the
+`sourcePath` map exists), then
+`GET https://raw.githubusercontent.com/{owner}/{repo}/{ref}/{sourcePath}/skills/{skill}/SKILL.md`
+→ response text.
+
+**Headers:** when `token` is set, attach `Authorization: Bearer <token>` to
+**every** request (Contents API, repo metadata, and raw — enabling private
+repos). When unset, send no auth header.
+
+**Errors:** any non-OK response throws `"<op> <status> <statusText>"` (matching
+`makeHttpTransport`'s style). A `403` on a Contents-API call additionally hints
+that an unauthenticated rate limit was likely hit and a `token` should be set.
+
+### Component 2 — config schema + parse
+
+File: `packages/llm-agent-server-libs/src/smart-agent/skill-plugins-config.ts`.
+
+Extend `SkillPluginsFetchedSource` with GitHub fields:
+
+```ts
+export interface SkillPluginsFetchedSource {
+  id: string;
+  registry?: string;        // HTTP marketplace (existing)
+  github?: string;          // GitHub repo URL or owner/repo (new)
+  ref?: string;             // branch/tag/sha; default = repo default_branch
+  token?: string;           // optional auth (env-expanded like other config)
+  enabled?: readonly string[];
+  strategy?: string;
+  strategyConfig?: Record<string, unknown>;
+}
+```
+
+**Parse rules (fail-loud):**
+
+- A fetched source must have **exactly one** of `registry` / `github` — both set
+  → error; neither set → error. (Today `registry` is silently optional; this
+  tightens it.)
+- `github`, `ref`, `token` parsed as strings; `ref`/`token` optional. `token`
+  goes through the same `${ENV}` expansion the loader applies to other config
+  values (e.g. `${GITHUB_TOKEN}`).
+- The existing `enabled` non-empty requirement is unchanged (applies to both
+  transports).
+
+Config example:
+
+```yaml
+skillPlugins:
+  sources:
+    - id: sap-skills
+      github: https://github.com/secondsky/sap-skills.git   # host self-fetches
+      ref: main                 # optional; default = repo default_branch
+      token: ${GITHUB_TOKEN}    # optional
+      enabled: [sap-abap, sap-btp-developer-guide]
+      strategy: single-collection
+      strategyConfig: { collection: sap }
+```
+
+### Component 3 — wiring
+
+File: `packages/llm-agent-server-libs/src/smart-agent/skill-plugins-host-factory.ts`,
+`buildSources()` (currently builds `makeHttpTransport({ registry })`).
+
+In the fetched-source branch, pick the transport by which field is present:
+
+- `src.github` present → `makeGitHubTransport({ ...parseGitHubRepo(src.github),
+  ...(src.ref ? { ref: src.ref } : {}), ...(src.token ? { token: src.token } :
+  {}), enabled: src.enabled ?? [] })`.
+- else → `makeHttpTransport({ registry: src.registry ?? '' })` (unchanged).
+
+Export `makeGitHubTransport` and `parseGitHubRepo` from the `llm-agent-libs`
+package index (alongside `makeHttpTransport`).
+
+## Data flow (load)
+
+`host.load()` → source `acquire()` → `transport.listPlugins()` (default-branch
+resolve + raw marketplace.json + Contents-API skills listing for enabled
+plugins) → `transport.fetchSkillMd()` per skill (raw) → `buildIngestResult`
+(strategy placement + chunking) → store upsert. No file is ever written to disk.
+
+## Error handling
+
+| Condition | Behaviour |
+|-----------|-----------|
+| Unparseable `github` URL | `parseGitHubRepo` throws at build time |
+| Both/neither `registry`+`github` | config parse throws (fail-loud) |
+| `marketplace.json` missing / not JSON | `listPlugins` throws with status/parse error |
+| Plugin has no `skills/` dir (404) | throws a clear "no skills/ directory" error |
+| Contents-API `403` (rate limit) | throws, hinting to set `token` |
+| Any non-OK fetch | throws `"<op> <status> <statusText>"` |
+
+## Testing
+
+**Unit (no real network):**
+
+- `parseGitHubRepo`: all accepted URL forms + `.git` suffix + bare `owner/repo`;
+  throw on garbage.
+- `parseMarketplace`: maps `plugins[]` (name/version/source, `./` stripped);
+  throws on missing `plugins`.
+- `skillDirsFromContents`: returns only `type === 'dir'` names.
+- `makeGitHubTransport` via an injected fake `fetch` scripted with the response
+  sequence (default-branch → marketplace.json → contents listing → SKILL.md):
+  - `listPlugins()` returns `[{plugin,version,skills}]` for the enabled subset;
+  - **only enabled plugins are enumerated** (no Contents-API call for the rest);
+  - `ref` defaults to `default_branch` when unset, and the metadata call is
+    skipped when `ref` is provided;
+  - a `token` attaches `Authorization: Bearer` to requests;
+  - `fetchSkillMd` hits the correct raw URL and returns the body.
+- Config parse: `github` XOR `registry` (both → throw, neither → throw); `ref`
+  and `token` parsed; `enabled` requirement preserved.
+
+**Live verification (manual, after build):** re-run the `sap-skills` review
+config with a `github:` source (no shim) and confirm the host fetches
+`sap-abap` + `sap-btp-developer-guide` itself and the controller uses them.
+
+## Out of scope (YAGNI)
+
+- `git clone` / any on-disk caching.
+- Generic git-host abstraction (GitLab/Bitbucket/self-hosted).
+- Reading `plugin.json` or `commands` (marketplace.json + the `skills/` listing
+  are sufficient).
+- Multi-skill-name conventions beyond what the Contents-API listing returns
+  (the listing already handles plugins with any number of differently-named
+  skills).

--- a/packages/llm-agent-libs/src/skills/plugin-host/github-transport.test.ts
+++ b/packages/llm-agent-libs/src/skills/plugin-host/github-transport.test.ts
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  parseGitHubRepo,
+  parseMarketplace,
+  skillDirsFromContents,
+} from './github-transport.js';
+
+test('parseGitHubRepo accepts all URL forms', () => {
+  const expected = { owner: 'secondsky', repo: 'sap-skills' };
+  assert.deepEqual(
+    parseGitHubRepo('https://github.com/secondsky/sap-skills.git'),
+    expected,
+  );
+  assert.deepEqual(
+    parseGitHubRepo('https://github.com/secondsky/sap-skills'),
+    expected,
+  );
+  assert.deepEqual(
+    parseGitHubRepo('github.com/secondsky/sap-skills'),
+    expected,
+  );
+  assert.deepEqual(parseGitHubRepo('secondsky/sap-skills'), expected);
+  assert.deepEqual(
+    parseGitHubRepo('https://github.com/secondsky/sap-skills/'),
+    expected,
+  );
+});
+
+test('parseGitHubRepo throws on garbage', () => {
+  assert.throws(
+    () => parseGitHubRepo('not a repo'),
+    /cannot parse GitHub repo/,
+  );
+});
+
+test('parseMarketplace maps plugins[] and strips a leading ./', () => {
+  const out = parseMarketplace({
+    plugins: [
+      { name: 'sap-abap', version: '2.3.2', source: './plugins/sap-abap' },
+      { name: 'x', source: 'plugins/x' },
+    ],
+  });
+  assert.deepEqual(out, [
+    { plugin: 'sap-abap', version: '2.3.2', sourcePath: 'plugins/sap-abap' },
+    { plugin: 'x', version: '0.0.0', sourcePath: 'plugins/x' },
+  ]);
+});
+
+test('parseMarketplace throws when plugins[] is missing', () => {
+  assert.throws(() => parseMarketplace({}), /no plugins\[\] array/);
+});
+
+test('skillDirsFromContents returns only dir entries', () => {
+  const out = skillDirsFromContents([
+    { name: 'sap-abap', type: 'dir' },
+    { name: 'README.md', type: 'file' },
+    { name: 'extra', type: 'dir' },
+  ]);
+  assert.deepEqual(out, ['sap-abap', 'extra']);
+});
+
+test('skillDirsFromContents throws on a non-array', () => {
+  assert.throws(
+    () => skillDirsFromContents({ message: 'Not Found' }),
+    /expected a Contents-API directory array/,
+  );
+});

--- a/packages/llm-agent-libs/src/skills/plugin-host/github-transport.test.ts
+++ b/packages/llm-agent-libs/src/skills/plugin-host/github-transport.test.ts
@@ -66,3 +66,146 @@ test('skillDirsFromContents throws on a non-array', () => {
     /expected a Contents-API directory array/,
   );
 });
+
+import { makeGitHubTransport } from './github-transport.js';
+
+/** Build a fake `fetch` from a URL→response map. Each value is `{ status?, body }`
+ *  where body is an object (JSON) or string (raw text). Unmapped URL → 404. */
+function fakeFetch(routes: Record<string, { status?: number; body: unknown }>) {
+  const calls: string[] = [];
+  const headers: Array<Record<string, string> | undefined> = [];
+  const impl = async (
+    input: unknown,
+    init?: { headers?: Record<string, string> },
+  ) => {
+    const url = String(input);
+    calls.push(url);
+    headers.push(init?.headers);
+    const hit = routes[url];
+    const status = hit?.status ?? (hit ? 200 : 404);
+    const ok = status >= 200 && status < 300;
+    return {
+      ok,
+      status,
+      statusText: ok ? 'OK' : 'Not Found',
+      json: async () => hit?.body,
+      text: async () => String(hit?.body ?? ''),
+    } as unknown as Response;
+  };
+  return { impl: impl as unknown as typeof fetch, calls, headers };
+}
+
+const RAW = 'https://raw.githubusercontent.com';
+const API = 'https://api.github.com';
+
+const MARKETPLACE = {
+  plugins: [
+    { name: 'sap-abap', version: '2.3.2', source: './plugins/sap-abap' },
+    { name: 'sap-btp', version: '1.0.0', source: './plugins/sap-btp' },
+    { name: 'unused', version: '9.9.9', source: './plugins/unused' },
+  ],
+};
+
+test('listPlugins resolves default branch and enumerates ONLY enabled plugins', async () => {
+  const { impl, calls } = fakeFetch({
+    [`${API}/repos/o/r`]: { body: { default_branch: 'main' } },
+    [`${RAW}/o/r/main/.claude-plugin/marketplace.json`]: { body: MARKETPLACE },
+    [`${API}/repos/o/r/contents/plugins/sap-abap/skills?ref=main`]: {
+      body: [{ name: 'sap-abap', type: 'dir' }],
+    },
+    [`${API}/repos/o/r/contents/plugins/sap-btp/skills?ref=main`]: {
+      body: [{ name: 'sap-btp', type: 'dir' }],
+    },
+  });
+  const t = makeGitHubTransport({
+    owner: 'o',
+    repo: 'r',
+    enabled: ['sap-abap', 'sap-btp'],
+    fetchImpl: impl,
+  });
+  const out = await t.listPlugins();
+  assert.deepEqual(out, [
+    { plugin: 'sap-abap', version: '2.3.2', skills: ['sap-abap'] },
+    { plugin: 'sap-btp', version: '1.0.0', skills: ['sap-btp'] },
+  ]);
+  // The 'unused' plugin must NOT be enumerated (no Contents-API call for it).
+  assert.ok(!calls.some((u) => u.includes('plugins/unused/skills')));
+});
+
+test('an explicit ref skips the default-branch metadata call', async () => {
+  const { impl, calls } = fakeFetch({
+    [`${RAW}/o/r/dev/.claude-plugin/marketplace.json`]: { body: MARKETPLACE },
+    [`${API}/repos/o/r/contents/plugins/sap-abap/skills?ref=dev`]: {
+      body: [{ name: 'sap-abap', type: 'dir' }],
+    },
+  });
+  const t = makeGitHubTransport({
+    owner: 'o',
+    repo: 'r',
+    ref: 'dev',
+    enabled: ['sap-abap'],
+    fetchImpl: impl,
+  });
+  await t.listPlugins();
+  assert.ok(!calls.some((u) => u === `${API}/repos/o/r`));
+});
+
+test('fetchSkillMd hits the raw SKILL.md URL and returns the body', async () => {
+  const { impl } = fakeFetch({
+    [`${API}/repos/o/r`]: { body: { default_branch: 'main' } },
+    [`${RAW}/o/r/main/.claude-plugin/marketplace.json`]: { body: MARKETPLACE },
+    [`${RAW}/o/r/main/plugins/sap-abap/skills/sap-abap/SKILL.md`]: {
+      body: '# ABAP skill',
+    },
+  });
+  const t = makeGitHubTransport({
+    owner: 'o',
+    repo: 'r',
+    enabled: ['sap-abap'],
+    fetchImpl: impl,
+  });
+  assert.equal(await t.fetchSkillMd('sap-abap', 'sap-abap'), '# ABAP skill');
+});
+
+test('a token attaches an Authorization header to every request', async () => {
+  // Proper response sequence: marketplace JSON for the manifest URL, a directory
+  // array for the one enabled plugin's Contents URL. (ref is provided, so no
+  // default-branch metadata call.) Then assert EVERY captured call carried auth.
+  const { impl, headers } = fakeFetch({
+    [`${RAW}/o/r/main/.claude-plugin/marketplace.json`]: { body: MARKETPLACE },
+    [`${API}/repos/o/r/contents/plugins/sap-abap/skills?ref=main`]: {
+      body: [{ name: 'sap-abap', type: 'dir' }],
+    },
+  });
+  const t = makeGitHubTransport({
+    owner: 'o',
+    repo: 'r',
+    ref: 'main',
+    token: 'gho_x',
+    enabled: ['sap-abap'],
+    fetchImpl: impl,
+  });
+  await t.listPlugins();
+  assert.ok(headers.length > 0);
+  for (const h of headers) {
+    assert.equal(h?.authorization, 'Bearer gho_x');
+  }
+});
+
+test('listPlugins throws with a token hint on a 403', async () => {
+  const { impl } = fakeFetch({
+    [`${RAW}/o/r/main/.claude-plugin/marketplace.json`]: { body: MARKETPLACE },
+    [`${API}/repos/o/r/contents/plugins/sap-abap/skills?ref=main`]: {
+      status: 403,
+      body: {},
+    },
+  });
+  const t = makeGitHubTransport({
+    owner: 'o',
+    repo: 'r',
+    ref: 'main',
+    enabled: ['sap-abap'],
+    fetchImpl: impl,
+  });
+  await assert.rejects(() => t.listPlugins(), /set a token/);
+});

--- a/packages/llm-agent-libs/src/skills/plugin-host/github-transport.ts
+++ b/packages/llm-agent-libs/src/skills/plugin-host/github-transport.ts
@@ -53,3 +53,116 @@ export function skillDirsFromContents(json: unknown): string[] {
     .filter((e) => e.type === 'dir' && typeof e.name === 'string')
     .map((e) => e.name as string);
 }
+
+const RAW_BASE = 'https://raw.githubusercontent.com';
+const API_BASE = 'https://api.github.com';
+
+export interface GitHubTransportOptions {
+  owner: string;
+  repo: string;
+  /** Branch/tag/sha; default = the repo's `default_branch`. */
+  ref?: string;
+  /** Optional auth token (lifts rate limit + enables private repos). */
+  token?: string;
+  /** Plugins to enumerate; `['*']` = all. Only these get a Contents-API call. */
+  enabled: readonly string[];
+  /** Injected for tests; default global `fetch`. */
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * An {@link IMarketplaceTransport} over a GitHub Claude-plugin repo. Reads the
+ * standard layout via HTTPS into memory (no clone, no FS): marketplace.json and
+ * each SKILL.md from `raw.githubusercontent.com`; per-plugin `skills/` listings
+ * from the GitHub Contents API. NOT unit-tested over a real network — the unit
+ * tests inject `fetchImpl`.
+ */
+export function makeGitHubTransport(
+  opts: GitHubTransportOptions,
+): IMarketplaceTransport {
+  const { owner, repo, token, enabled } = opts;
+  const doFetch = opts.fetchImpl ?? fetch;
+  const headers: Record<string, string> = token
+    ? { authorization: `Bearer ${token}` }
+    : {};
+  const wantAll = enabled.includes('*');
+  const enabledSet = new Set(enabled);
+
+  let ref = opts.ref;
+  let manifest:
+    | Array<{ plugin: string; version: string; sourcePath: string }>
+    | undefined;
+
+  async function resolveRef(): Promise<string> {
+    if (ref) return ref;
+    const res = await doFetch(`${API_BASE}/repos/${owner}/${repo}`, {
+      headers,
+    });
+    if (!res.ok) {
+      throw new Error(`resolveRef ${res.status} ${res.statusText}`);
+    }
+    const meta = (await res.json()) as { default_branch?: string };
+    ref = meta.default_branch ?? 'main';
+    return ref;
+  }
+
+  async function loadManifest() {
+    if (manifest) return manifest;
+    const r = await resolveRef();
+    const url = `${RAW_BASE}/${owner}/${repo}/${r}/.claude-plugin/marketplace.json`;
+    const res = await doFetch(url, { headers });
+    if (!res.ok) {
+      throw new Error(`marketplace.json ${res.status} ${res.statusText}`);
+    }
+    manifest = parseMarketplace(await res.json());
+    return manifest;
+  }
+
+  function sourcePathOf(plugin: string): string {
+    const entry = manifest?.find((m) => m.plugin === plugin);
+    if (!entry) {
+      throw new Error(
+        `github transport: unknown plugin '${plugin}' (not in marketplace.json)`,
+      );
+    }
+    return entry.sourcePath;
+  }
+
+  return {
+    async listPlugins() {
+      const m = await loadManifest();
+      const r = await resolveRef();
+      const selected = wantAll ? m : m.filter((p) => enabledSet.has(p.plugin));
+      return Promise.all(
+        selected.map(async (p) => {
+          const url = `${API_BASE}/repos/${owner}/${repo}/contents/${p.sourcePath}/skills?ref=${encodeURIComponent(r)}`;
+          const res = await doFetch(url, { headers });
+          if (!res.ok) {
+            const hint = res.status === 403 ? ' (rate limit? set a token)' : '';
+            throw new Error(
+              `list skills(${p.plugin}) ${res.status} ${res.statusText}${hint}`,
+            );
+          }
+          return {
+            plugin: p.plugin,
+            version: p.version,
+            skills: skillDirsFromContents(await res.json()),
+          };
+        }),
+      );
+    },
+    async fetchSkillMd(plugin: string, skill: string) {
+      await loadManifest();
+      const r = await resolveRef();
+      const sp = sourcePathOf(plugin);
+      const url = `${RAW_BASE}/${owner}/${repo}/${r}/${sp}/skills/${skill}/SKILL.md`;
+      const res = await doFetch(url, { headers });
+      if (!res.ok) {
+        throw new Error(
+          `fetchSkillMd(${plugin}/${skill}) ${res.status} ${res.statusText}`,
+        );
+      }
+      return res.text();
+    },
+  };
+}

--- a/packages/llm-agent-libs/src/skills/plugin-host/github-transport.ts
+++ b/packages/llm-agent-libs/src/skills/plugin-host/github-transport.ts
@@ -1,0 +1,55 @@
+import type { IMarketplaceTransport } from './http-marketplace-source.js';
+
+/** Parse `owner`/`repo` from a GitHub URL or bare `owner/repo`. */
+export function parseGitHubRepo(url: string): { owner: string; repo: string } {
+  const cleaned = url
+    .trim()
+    .replace(/\.git$/, '')
+    .replace(/\/+$/, '');
+  const m = cleaned.match(
+    /^(?:https?:\/\/)?(?:github\.com\/)?([^/\s]+)\/([^/\s]+)$/,
+  );
+  if (!m) {
+    throw new Error(`parseGitHubRepo: cannot parse GitHub repo from '${url}'`);
+  }
+  return { owner: m[1], repo: m[2] };
+}
+
+/** Map a parsed `.claude-plugin/marketplace.json` to plugin coordinates. */
+export function parseMarketplace(
+  json: unknown,
+): Array<{ plugin: string; version: string; sourcePath: string }> {
+  const plugins = (json as { plugins?: unknown } | null)?.plugins;
+  if (!Array.isArray(plugins)) {
+    throw new Error(
+      'parseMarketplace: marketplace.json has no plugins[] array',
+    );
+  }
+  return plugins.map((p) => {
+    const o = p as { name?: unknown; version?: unknown; source?: unknown };
+    if (typeof o.name !== 'string' || o.name.length === 0) {
+      throw new Error(
+        'parseMarketplace: a plugin entry is missing a string name',
+      );
+    }
+    const source =
+      typeof o.source === 'string' ? o.source : `./plugins/${o.name}`;
+    return {
+      plugin: o.name,
+      version: typeof o.version === 'string' ? o.version : '0.0.0',
+      sourcePath: source.replace(/^\.\//, '').replace(/\/+$/, ''),
+    };
+  });
+}
+
+/** Extract subdirectory names from a GitHub Contents-API directory response. */
+export function skillDirsFromContents(json: unknown): string[] {
+  if (!Array.isArray(json)) {
+    throw new Error(
+      'skillDirsFromContents: expected a Contents-API directory array',
+    );
+  }
+  return (json as Array<{ name?: unknown; type?: unknown }>)
+    .filter((e) => e.type === 'dir' && typeof e.name === 'string')
+    .map((e) => e.name as string);
+}

--- a/packages/llm-agent-libs/src/skills/plugin-host/index.ts
+++ b/packages/llm-agent-libs/src/skills/plugin-host/index.ts
@@ -7,6 +7,11 @@ export {
   makeCompatibleSkillsRag,
 } from './compatible-skills-rag.js';
 export {
+  type GitHubTransportOptions,
+  makeGitHubTransport,
+  parseGitHubRepo,
+} from './github-transport.js';
+export {
   type HttpMarketplaceSourceOptions,
   type HttpTransportOptions,
   type IMarketplaceTransport,

--- a/packages/llm-agent-server-libs/src/smart-agent/skill-plugins-config.test.ts
+++ b/packages/llm-agent-server-libs/src/smart-agent/skill-plugins-config.test.ts
@@ -573,3 +573,91 @@ test('controllerSkillGroup valid string parses through', () => {
   );
   assert.equal(cfg.controllerSkillGroup, 'abap');
 });
+
+test('a github source parses with ref + token', () => {
+  const cfg = parseSkillPluginsConfig({
+    store: { type: 'in-memory' },
+    embedder: { provider: 'sap-ai-core', model: 'text-embedding-3-small' },
+    sources: [
+      {
+        id: 'sap-skills',
+        github: 'https://github.com/secondsky/sap-skills.git',
+        ref: 'main',
+        token: 'gho_x',
+        enabled: ['sap-abap'],
+        strategy: 'single-collection',
+        strategyConfig: { collection: 'sap' },
+      },
+    ],
+  });
+  const src = cfg.sources?.[0] as {
+    github?: string;
+    ref?: string;
+    token?: string;
+  };
+  assert.equal(src.github, 'https://github.com/secondsky/sap-skills.git');
+  assert.equal(src.ref, 'main');
+  assert.equal(src.token, 'gho_x');
+});
+
+test('a fetched source with BOTH github and registry fails loud', () => {
+  assert.throws(
+    () =>
+      parseSkillPluginsConfig({
+        store: { type: 'in-memory' },
+        embedder: { provider: 'sap-ai-core', model: 'm' },
+        sources: [
+          {
+            id: 'x',
+            github: 'secondsky/sap-skills',
+            registry: 'http://localhost:4100',
+            enabled: ['sap-abap'],
+          },
+        ],
+      }),
+    /exactly one of 'registry' or 'github'/,
+  );
+});
+
+test('a fetched source with NEITHER github nor registry fails loud', () => {
+  assert.throws(
+    () =>
+      parseSkillPluginsConfig({
+        store: { type: 'in-memory' },
+        embedder: { provider: 'sap-ai-core', model: 'm' },
+        sources: [{ id: 'x', enabled: ['sap-abap'] }],
+      }),
+    /exactly one of 'registry' or 'github'/,
+  );
+});
+
+test('a fetched source rejects an empty / non-string selector', () => {
+  const base = {
+    store: { type: 'in-memory' as const },
+    embedder: { provider: 'sap-ai-core', model: 'm' },
+  };
+  assert.throws(
+    () =>
+      parseSkillPluginsConfig({
+        ...base,
+        sources: [{ id: 'x', registry: '', enabled: ['a'] }],
+      }),
+    /registry must be a non-empty string/,
+  );
+  assert.throws(
+    () =>
+      parseSkillPluginsConfig({
+        ...base,
+        sources: [{ id: 'x', github: '', enabled: ['a'] }],
+      }),
+    /github must be a non-empty string/,
+  );
+  assert.throws(
+    () =>
+      parseSkillPluginsConfig({
+        ...base,
+        sources: [{ id: 'x', registry: 123, enabled: ['a'] }],
+      }),
+    /registry must be a non-empty string/,
+  );
+});

--- a/packages/llm-agent-server-libs/src/smart-agent/skill-plugins-config.ts
+++ b/packages/llm-agent-server-libs/src/smart-agent/skill-plugins-config.ts
@@ -24,10 +24,18 @@ export type SkillPluginsCatalogConfig =
   | { type: 'postgres'; connectionString: string; table?: string };
 
 /** A FETCHED source: a marketplace/registry pulled into memory. Requires a
- *  non-empty `enabled` plugin list (omitting it is a config error, NOT "load all"). */
+ *  non-empty `enabled` plugin list AND exactly one transport selector
+ *  (`registry` for an HTTP marketplace, or `github` for a GitHub repo). */
 export interface SkillPluginsFetchedSource {
   id: string;
+  /** HTTP marketplace base URL. Mutually exclusive with `github`. */
   registry?: string;
+  /** GitHub repo URL or bare `owner/repo`. Mutually exclusive with `registry`. */
+  github?: string;
+  /** Branch/tag/sha for a `github` source; default = repo `default_branch`. */
+  ref?: string;
+  /** Optional auth token for a `github` source (env-expanded upstream). */
+  token?: string;
   enabled?: readonly string[];
   /** Acquisition/materialisation strategy name (validated via the registry). */
   strategy?: string;
@@ -199,8 +207,36 @@ function parseSource(raw: unknown): SkillPluginsSource {
   const out: SkillPluginsFetchedSource = {
     id,
     enabled: enabled as readonly string[],
-    ...(typeof raw.registry === 'string' ? { registry: raw.registry } : {}),
   };
+  if (raw.registry !== undefined) {
+    if (typeof raw.registry !== 'string' || raw.registry.length === 0) {
+      fail(`source '${id}': registry must be a non-empty string`);
+    }
+    out.registry = raw.registry;
+  }
+  if (raw.github !== undefined) {
+    if (typeof raw.github !== 'string' || raw.github.length === 0) {
+      fail(`source '${id}': github must be a non-empty string`);
+    }
+    out.github = raw.github;
+  }
+  if (raw.ref !== undefined) {
+    if (typeof raw.ref !== 'string') {
+      fail(`source '${id}': ref must be a string`);
+    }
+    out.ref = raw.ref;
+  }
+  if (raw.token !== undefined) {
+    if (typeof raw.token !== 'string') {
+      fail(`source '${id}': token must be a string`);
+    }
+    out.token = raw.token;
+  }
+  if ((out.registry === undefined) === (out.github === undefined)) {
+    fail(
+      `source '${id}': a fetched source needs exactly one of 'registry' or 'github'`,
+    );
+  }
   if (raw.strategy !== undefined) {
     if (typeof raw.strategy !== 'string') {
       fail(`source '${id}': strategy must be a string`);

--- a/packages/llm-agent-server-libs/src/smart-agent/skill-plugins-host-factory.test.ts
+++ b/packages/llm-agent-server-libs/src/smart-agent/skill-plugins-host-factory.test.ts
@@ -7,13 +7,18 @@ import {
   type SkillGroupInfo,
   SkillsIncompatibleError,
 } from '@mcp-abap-adt/llm-agent';
-import type { IPgPool } from '@mcp-abap-adt/llm-agent-libs';
+import type {
+  GitHubTransportOptions,
+  IPgPool,
+} from '@mcp-abap-adt/llm-agent-libs';
 import type { SkillPluginsConfig } from './skill-plugins-config.js';
 import { parseSkillPluginsConfig } from './skill-plugins-config.js';
 import {
   buildSkillHostFromConfig,
+  buildSources,
   type IClosablePool,
   initSkillHost,
+  type TransportFactories,
   validateServedGroups,
 } from './skill-plugins-host-factory.js';
 
@@ -528,4 +533,75 @@ test('initSkillHost: no controllerSkillGroup → no eager probe', async () => {
   const out = await initSkillHost(async () => host, recallOnlyCfg(), pools);
   assert.equal(out, host, 'host returned');
   assert.equal(probed, false, 'no controllerSkillGroup → no eager probe');
+});
+
+// Task 5 — buildSources transport wiring (DI seam).
+
+const STUB_TRANSPORT = {
+  listPlugins: async () => [],
+  fetchSkillMd: async () => '',
+};
+
+test('buildSources builds a github source, threading repo/ref/token/enabled', () => {
+  let captured: GitHubTransportOptions | undefined;
+  const factories: TransportFactories = {
+    github: (opts) => {
+      captured = opts;
+      return STUB_TRANSPORT;
+    },
+    http: () => {
+      throw new Error('should not build an http transport for a github source');
+    },
+  };
+  const sources = buildSources(
+    {
+      chunk: { maxChars: 1000 },
+      sources: [
+        {
+          id: 'sap-skills',
+          github: 'https://github.com/secondsky/sap-skills.git',
+          ref: 'main',
+          token: 'gho_x',
+          enabled: ['sap-abap'],
+          strategy: 'single-collection',
+          strategyConfig: { collection: 'sap' },
+        },
+      ],
+    } as unknown as SkillPluginsConfig,
+    factories,
+  );
+  assert.equal(sources.length, 1);
+  assert.equal(sources[0].id, 'sap-skills');
+  // parseGitHubRepo ran (URL → owner/repo) AND ref/token/enabled were threaded.
+  assert.deepEqual(captured, {
+    owner: 'secondsky',
+    repo: 'sap-skills',
+    ref: 'main',
+    token: 'gho_x',
+    enabled: ['sap-abap'],
+  });
+});
+
+test('buildSources builds an http source from registry', () => {
+  let registry: string | undefined;
+  const factories: TransportFactories = {
+    github: () => {
+      throw new Error(
+        'should not build a github transport for a registry source',
+      );
+    },
+    http: (opts) => {
+      registry = opts.registry;
+      return STUB_TRANSPORT;
+    },
+  };
+  const sources = buildSources(
+    {
+      chunk: { maxChars: 1000 },
+      sources: [{ id: 'r', registry: 'http://h', enabled: ['*'] }],
+    } as unknown as SkillPluginsConfig,
+    factories,
+  );
+  assert.equal(sources.length, 1);
+  assert.equal(registry, 'http://h');
 });

--- a/packages/llm-agent-server-libs/src/smart-agent/skill-plugins-host-factory.ts
+++ b/packages/llm-agent-server-libs/src/smart-agent/skill-plugins-host-factory.ts
@@ -33,8 +33,12 @@ import type {
   SkillRecord,
 } from '@mcp-abap-adt/llm-agent';
 import {
+  type GitHubTransportOptions,
+  type HttpTransportOptions,
   type ICatalogStore,
+  type IMarketplaceTransport,
   type IPgPool,
+  makeGitHubTransport,
   makeHttpTransport,
   makeInMemoryStoreProvider,
   makeInProcessCatalogStore,
@@ -45,6 +49,7 @@ import {
   makeQdrantReader,
   makeQdrantStoreProvider,
   makeSkillPluginHost,
+  parseGitHubRepo,
   pointId,
   resolveSkillSourceStrategy,
 } from '@mcp-abap-adt/llm-agent-libs';
@@ -149,9 +154,23 @@ function makeRecordsSource(src: SkillPluginsRecordsSource): ISkillSource {
   return { acquire: async () => result };
 }
 
+/** Transport factories for {@link buildSources}. A DI seam: production uses the
+ *  defaults; unit tests inject capturing stubs to assert the wiring without
+ *  touching the network. */
+export interface TransportFactories {
+  github: (opts: GitHubTransportOptions) => IMarketplaceTransport;
+  http: (opts: HttpTransportOptions) => IMarketplaceTransport;
+}
+
+const defaultTransports: TransportFactories = {
+  github: makeGitHubTransport,
+  http: makeHttpTransport,
+};
+
 /** Map every config source to a `{ id, source }` ingest entry. */
-function buildSources(
+export function buildSources(
   cfg: SkillPluginsConfig,
+  transports: TransportFactories = defaultTransports,
 ): ReadonlyArray<{ id: string; source: ISkillSource }> {
   const out: { id: string; source: ISkillSource }[] = [];
   for (const src of cfg.sources ?? []) {
@@ -159,16 +178,25 @@ function buildSources(
       out.push({ id: src.id, source: makeRecordsSource(src) });
       continue;
     }
-    // Fetched (registry) source → resolve the named strategy.
+    // Fetched source → resolve the named strategy + pick a transport by selector.
     const strategy = resolveSkillSourceStrategy(
       src.strategy ?? 'one-group-per-plugin',
     );
+    const transport =
+      src.github !== undefined
+        ? transports.github({
+            ...parseGitHubRepo(src.github),
+            ...(src.ref !== undefined ? { ref: src.ref } : {}),
+            ...(src.token !== undefined ? { token: src.token } : {}),
+            enabled: src.enabled ?? [],
+          })
+        : transports.http({ registry: src.registry ?? '' });
     out.push({
       id: src.id,
       source: strategy({
         source: src.id,
         enabled: src.enabled ?? [],
-        transport: makeHttpTransport({ registry: src.registry ?? '' }),
+        transport,
         chunk: cfg.chunk,
         ...(src.strategyConfig !== undefined
           ? { strategyConfig: src.strategyConfig }


### PR DESCRIPTION
## Summary

The skill plugin-host can now **self-fetch** skills from a GitHub Claude-plugin repo (e.g. `https://github.com/secondsky/sap-skills.git`) — the consumer writes the repo URL in config and the host downloads the skills itself. **No `git clone`, zero filesystem** (the FS may be absent on serverless/edge): everything is fetched over HTTPS into memory.

- New `makeGitHubTransport` behind the existing `IMarketplaceTransport` seam — **zero changes** to strategies, adapter, host, or store. Reads `.claude-plugin/marketplace.json` + each `SKILL.md` from `raw.githubusercontent.com`; enumerates each plugin's `skills/` subdirs via the GitHub Contents API (the only HTTP way to list a folder). Enumerates **only the enabled plugins** (rate-limit thrift). Optional `token` lifts the rate limit + enables private repos.
- Config grows a `github`/`ref`/`token` source variant, **mutually exclusive with `registry`** (fail-loud, both selectors validated as non-empty strings). `buildSources` picks the transport via a `TransportFactories` DI seam.
- Docs example: `docs/examples/skill-plugins-github.yaml`.

Closes the gap that previously forced a manual marketplace shim over a hand-clone.

## Review trail

- Spec: `docs/superpowers/specs/2026-06-22-github-skill-source-strategy-design.md`
- Plan: `docs/superpowers/plans/2026-06-22-github-skill-source-strategy.md`
- External review (clean) + final code review (APPROVED, no Critical/Important).

## Test Plan

- [x] Unit: pure helpers (URL/manifest/contents parsing), `makeGitHubTransport` via injected fake `fetch` (default-branch resolve, enabled-only enumeration, ref short-circuit, token header on every call, 403 hint), config XOR/non-empty, real `buildSources` wiring (repo/ref/token/enabled threading).
- [x] Full suite green (0 failures), lint:check exit 0, full `tsc -b` build clean.
- [x] **Live self-fetch verified** against the real `secondsky/sap-skills` repo — fetched `sap-abap` + `sap-btp-developer-guide` SKILL.md (15.7 KB + 17.5 KB), in-memory, no shim.

## Follow-up (non-blocking)

A typo'd `enabled` plugin is silently dropped — pre-existing fail-quiet shared with the HTTP transport; worth a fail-loud pass across both transports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)