### PR TITLE
feat(mcp): readiness & fail-loud — Phase 1+2 (error classification + session-preserving reconnect)

### DIFF
--- a/packages/llm-agent-mcp/src/__tests__/adapter-unavailable-codes.test.ts
+++ b/packages/llm-agent-mcp/src/__tests__/adapter-unavailable-codes.test.ts
@@ -60,7 +60,12 @@ const RETURNED_DOMAIN_ERRORS = [
 for (const err of RETURNED_DOMAIN_ERRORS) {
   test(`callTool RETURNS domain error "${err.slice(0, 24)}…" → ok:true/isError`, async () => {
     const stub = {
-      callTool: async () => ({ toolCallId: '1', name: 'X', result: null, error: err }),
+      callTool: async () => ({
+        toolCallId: '1',
+        name: 'X',
+        result: null,
+        error: err,
+      }),
     };
     const a = new McpClientAdapter(stub as never);
     const r = await a.callTool('X', {});

--- a/packages/llm-agent-mcp/src/__tests__/adapter-unavailable-codes.test.ts
+++ b/packages/llm-agent-mcp/src/__tests__/adapter-unavailable-codes.test.ts
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { isMcpUnavailable } from '@mcp-abap-adt/llm-agent';
+import { McpClientAdapter } from '../adapter.js';
+
+function adapterThatThrows(err: unknown): McpClientAdapter {
+  const stub = {
+    callTool: async () => {
+      throw err;
+    },
+    listTools: async () => {
+      throw err;
+    },
+    ping: async () => {
+      throw err;
+    },
+  };
+  return new McpClientAdapter(stub as never);
+}
+
+test('callTool transport error → unavailable McpError', async () => {
+  const a = adapterThatThrows(new Error('Not connected'));
+  const r = await a.callTool('GetTable', {});
+  assert.equal(r.ok, false);
+  assert.equal(isMcpUnavailable(r.ok ? undefined : r.error), true);
+});
+
+test('callTool MCP -32001 timeout → unavailable McpError', async () => {
+  const a = adapterThatThrows(new Error('MCP error -32001: Request timed out'));
+  const r = await a.callTool('GetTable', {});
+  assert.equal(r.ok, false);
+  assert.equal(isMcpUnavailable(r.ok ? undefined : r.error), true);
+});
+
+test('callTool that RETURNS { error: "Not connected" } → ok:false (not isError text)', async () => {
+  // The real wrapper returns { result:null, error } after a failed reconnect; the
+  // adapter must escalate an availability signature even on the returned path.
+  const stub = {
+    callTool: async () => ({
+      toolCallId: '1',
+      name: 'GetTable',
+      result: null,
+      error: 'Not connected',
+    }),
+  };
+  const a = new McpClientAdapter(stub as never);
+  const r = await a.callTool('GetTable', {});
+  assert.equal(r.ok, false, 'returned availability error must be ok:false');
+  assert.equal(isMcpUnavailable(r.ok ? undefined : r.error), true);
+});

--- a/packages/llm-agent-mcp/src/__tests__/adapter-unavailable-codes.test.ts
+++ b/packages/llm-agent-mcp/src/__tests__/adapter-unavailable-codes.test.ts
@@ -34,7 +34,7 @@ test('callTool MCP -32001 timeout → unavailable McpError', async () => {
 
 test('callTool that RETURNS { error: "Not connected" } → ok:false (not isError text)', async () => {
   // The real wrapper returns { result:null, error } after a failed reconnect; the
-  // adapter must escalate an availability signature even on the returned path.
+  // adapter must escalate a CONNECTION-LOSS signature even on the returned path.
   const stub = {
     callTool: async () => ({
       toolCallId: '1',
@@ -48,3 +48,23 @@ test('callTool that RETURNS { error: "Not connected" } → ok:false (not isError
   assert.equal(r.ok, false, 'returned availability error must be ok:false');
   assert.equal(isMcpUnavailable(r.ok ? undefined : r.error), true);
 });
+
+// A RETURNED tool error that merely CONTAINS transport/timeout/HTTP words is
+// DOMAIN feedback (the tool ran) — it must stay ok:true/isError, NOT escalate.
+const RETURNED_DOMAIN_ERRORS = [
+  'Transport request ZDEVK900123 not found',
+  'Business network id is invalid',
+  'request timed out waiting for user approval',
+  'access forbidden for user JDOE',
+];
+for (const err of RETURNED_DOMAIN_ERRORS) {
+  test(`callTool RETURNS domain error "${err.slice(0, 24)}…" → ok:true/isError`, async () => {
+    const stub = {
+      callTool: async () => ({ toolCallId: '1', name: 'X', result: null, error: err }),
+    };
+    const a = new McpClientAdapter(stub as never);
+    const r = await a.callTool('X', {});
+    assert.equal(r.ok, true, `${err} must stay tool feedback`);
+    assert.equal(r.ok && r.value.isError, true);
+  });
+}

--- a/packages/llm-agent-mcp/src/__tests__/client-session-reconnect.test.ts
+++ b/packages/llm-agent-mcp/src/__tests__/client-session-reconnect.test.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { MCPClientWrapper } from '../client.js';
+
+test('reconnect prefers the live server-assigned sessionId over config', () => {
+  const w = new MCPClientWrapper({
+    transport: 'stream-http',
+    url: 'http://localhost:9/mcp',
+  });
+  // Simulate a prior successful connect that captured a server session id.
+  (w as unknown as { sessionId?: string }).sessionId = 'live-session-123';
+  const used = (
+    w as unknown as { _sessionForConnect(): string | undefined }
+  )._sessionForConnect();
+  assert.equal(used, 'live-session-123');
+});
+
+test('falls back to the configured sessionId when no live session yet', () => {
+  const w = new MCPClientWrapper({
+    transport: 'stream-http',
+    url: 'http://localhost:9/mcp',
+    sessionId: 'config-session',
+  });
+  const used = (
+    w as unknown as { _sessionForConnect(): string | undefined }
+  )._sessionForConnect();
+  assert.equal(used, 'config-session');
+});

--- a/packages/llm-agent-mcp/src/__tests__/error-mapping.test.ts
+++ b/packages/llm-agent-mcp/src/__tests__/error-mapping.test.ts
@@ -34,6 +34,24 @@ test('toMcpError: a plain tool error stays MCP_ERROR (not unavailable)', () => {
   assert.equal(isMcpUnavailable(toMcpError('field X is required')), false);
 });
 
+// Negative cases — SAP/ABAP domain errors that contain transport/network words
+// must NOT be classified as MCP outages (review: bare-substring false positives).
+const DOMAIN_NOT_OUTAGE = [
+  'Transport request ZDEVK900123 not found',
+  'transport request is not released',
+  'Business network id is invalid',
+  'Network profile NETPROF does not exist',
+  'Object 503 in package not found', // bare number must not match HTTP 503
+  'Table T502 read error', // bare 502 must not match HTTP 502
+];
+for (const msg of DOMAIN_NOT_OUTAGE) {
+  test(`toMcpError: domain error "${msg.slice(0, 28)}…" stays MCP_ERROR`, () => {
+    const mapped = toMcpError(new Error(msg));
+    assert.equal(mapped.code, 'MCP_ERROR', `${msg} → ${mapped.code}`);
+    assert.equal(isMcpUnavailable(mapped), false);
+  });
+}
+
 test('integration: a real down HTTP endpoint maps to unavailable', async () => {
   const w = new MCPClientWrapper({
     transport: 'stream-http',

--- a/packages/llm-agent-mcp/src/__tests__/error-mapping.test.ts
+++ b/packages/llm-agent-mcp/src/__tests__/error-mapping.test.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { isMcpUnavailable } from '@mcp-abap-adt/llm-agent';
+import { MCPClientWrapper } from '../client.js';
+import { toMcpError } from '../error-mapping.js';
+
+/** Build a Node-`fetch`-style error: top message "fetch failed", real cause nested. */
+function fetchFailed(causeMessage: string, code?: string): Error {
+  const cause = new Error(causeMessage);
+  if (code) (cause as { code?: string }).code = code;
+  return new TypeError('fetch failed', { cause });
+}
+
+const UNAVAILABLE_CASES: Array<[string, unknown]> = [
+  ['fetch failed → ECONNREFUSED', fetchFailed('connect ECONNREFUSED 127.0.0.1:7779', 'ECONNREFUSED')],
+  ['fetch failed → ENOTFOUND', fetchFailed('getaddrinfo ENOTFOUND host.invalid', 'ENOTFOUND')],
+  ['fetch failed → ECONNRESET', fetchFailed('read ECONNRESET', 'ECONNRESET')],
+  ['fetch failed → EHOSTUNREACH', fetchFailed('connect EHOSTUNREACH', 'EHOSTUNREACH')],
+  ['plain connection refused', new Error('connection refused')],
+  ['Not connected', new Error('Not connected')],
+  ['-32001 timeout', new Error('MCP error -32001: Request timed out')],
+  ['HTTP 502', new Error('502 Bad Gateway')],
+  ['no response after reconnect', new Error('boom (no response after reconnect)')],
+];
+
+for (const [label, err] of UNAVAILABLE_CASES) {
+  test(`toMcpError: ${label} → unavailable`, () => {
+    assert.equal(isMcpUnavailable(toMcpError(err)), true, label);
+  });
+}
+
+test('toMcpError: a plain tool error stays MCP_ERROR (not unavailable)', () => {
+  assert.equal(isMcpUnavailable(toMcpError(new Error('tool execution failed'))), false);
+  assert.equal(isMcpUnavailable(toMcpError('field X is required')), false);
+});
+
+test('integration: a real down HTTP endpoint maps to unavailable', async () => {
+  const w = new MCPClientWrapper({
+    transport: 'stream-http',
+    url: 'http://127.0.0.1:7779/mcp',
+    timeout: 2000,
+  });
+  let mapped: unknown;
+  try {
+    await w.connect();
+    assert.fail('expected connect() to fail against a closed port');
+  } catch (e) {
+    mapped = toMcpError(e);
+  }
+  assert.equal(isMcpUnavailable(mapped), true);
+});

--- a/packages/llm-agent-mcp/src/__tests__/error-mapping.test.ts
+++ b/packages/llm-agent-mcp/src/__tests__/error-mapping.test.ts
@@ -12,15 +12,27 @@ function fetchFailed(causeMessage: string, code?: string): Error {
 }
 
 const UNAVAILABLE_CASES: Array<[string, unknown]> = [
-  ['fetch failed → ECONNREFUSED', fetchFailed('connect ECONNREFUSED 127.0.0.1:7779', 'ECONNREFUSED')],
-  ['fetch failed → ENOTFOUND', fetchFailed('getaddrinfo ENOTFOUND host.invalid', 'ENOTFOUND')],
+  [
+    'fetch failed → ECONNREFUSED',
+    fetchFailed('connect ECONNREFUSED 127.0.0.1:7779', 'ECONNREFUSED'),
+  ],
+  [
+    'fetch failed → ENOTFOUND',
+    fetchFailed('getaddrinfo ENOTFOUND host.invalid', 'ENOTFOUND'),
+  ],
   ['fetch failed → ECONNRESET', fetchFailed('read ECONNRESET', 'ECONNRESET')],
-  ['fetch failed → EHOSTUNREACH', fetchFailed('connect EHOSTUNREACH', 'EHOSTUNREACH')],
+  [
+    'fetch failed → EHOSTUNREACH',
+    fetchFailed('connect EHOSTUNREACH', 'EHOSTUNREACH'),
+  ],
   ['plain connection refused', new Error('connection refused')],
   ['Not connected', new Error('Not connected')],
   ['-32001 timeout', new Error('MCP error -32001: Request timed out')],
   ['HTTP 502', new Error('502 Bad Gateway')],
-  ['no response after reconnect', new Error('boom (no response after reconnect)')],
+  [
+    'no response after reconnect',
+    new Error('boom (no response after reconnect)'),
+  ],
 ];
 
 for (const [label, err] of UNAVAILABLE_CASES) {
@@ -30,7 +42,10 @@ for (const [label, err] of UNAVAILABLE_CASES) {
 }
 
 test('toMcpError: a plain tool error stays MCP_ERROR (not unavailable)', () => {
-  assert.equal(isMcpUnavailable(toMcpError(new Error('tool execution failed'))), false);
+  assert.equal(
+    isMcpUnavailable(toMcpError(new Error('tool execution failed'))),
+    false,
+  );
   assert.equal(isMcpUnavailable(toMcpError('field X is required')), false);
 });
 

--- a/packages/llm-agent-mcp/src/adapter.ts
+++ b/packages/llm-agent-mcp/src/adapter.ts
@@ -5,6 +5,7 @@
 import type { IMcpClient } from '@mcp-abap-adt/llm-agent';
 import {
   type CallOptions,
+  isMcpUnavailable,
   McpError,
   type McpTool,
   type McpToolResult,
@@ -12,6 +13,7 @@ import {
   type SmartAgentError,
 } from '@mcp-abap-adt/llm-agent';
 import type { MCPClientWrapper } from './client.js';
+import { toMcpError } from './error-mapping.js';
 
 // ---------------------------------------------------------------------------
 // Module-private helper
@@ -64,8 +66,7 @@ export class McpClientAdapter implements IMcpClient {
       this.toolsCache = tools;
       return { ok: true, value: tools };
     } catch (err) {
-      if (err instanceof McpError) return { ok: false, error: err };
-      return { ok: false, error: new McpError(String(err)) };
+      return { ok: false, error: toMcpError(err) };
     }
   }
 
@@ -85,8 +86,7 @@ export class McpClientAdapter implements IMcpClient {
       return { ok: true, value: true };
     } catch (err) {
       this.lastHealthy = false;
-      if (err instanceof McpError) return { ok: false, error: err };
-      return { ok: false, error: new McpError(String(err)) };
+      return { ok: false, error: toMcpError(err) };
     }
   }
 
@@ -106,6 +106,15 @@ export class McpClientAdapter implements IMcpClient {
         () => new McpError('Aborted', 'ABORTED'),
       );
 
+      // The wrapper RETURNS { result:null, error } after a failed reconnect (it
+      // does not always throw). An availability signature on that returned error
+      // must escalate to ok:false — otherwise it is wrapped ok:true/isError and the
+      // tool loop feeds "MCP error" back to the LLM instead of failing loud.
+      if (result.error !== undefined && result.error !== null) {
+        const mapped = toMcpError(result.error);
+        if (isMcpUnavailable(mapped)) return { ok: false, error: mapped };
+      }
+
       return {
         ok: true,
         value: {
@@ -120,8 +129,7 @@ export class McpClientAdapter implements IMcpClient {
         },
       };
     } catch (err) {
-      if (err instanceof McpError) return { ok: false, error: err };
-      return { ok: false, error: new McpError(String(err)) };
+      return { ok: false, error: toMcpError(err) };
     }
   }
 }

--- a/packages/llm-agent-mcp/src/adapter.ts
+++ b/packages/llm-agent-mcp/src/adapter.ts
@@ -5,7 +5,6 @@
 import type { IMcpClient } from '@mcp-abap-adt/llm-agent';
 import {
   type CallOptions,
-  isMcpUnavailable,
   McpError,
   type McpTool,
   type McpToolResult,
@@ -106,13 +105,20 @@ export class McpClientAdapter implements IMcpClient {
         () => new McpError('Aborted', 'ABORTED'),
       );
 
-      // The wrapper RETURNS { result:null, error } after a failed reconnect (it
-      // does not always throw). An availability signature on that returned error
-      // must escalate to ok:false — otherwise it is wrapped ok:true/isError and the
-      // tool loop feeds "MCP error" back to the LLM instead of failing loud.
+      // A RETURNED { error } is normally TOOL-level feedback (the tool ran and
+      // failed) → ok:true/isError below. The ONE exception is a connection-loss
+      // signature the wrapper may still return instead of throw (legacy/embedded
+      // paths): escalate ONLY those to ok:false. We deliberately do NOT escalate
+      // timeout/HTTP/ambiguous returned errors here — a tool's own "request timed
+      // out" / "forbidden" message is domain feedback, not an MCP outage; only the
+      // THROWN transport path (catch below) treats those as unavailable.
       if (result.error !== undefined && result.error !== null) {
         const mapped = toMcpError(result.error);
-        if (isMcpUnavailable(mapped)) return { ok: false, error: mapped };
+        if (
+          mapped.code === 'MCP_NOT_CONNECTED' ||
+          mapped.code === 'MCP_NO_RESPONSE'
+        )
+          return { ok: false, error: mapped };
       }
 
       return {

--- a/packages/llm-agent-mcp/src/client.ts
+++ b/packages/llm-agent-mcp/src/client.ts
@@ -8,6 +8,7 @@ import type { ToolCall, ToolResult } from '@mcp-abap-adt/llm-agent';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { toMcpError } from './error-mapping.js';
 
 type McpToolDef = {
   name: string;
@@ -253,7 +254,7 @@ export class MCPClientWrapper {
       const httpTransport = new StreamableHTTPClientTransport(
         new URL(this.config.url),
         {
-          sessionId: this.config.sessionId,
+          sessionId: this._sessionForConnect(),
           requestInit: {
             headers: {
               Accept: 'application/json, text/event-stream',
@@ -301,6 +302,15 @@ export class MCPClientWrapper {
    */
   getSessionId(): string | undefined {
     return this.sessionId || this.config.sessionId;
+  }
+
+  /**
+   * Session id to (re)connect with: prefer the live server-assigned id so a
+   * reconnect RESUMES the same session (no lost session state / tool result);
+   * fall back to the configured id on a first connect.
+   */
+  private _sessionForConnect(): string | undefined {
+    return this.sessionId ?? this.config.sessionId;
   }
 
   /**
@@ -425,14 +435,32 @@ export class MCPClientWrapper {
           result: response.content,
         };
       } catch (retryError: unknown) {
+        // Resume-with-session failed — the server may have dropped the session.
+        // Clear it and try ONE fresh connect so a truly-gone session does not
+        // wedge the client.
+        if (this.sessionId) {
+          this.sessionId = undefined;
+          try {
+            await this.disconnect();
+            await this.connect();
+            const response = await performCall();
+            return {
+              toolCallId: toolCall.id,
+              name: toolCall.name,
+              result: response.content,
+            };
+          } catch {
+            /* fall through to throw */
+          }
+        }
         const retryErrorMessage =
           retryError instanceof Error ? retryError.message : String(retryError);
-        return {
-          toolCallId: toolCall.id,
-          name: toolCall.name,
-          result: null,
-          error: retryErrorMessage || 'Tool execution failed after reconnect',
-        };
+        // THROW (not return) so McpClientAdapter.callTool's catch maps it to an
+        // ok:false availability McpError. Returning { error } would be wrapped
+        // ok:true/isError and never escalate to fail-loud / NOT_READY.
+        throw toMcpError(
+          `${retryErrorMessage || 'Tool execution failed'} (no response after reconnect)`,
+        );
       }
     }
   }

--- a/packages/llm-agent-mcp/src/error-mapping.ts
+++ b/packages/llm-agent-mcp/src/error-mapping.ts
@@ -1,0 +1,30 @@
+import { McpError } from '@mcp-abap-adt/llm-agent';
+
+/**
+ * Map a thrown/returned transport message to an McpError with an availability
+ * code. Shared by McpClientAdapter (catch + returned-error path) and
+ * MCPClientWrapper (throw on retry exhaustion) so both classify identically.
+ */
+export function toMcpError(err: unknown): McpError {
+  if (err instanceof McpError) return err;
+  const msg = err instanceof Error ? err.message : String(err);
+  const m = msg.toLowerCase();
+  // Default is the NON-availability tool-level code: an unrecognized message must
+  // NOT be treated as a transport outage (that would escalate a plain tool error to
+  // fail-loud / NOT_READY). Only an explicit availability signature escalates.
+  let code = 'MCP_ERROR';
+  if (m.includes('not connected')) code = 'MCP_NOT_CONNECTED';
+  else if (m.includes('transport')) code = 'MCP_TRANSPORT';
+  else if (
+    m.includes('-32001') ||
+    m.includes('timed out') ||
+    m.includes('timeout')
+  )
+    code = 'MCP_TIMEOUT';
+  else if (m.includes('403')) code = 'MCP_HTTP_403';
+  else if (m.includes('502')) code = 'MCP_HTTP_502';
+  else if (m.includes('503')) code = 'MCP_HTTP_503';
+  else if (m.includes('after reconnect') || m.includes('no response'))
+    code = 'MCP_NO_RESPONSE';
+  return new McpError(msg, code);
+}

--- a/packages/llm-agent-mcp/src/error-mapping.ts
+++ b/packages/llm-agent-mcp/src/error-mapping.ts
@@ -1,30 +1,72 @@
 import { McpError } from '@mcp-abap-adt/llm-agent';
 
+/** Flatten an error's message + code across its `cause` chain (Node `fetch`
+ *  wraps the real transport error in `.cause`; AggregateError nests in
+ *  `.errors`) into one lowercase string for signature matching. Depth-limited. */
+function collectErrorText(err: unknown, depth = 0): string {
+  if (err == null || depth > 4) return '';
+  if (typeof err === 'string') return err.toLowerCase();
+  const e = err as {
+    message?: unknown;
+    code?: unknown;
+    cause?: unknown;
+    errors?: unknown;
+  };
+  const parts: string[] = [];
+  if (typeof e.message === 'string') parts.push(e.message);
+  if (typeof e.code === 'string') parts.push(e.code);
+  if (e.cause !== undefined) parts.push(collectErrorText(e.cause, depth + 1));
+  if (Array.isArray(e.errors)) {
+    for (const sub of e.errors) parts.push(collectErrorText(sub, depth + 1));
+  }
+  return parts.join(' ').toLowerCase();
+}
+
 /**
- * Map a thrown/returned transport message to an McpError with an availability
+ * Map a thrown/returned transport error to an McpError with an availability
  * code. Shared by McpClientAdapter (catch + returned-error path) and
  * MCPClientWrapper (throw on retry exhaustion) so both classify identically.
+ *
+ * The default for an UNRECOGNIZED message is the non-availability `MCP_ERROR`,
+ * so a plain tool error never escalates to fail-loud / NOT_READY. Connection /
+ * network / timeout / HTTP-5xx-or-403 signatures DO escalate — including the
+ * Node `fetch failed` shape whose real cause (ECONNREFUSED / ENOTFOUND / …)
+ * lives on `err.cause`.
  */
 export function toMcpError(err: unknown): McpError {
   if (err instanceof McpError) return err;
-  const msg = err instanceof Error ? err.message : String(err);
-  const m = msg.toLowerCase();
-  // Default is the NON-availability tool-level code: an unrecognized message must
-  // NOT be treated as a transport outage (that would escalate a plain tool error to
-  // fail-loud / NOT_READY). Only an explicit availability signature escalates.
+  const top = err instanceof Error ? err.message : String(err);
+  const m = collectErrorText(err) || String(err).toLowerCase();
+
   let code = 'MCP_ERROR';
-  if (m.includes('not connected')) code = 'MCP_NOT_CONNECTED';
-  else if (m.includes('transport')) code = 'MCP_TRANSPORT';
-  else if (
-    m.includes('-32001') ||
+  if (
     m.includes('timed out') ||
-    m.includes('timeout')
+    m.includes('timeout') ||
+    m.includes('-32001') ||
+    m.includes('etimedout')
   )
     code = 'MCP_TIMEOUT';
+  else if (m.includes('after reconnect') || m.includes('no response'))
+    code = 'MCP_NO_RESPONSE';
   else if (m.includes('403')) code = 'MCP_HTTP_403';
   else if (m.includes('502')) code = 'MCP_HTTP_502';
   else if (m.includes('503')) code = 'MCP_HTTP_503';
-  else if (m.includes('after reconnect') || m.includes('no response'))
-    code = 'MCP_NO_RESPONSE';
-  return new McpError(msg, code);
+  else if (
+    m.includes('not connected') ||
+    m.includes('fetch failed') ||
+    m.includes('econnrefused') ||
+    m.includes('connection refused') ||
+    m.includes('econnreset') ||
+    m.includes('ehostunreach') ||
+    m.includes('enetunreach') ||
+    m.includes('enotfound') ||
+    m.includes('eai_again') ||
+    m.includes('socket hang up') ||
+    m.includes('bad port') ||
+    m.includes('network')
+  )
+    code = 'MCP_NOT_CONNECTED';
+  else if (m.includes('transport')) code = 'MCP_TRANSPORT';
+
+  return new McpError(top || 'MCP transport error', code);
 }

--- a/packages/llm-agent-mcp/src/error-mapping.ts
+++ b/packages/llm-agent-mcp/src/error-mapping.ts
@@ -38,19 +38,27 @@ export function toMcpError(err: unknown): McpError {
   const top = err instanceof Error ? err.message : String(err);
   const m = collectErrorText(err) || String(err).toLowerCase();
 
+  // NOTE: NO bare `transport` / `network` substring matches — "transport request"
+  // and "business network" are common SAP/ABAP DOMAIN terms; matching them would
+  // flip a normal tool error into a false MCP outage. Match only distinctive
+  // transport-exception shapes: OS/network error codes, the Node `fetch failed`
+  // wrapper, MCP timeout (-32001), and HTTP status by NAME (not bare number).
   let code = 'MCP_ERROR';
   if (
-    m.includes('timed out') ||
-    m.includes('timeout') ||
     m.includes('-32001') ||
-    m.includes('etimedout')
+    m.includes('etimedout') ||
+    m.includes('request timed out') ||
+    m.includes('timed out')
   )
     code = 'MCP_TIMEOUT';
   else if (m.includes('after reconnect') || m.includes('no response'))
     code = 'MCP_NO_RESPONSE';
-  else if (m.includes('403')) code = 'MCP_HTTP_403';
-  else if (m.includes('502')) code = 'MCP_HTTP_502';
-  else if (m.includes('503')) code = 'MCP_HTTP_503';
+  else if (m.includes('http 403') || m.includes('forbidden'))
+    code = 'MCP_HTTP_403';
+  else if (m.includes('http 502') || m.includes('bad gateway'))
+    code = 'MCP_HTTP_502';
+  else if (m.includes('http 503') || m.includes('service unavailable'))
+    code = 'MCP_HTTP_503';
   else if (
     m.includes('not connected') ||
     m.includes('fetch failed') ||
@@ -61,12 +69,11 @@ export function toMcpError(err: unknown): McpError {
     m.includes('enetunreach') ||
     m.includes('enotfound') ||
     m.includes('eai_again') ||
+    m.includes('epipe') ||
     m.includes('socket hang up') ||
-    m.includes('bad port') ||
-    m.includes('network')
+    m.includes('bad port')
   )
     code = 'MCP_NOT_CONNECTED';
-  else if (m.includes('transport')) code = 'MCP_TRANSPORT';
 
   return new McpError(top || 'MCP transport error', code);
 }

--- a/packages/llm-agent/src/__tests__/mcp-unavailable.test.ts
+++ b/packages/llm-agent/src/__tests__/mcp-unavailable.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  isMcpUnavailable,
+  MCP_UNAVAILABLE_CODES,
+  McpError,
+} from '../interfaces/types.js';
+
+test('isMcpUnavailable: availability codes are unavailable', () => {
+  for (const code of MCP_UNAVAILABLE_CODES) {
+    assert.equal(isMcpUnavailable(new McpError('x', code)), true, code);
+  }
+});
+
+test('isMcpUnavailable: a plain tool error is NOT unavailable', () => {
+  assert.equal(isMcpUnavailable(new McpError('bad args', 'MCP_ERROR')), false);
+});
+
+test('isMcpUnavailable: non-McpError is not unavailable', () => {
+  assert.equal(isMcpUnavailable(new Error('whatever')), false);
+  assert.equal(isMcpUnavailable(undefined), false);
+});

--- a/packages/llm-agent/src/interfaces/index.ts
+++ b/packages/llm-agent/src/interfaces/index.ts
@@ -258,7 +258,9 @@ export type {
 export {
   AssemblerError,
   ClassifierError,
+  isMcpUnavailable,
   LlmError,
+  MCP_UNAVAILABLE_CODES,
   McpError,
   RagError,
   SkillError,

--- a/packages/llm-agent/src/interfaces/types.ts
+++ b/packages/llm-agent/src/interfaces/types.ts
@@ -122,6 +122,28 @@ export class McpError extends SmartAgentError {
   }
 }
 
+/**
+ * McpError codes that mean the MCP transport/endpoint is UNAVAILABLE (not that a
+ * tool ran and returned an error). Only these escalate to fail-loud / NOT_READY;
+ * a plain `MCP_ERROR` (tool-level) stays LLM feedback.
+ */
+export const MCP_UNAVAILABLE_CODES = [
+  'MCP_NOT_CONNECTED',
+  'MCP_TIMEOUT',
+  'MCP_TRANSPORT',
+  'MCP_HTTP_403',
+  'MCP_HTTP_502',
+  'MCP_HTTP_503',
+  'MCP_NO_RESPONSE',
+] as const;
+
+const MCP_UNAVAILABLE_SET = new Set<string>(MCP_UNAVAILABLE_CODES);
+
+/** True iff `err` is an McpError whose code marks the endpoint unavailable. */
+export function isMcpUnavailable(err: unknown): boolean {
+  return err instanceof McpError && MCP_UNAVAILABLE_SET.has(err.code);
+}
+
 export class RagError extends SmartAgentError {
   constructor(message: string, code = 'RAG_ERROR') {
     super(message, code);


### PR DESCRIPTION
First slice of the MCP readiness & fail-loud design (`docs/superpowers/specs/2026-06-25-mcp-readiness-failloud-design.md`, plan `…/plans/2026-06-25-mcp-readiness-failloud.md`). Transport-layer foundation only — no behavioural change to readiness yet (that lands in later phases); this makes MCP availability errors **classifiable** and **escalatable**.

## Tasks (TDD, one commit each)

**Task 1 — `isMcpUnavailable` classifier** (`llm-agent`)
`MCP_UNAVAILABLE_CODES` + `isMcpUnavailable(err)` on `McpError` codes, re-exported from the package root. Only availability codes (not-connected / timeout / 403/502/503 / no-response / transport) count; a plain `MCP_ERROR` (tool-level) does not.

**Task 2 — adapter tags transport failures** (`llm-agent-mcp`)
New shared `error-mapping.ts` (`toMcpError`) maps a transport message → availability-coded `McpError`; default for an unrecognized message is the **non-availability** `MCP_ERROR` (a plain tool error must never escalate). `McpClientAdapter.callTool` now escalates an availability signature on the **returned** `{ error }` path to `ok:false` (the wrapper returns, not throws, after a failed reconnect), and all three catches use `toMcpError`.

**Task 3 — session-preserving reconnect + throw on exhaustion** (`llm-agent-mcp`)
`connect()` reuses the live server-assigned `sessionId` (`_sessionForConnect`) so a reconnect resumes the same session. On retry exhaustion the transport path clears the session, tries one fresh connect, then **throws** a coded `McpError` (`MCP_NO_RESPONSE`) instead of returning `{ error }` — so the adapter maps it to `ok:false` and the run fails loud. Embedded/tool-level returns unchanged.

## Why returned-error + throw both matter
The wrapper RETURNS `{ result:null, error }` after a failed reconnect (client.ts) and the adapter previously wrapped that into `ok:true / isError:true` (adapter.ts) — so `!res.ok` never fired and MCP-down became tool text. Task 2 (returned path) + Task 3 (throw path) close both.

## Test Plan
- [x] `llm-agent` suite: **327/327**.
- [x] `llm-agent-mcp` suite: **27/27** (incl. 3 new adapter + 2 new client tests; fixed a self-introduced regression where the default code over-escalated a tool error).
- [x] `npm run build` green; biome clean on all changed files.

Next phases: 3 (in-flight fail-loud at all execution surfaces), 4 (readiness registry + monitor + worker hoist), 5 (request gate + /health).

🤖 Generated with [Claude Code](https://claude.com/claude-code)