### PR TITLE
feat(mcp): readiness & fail-loud — Phase 3 (in-flight fail-loud at every execution surface)

### DIFF
--- a/packages/llm-agent-libs/src/__tests__/agent-mcp-unavailable-escalates.test.ts
+++ b/packages/llm-agent-libs/src/__tests__/agent-mcp-unavailable-escalates.test.ts
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import type {
+  ILlm,
+  IMcpClient,
+  LlmError,
+  LlmResponse,
+  McpError as McpErrorType,
+  McpTool,
+  McpToolResult,
+  Result,
+} from '@mcp-abap-adt/llm-agent';
+import { McpError } from '@mcp-abap-adt/llm-agent';
+import { SmartAgent } from '../agent.js';
+import { makeDefaultDeps } from '../testing/index.js';
+
+const TOOL: McpTool = {
+  name: 'GetTable',
+  description: 'read table',
+  inputSchema: {},
+};
+
+/** LLM that asks for GetTable once, then (if reached) returns final text. */
+function toolThenText(final: string): ILlm {
+  let n = 0;
+  const first = (): Result<LlmResponse, LlmError> => ({
+    ok: true,
+    value: {
+      content: '',
+      finishReason: 'tool_calls',
+      toolCalls: [{ id: 'c0', name: 'GetTable', arguments: {} }],
+    },
+  });
+  const rest = (): Result<LlmResponse, LlmError> => ({
+    ok: true,
+    value: { content: final, finishReason: 'stop' },
+  });
+  return {
+    async chat() {
+      return ++n === 1 ? first() : rest();
+    },
+    async *streamChat() {
+      yield ++n === 1 ? first() : rest();
+    },
+  } as ILlm;
+}
+
+function clientReturning(
+  result: Result<McpToolResult, McpErrorType>,
+): IMcpClient {
+  return {
+    async listTools(): Promise<Result<McpTool[], McpErrorType>> {
+      return { ok: true, value: [TOOL] };
+    },
+    async callTool(): Promise<Result<McpToolResult, McpErrorType>> {
+      return result;
+    },
+  } as IMcpClient;
+}
+
+test('availability error in the tool loop fails the run (not tool text)', async () => {
+  const client = clientReturning({
+    ok: false,
+    error: new McpError('Not connected', 'MCP_NOT_CONNECTED'),
+  });
+  const { deps } = makeDefaultDeps({ mcpClients: [client] });
+  deps.mainLlm = toolThenText('should not be reached');
+  const agent = new SmartAgent(deps, { maxIterations: 5, mode: 'hard' });
+  const res = await agent.process('read table T');
+  assert.equal(res.ok, false, 'run must fail loud on MCP unavailability');
+});
+
+test('a tool-level error does NOT fail the run (stays LLM feedback)', async () => {
+  const client = clientReturning({
+    ok: false,
+    error: new McpError('table not found', 'MCP_ERROR'),
+  });
+  const { deps } = makeDefaultDeps({ mcpClients: [client] });
+  deps.mainLlm = toolThenText('the table does not exist');
+  const agent = new SmartAgent(deps, { maxIterations: 5, mode: 'hard' });
+  const res = await agent.process('read table T');
+  assert.equal(res.ok, true, 'a tool-level error must stay LLM feedback');
+});

--- a/packages/llm-agent-libs/src/agent.ts
+++ b/packages/llm-agent-libs/src/agent.ts
@@ -32,6 +32,7 @@ import {
   type AgentCallOptions,
   getStreamToolCallName,
   type IQueryExpander,
+  isMcpUnavailable,
   NoopQueryExpander,
   NoopToolCache,
   normalizeExternalTools,
@@ -1945,6 +1946,18 @@ export class SmartAgent {
       const toolMessages: Message[] = [];
       for (const { tc, text, res } of results) {
         if (!res) continue;
+        // FAIL LOUD on an MCP availability failure (transport down / 403 / timeout
+        // after reconnect) — do NOT feed "MCP error" back to the LLM as tool text.
+        // Yield an error chunk (not throw) so process() returns ok:false (a real
+        // error to the consumer) instead of a silent "(no response)" or an uncaught
+        // exception escaping the generator.
+        if (!res.ok && isMcpUnavailable(res.error)) {
+          yield {
+            ok: false,
+            error: new OrchestratorError(res.error.message, 'MCP_UNAVAILABLE'),
+          };
+          return;
+        }
         if (
           !res.ok &&
           isToolContextUnavailableError(text) &&

--- a/packages/llm-agent-libs/src/agent.ts
+++ b/packages/llm-agent-libs/src/agent.ts
@@ -32,7 +32,6 @@ import {
   type AgentCallOptions,
   getStreamToolCallName,
   type IQueryExpander,
-  isMcpUnavailable,
   NoopQueryExpander,
   NoopToolCache,
   normalizeExternalTools,
@@ -63,6 +62,7 @@ import { NoopRequestLogger } from './logger/noop-request-logger.js';
 import { summaryToUsage } from './logger/session-request-logger.js';
 import { NoopMetrics } from './metrics/noop-metrics.js';
 import type { IMetrics } from './metrics/types.js';
+import { classifyToolResult } from './pipeline/handlers/escalate-if-unavailable.js';
 import { fireInternalToolsAsync } from './policy/mixed-tool-call-handler.js';
 import { PendingToolResultsRegistry } from './policy/pending-tool-results-registry.js';
 import {
@@ -1950,11 +1950,15 @@ export class SmartAgent {
         // after reconnect) — do NOT feed "MCP error" back to the LLM as tool text.
         // Yield an error chunk (not throw) so process() returns ok:false (a real
         // error to the consumer) instead of a silent "(no response)" or an uncaught
-        // exception escaping the generator.
-        if (!res.ok && isMcpUnavailable(res.error)) {
+        // exception escaping the generator. classifyToolResult is the shared decision.
+        const decision = classifyToolResult(res);
+        if (decision.escalate) {
           yield {
             ok: false,
-            error: new OrchestratorError(res.error.message, 'MCP_UNAVAILABLE'),
+            error: new OrchestratorError(
+              decision.escalate.message,
+              'MCP_UNAVAILABLE',
+            ),
           };
           return;
         }

--- a/packages/llm-agent-libs/src/pipeline/handlers/__tests__/escalate-if-unavailable.test.ts
+++ b/packages/llm-agent-libs/src/pipeline/handlers/__tests__/escalate-if-unavailable.test.ts
@@ -1,30 +1,33 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import { McpError } from '@mcp-abap-adt/llm-agent';
-import { escalateIfUnavailable } from '../escalate-if-unavailable.js';
+import { classifyToolResult } from '../escalate-if-unavailable.js';
 
-test('throws on an availability error result', () => {
-  const res = {
-    ok: false as const,
+test('classify: availability error → escalate', () => {
+  const d = classifyToolResult({
+    ok: false,
     error: new McpError('Not connected', 'MCP_NOT_CONNECTED'),
-  };
-  assert.throws(() => escalateIfUnavailable(res), /Not connected/);
+  });
+  assert.ok(d.escalate, 'must escalate');
+  assert.equal(d.escalate?.message, 'Not connected');
 });
 
-test('returns text for a tool-level error result', () => {
-  const res = {
-    ok: false as const,
+test('classify: tool-level error → text (LLM feedback)', () => {
+  const d = classifyToolResult({
+    ok: false,
     error: new McpError('bad args', 'MCP_ERROR'),
-  };
-  assert.equal(escalateIfUnavailable(res), 'bad args');
+  });
+  assert.equal(d.escalate, undefined);
+  assert.equal(d.text, 'bad args');
 });
 
-test('returns string content for an ok result', () => {
-  const res = { ok: true as const, value: { content: 'hello' } };
-  assert.equal(escalateIfUnavailable(res), 'hello');
+test('classify: ok string content → text', () => {
+  const d = classifyToolResult({ ok: true, value: { content: 'hello' } });
+  assert.equal(d.escalate, undefined);
+  assert.equal(d.text, 'hello');
 });
 
-test('JSON-stringifies non-string content for an ok result', () => {
-  const res = { ok: true as const, value: { content: { rows: 3 } } };
-  assert.equal(escalateIfUnavailable(res), '{"rows":3}');
+test('classify: ok non-string content → JSON text', () => {
+  const d = classifyToolResult({ ok: true, value: { content: { rows: 3 } } });
+  assert.equal(d.text, '{"rows":3}');
 });

--- a/packages/llm-agent-libs/src/pipeline/handlers/__tests__/escalate-if-unavailable.test.ts
+++ b/packages/llm-agent-libs/src/pipeline/handlers/__tests__/escalate-if-unavailable.test.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { McpError } from '@mcp-abap-adt/llm-agent';
+import { escalateIfUnavailable } from '../escalate-if-unavailable.js';
+
+test('throws on an availability error result', () => {
+  const res = {
+    ok: false as const,
+    error: new McpError('Not connected', 'MCP_NOT_CONNECTED'),
+  };
+  assert.throws(() => escalateIfUnavailable(res), /Not connected/);
+});
+
+test('returns text for a tool-level error result', () => {
+  const res = {
+    ok: false as const,
+    error: new McpError('bad args', 'MCP_ERROR'),
+  };
+  assert.equal(escalateIfUnavailable(res), 'bad args');
+});
+
+test('returns string content for an ok result', () => {
+  const res = { ok: true as const, value: { content: 'hello' } };
+  assert.equal(escalateIfUnavailable(res), 'hello');
+});
+
+test('JSON-stringifies non-string content for an ok result', () => {
+  const res = { ok: true as const, value: { content: { rows: 3 } } };
+  assert.equal(escalateIfUnavailable(res), '{"rows":3}');
+});

--- a/packages/llm-agent-libs/src/pipeline/handlers/__tests__/tool-loop-mcp-unavailable.test.ts
+++ b/packages/llm-agent-libs/src/pipeline/handlers/__tests__/tool-loop-mcp-unavailable.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Phase 3 / Task 5 — the pipeline-handler tool loop fails loud on an MCP
+ * availability error (yields ok:false, execute() returns false) instead of
+ * feeding "MCP error" back to the LLM as tool text. A tool-level error stays
+ * feedback (the loop continues).
+ */
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import type {
+  CallOptions,
+  ILlm,
+  IMcpClient,
+  IRequestLogger,
+  LlmError,
+  LlmResponse,
+  LlmStreamChunk,
+  LlmTool,
+  McpToolResult,
+  Message,
+  Result,
+} from '@mcp-abap-adt/llm-agent';
+import { McpError, NoopToolCache } from '@mcp-abap-adt/llm-agent';
+import { PendingToolResultsRegistry } from '../../../policy/pending-tool-results-registry.js';
+import { ToolAvailabilityRegistry } from '../../../policy/tool-availability-registry.js';
+import type { ISpan } from '../../../tracer/types.js';
+import type { PipelineContext } from '../../context.js';
+import { ToolLoopHandler } from '../tool-loop.js';
+
+function makeSpan(): ISpan {
+  return {
+    name: 's',
+    setAttribute() {},
+    setStatus() {},
+    addEvent() {},
+    end() {},
+  } as unknown as ISpan;
+}
+
+const TOOL: LlmTool = {
+  type: 'function',
+  function: { name: 'GetTable', description: 'read', parameters: {} },
+} as unknown as LlmTool;
+
+/** LLM that streams one GetTable tool call, then final text if reached. */
+function toolThenText(): ILlm {
+  let n = 0;
+  async function* stream(): AsyncIterable<Result<LlmStreamChunk, LlmError>> {
+    if (++n === 1) {
+      yield {
+        ok: true,
+        value: {
+          content: '',
+          toolCalls: [{ id: 'c0', name: 'GetTable', arguments: {} }],
+          finishReason: 'tool_calls',
+        },
+      } as Result<LlmStreamChunk, LlmError>;
+      return;
+    }
+    yield {
+      ok: true,
+      value: { content: 'final', finishReason: 'stop' },
+    } as Result<LlmStreamChunk, LlmError>;
+  }
+  return {
+    model: 'stub',
+    async chat(): Promise<Result<LlmResponse, LlmError>> {
+      return { ok: true, value: { content: '', finishReason: 'stop' } };
+    },
+    streamChat: stream,
+  } as ILlm;
+}
+
+function makeCtx(client: IMcpClient): {
+  ctx: PipelineContext;
+  yielded: Result<LlmStreamChunk, unknown>[];
+} {
+  const yielded: Result<LlmStreamChunk, unknown>[] = [];
+  const llm = toolThenText();
+  const ctx = {
+    config: {
+      maxIterations: 3,
+      maxToolCalls: 5,
+      heartbeatIntervalMs: 5000,
+      mode: 'smart',
+      refreshToolsPerIteration: false,
+    },
+    options: {} as CallOptions,
+    sessionId: 's-unavail',
+    mcpClients: [client],
+    mainLlm: llm,
+    inputText: '',
+    history: [] as Message[],
+    assembledMessages: [{ role: 'user', content: 'read table' } as Message],
+    activeTools: [TOOL],
+    externalTools: [] as LlmTool[],
+    selectedTools: [TOOL],
+    mcpTools: [],
+    toolClientMap: new Map<string, IMcpClient>([['GetTable', client]]),
+    toolCache: new NoopToolCache(),
+    ragStores: {},
+    timing: [],
+    pendingToolResults: new PendingToolResultsRegistry(),
+    toolAvailabilityRegistry: new ToolAvailabilityRegistry(),
+    requestLogger: {
+      logLlmCall() {},
+      logRagQuery() {},
+      logToolCall() {},
+      startRequest() {},
+      endRequest() {},
+      dropRequest() {},
+      getSummary() {
+        return {
+          byModel: {},
+          byComponent: {},
+          byCategory: {},
+          ragQueries: 0,
+          toolCalls: 0,
+          totalDurationMs: 0,
+        };
+      },
+      reset() {},
+    } as IRequestLogger,
+    metrics: {
+      llmCallCount: { add() {} },
+      llmCallLatency: { record() {} },
+      toolCallCount: { add() {} },
+      toolCacheHitCount: { add() {} },
+    } as unknown as PipelineContext['metrics'],
+    tracer: {
+      startSpan: () => makeSpan(),
+    } as unknown as PipelineContext['tracer'],
+    sessionManager: {
+      addTokens() {},
+      isOverBudget: () => false,
+      reset() {},
+      totalTokens: 0,
+    } as unknown as PipelineContext['sessionManager'],
+    outputValidator: {
+      async validate() {
+        return { ok: true, value: { valid: true } };
+      },
+    } as unknown as PipelineContext['outputValidator'],
+    llmCallStrategy: {
+      call: () => llm.streamChat?.([], [], undefined),
+    } as unknown as PipelineContext['llmCallStrategy'],
+    yield(chunk: Result<LlmStreamChunk, unknown>) {
+      yielded.push(chunk);
+    },
+  } as unknown as PipelineContext;
+  return { ctx, yielded };
+}
+
+function clientReturning(res: Result<McpToolResult, McpError>): IMcpClient {
+  return {
+    async listTools() {
+      return {
+        ok: true as const,
+        value: [{ name: 'GetTable', description: 'read', inputSchema: {} }],
+      };
+    },
+    async callTool() {
+      return res;
+    },
+  } as IMcpClient;
+}
+
+test('tool-loop handler fails loud on an MCP availability error', async () => {
+  const { ctx, yielded } = makeCtx(
+    clientReturning({
+      ok: false,
+      error: new McpError('Not connected', 'MCP_NOT_CONNECTED'),
+    }),
+  );
+  const ok = await new ToolLoopHandler().execute(ctx, {}, makeSpan());
+  assert.equal(ok, false, 'execute() must report failure');
+  assert.ok(
+    yielded.some((c) => !c.ok),
+    'an error chunk must be yielded',
+  );
+});
+
+test('tool-loop handler keeps a tool-level error as feedback (no fail-loud)', async () => {
+  const { ctx, yielded } = makeCtx(
+    clientReturning({
+      ok: false,
+      error: new McpError('table not found', 'MCP_ERROR'),
+    }),
+  );
+  const ok = await new ToolLoopHandler().execute(ctx, {}, makeSpan());
+  // A tool-level error is fed back to the LLM; the loop proceeds to completion.
+  assert.equal(ok, true, 'tool-level error must not fail the loop');
+  assert.ok(
+    !yielded.some((c) => !c.ok),
+    'no error chunk for a tool-level error',
+  );
+});

--- a/packages/llm-agent-libs/src/pipeline/handlers/escalate-if-unavailable.ts
+++ b/packages/llm-agent-libs/src/pipeline/handlers/escalate-if-unavailable.ts
@@ -1,24 +1,33 @@
-import {
-  isMcpUnavailable,
-  type McpError,
-  type Result,
-} from '@mcp-abap-adt/llm-agent';
+import { isMcpUnavailable, type McpError } from '@mcp-abap-adt/llm-agent';
 
-type ToolRes = Result<{ content: unknown }, McpError>;
+// Loose over the exact tool-result shape (callTool's Result error is structurally
+// `{ message }`, but at runtime an availability failure is a real McpError — which
+// `isMcpUnavailable`'s instanceof check detects). Accepting `{ message: string }`
+// keeps both the core loop and the pipeline-handler loop type-compatible.
+type ToolRes =
+  | { ok: true; value: { content: unknown } }
+  | { ok: false; error: { message: string } };
 
-/**
- * The single decision both MCP tool loops (the core SmartAgent loop and the
- * pipeline-handler tool loop) use to turn a tool-call result into text — EXCEPT
- * an availability failure, which it THROWS so the run fails loud (→ a real error
- * to the consumer, not a silent "(no response)") instead of feeding "MCP error"
- * back to the LLM as tool text. A tool-level error stays text (LLM feedback).
- */
-export function escalateIfUnavailable(res: ToolRes): string {
+/** The decision both MCP tool loops share for one tool-call result:
+ *  - `escalate` → an availability failure (transport down / 403 / timeout after
+ *    reconnect): the caller must FAIL LOUD (yield an error → process() ok:false),
+ *    NOT feed it to the LLM as text;
+ *  - `text` → normal content OR a tool-level error, which stays LLM feedback. */
+export type ToolResultDecision =
+  | { escalate: McpError }
+  | { escalate?: undefined; text: string };
+
+/** Classify a tool-call result. Used by BOTH the core SmartAgent tool loop and the
+ *  pipeline-handler tool loop so the throw-or-text decision lives in ONE place. */
+export function classifyToolResult(res: ToolRes): ToolResultDecision {
   if (!res.ok) {
-    if (isMcpUnavailable(res.error)) throw res.error;
-    return res.error.message;
+    if (isMcpUnavailable(res.error)) return { escalate: res.error as McpError };
+    return { text: res.error.message };
   }
-  return typeof res.value.content === 'string'
-    ? res.value.content
-    : JSON.stringify(res.value.content);
+  return {
+    text:
+      typeof res.value.content === 'string'
+        ? res.value.content
+        : JSON.stringify(res.value.content),
+  };
 }

--- a/packages/llm-agent-libs/src/pipeline/handlers/escalate-if-unavailable.ts
+++ b/packages/llm-agent-libs/src/pipeline/handlers/escalate-if-unavailable.ts
@@ -1,0 +1,24 @@
+import {
+  isMcpUnavailable,
+  type McpError,
+  type Result,
+} from '@mcp-abap-adt/llm-agent';
+
+type ToolRes = Result<{ content: unknown }, McpError>;
+
+/**
+ * The single decision both MCP tool loops (the core SmartAgent loop and the
+ * pipeline-handler tool loop) use to turn a tool-call result into text — EXCEPT
+ * an availability failure, which it THROWS so the run fails loud (→ a real error
+ * to the consumer, not a silent "(no response)") instead of feeding "MCP error"
+ * back to the LLM as tool text. A tool-level error stays text (LLM feedback).
+ */
+export function escalateIfUnavailable(res: ToolRes): string {
+  if (!res.ok) {
+    if (isMcpUnavailable(res.error)) throw res.error;
+    return res.error.message;
+  }
+  return typeof res.value.content === 'string'
+    ? res.value.content
+    : JSON.stringify(res.value.content);
+}

--- a/packages/llm-agent-libs/src/pipeline/handlers/tool-loop.ts
+++ b/packages/llm-agent-libs/src/pipeline/handlers/tool-loop.ts
@@ -42,6 +42,7 @@ import { isToolContextUnavailableError } from '../../policy/tool-availability-re
 import type { ISpan } from '../../tracer/types.js';
 import type { PipelineContext } from '../context.js';
 import type { IStageHandler } from '../stage-handler.js';
+import { classifyToolResult } from './escalate-if-unavailable.js';
 
 function summarizeIterationMessages(
   messages: Message[],
@@ -946,6 +947,19 @@ export class ToolLoopHandler implements IStageHandler {
       for (const r of results) {
         const { tc, text, res } = r;
         if (!res) continue;
+        // FAIL LOUD on an MCP availability failure — yield an error (→ pipeline
+        // fails with ok:false) instead of feeding "MCP error" to the LLM as text.
+        const decision = classifyToolResult(res);
+        if (decision.escalate) {
+          ctx.yield({
+            ok: false,
+            error: new OrchestratorError(
+              decision.escalate.message,
+              'MCP_UNAVAILABLE',
+            ),
+          });
+          return false;
+        }
         if (
           !res.ok &&
           isToolContextUnavailableError(text) &&

--- a/packages/llm-agent-server-libs/src/smart-agent/__tests__/mcp-bridge-failloud.test.ts
+++ b/packages/llm-agent-server-libs/src/smart-agent/__tests__/mcp-bridge-failloud.test.ts
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import type { IMcpClient } from '@mcp-abap-adt/llm-agent';
+import { McpError } from '@mcp-abap-adt/llm-agent';
+import { buildMcpBridge } from '../smart-server.js';
+
+test('bridge throws on an availability listTools error (not "Tool not found")', async () => {
+  const client = {
+    async listTools() {
+      return {
+        ok: false as const,
+        error: new McpError('Not connected', 'MCP_NOT_CONNECTED'),
+      };
+    },
+    async callTool() {
+      return { ok: true as const, value: { content: 'x', isError: false } };
+    },
+  } as unknown as IMcpClient;
+  const bridge = buildMcpBridge([client]);
+  await assert.rejects(
+    () => bridge('GetTable', {}),
+    /not connected|MCP_NOT_CONNECTED/i,
+  );
+});
+
+test('bridge throws on an availability callTool error', async () => {
+  const client = {
+    async listTools() {
+      return {
+        ok: true as const,
+        value: [{ name: 'GetTable', description: '', inputSchema: {} }],
+      };
+    },
+    async callTool() {
+      return {
+        ok: false as const,
+        error: new McpError(
+          'MCP error -32001: Request timed out',
+          'MCP_TIMEOUT',
+        ),
+      };
+    },
+  } as unknown as IMcpClient;
+  const bridge = buildMcpBridge([client]);
+  await assert.rejects(() => bridge('GetTable', {}), /timed out|MCP_TIMEOUT/i);
+});
+
+test('bridge returns "Tool not found" when no client owns the name', async () => {
+  const client = {
+    async listTools() {
+      return { ok: true as const, value: [] };
+    },
+    async callTool() {
+      return { ok: true as const, value: { content: 'x', isError: false } };
+    },
+  } as unknown as IMcpClient;
+  const bridge = buildMcpBridge([client]);
+  assert.match(await bridge('Nope', {}), /Tool not found/);
+});
+
+test('bridge returns a tool-level error as text (not a throw)', async () => {
+  const client = {
+    async listTools() {
+      return {
+        ok: true as const,
+        value: [{ name: 'GetTable', description: '', inputSchema: {} }],
+      };
+    },
+    async callTool() {
+      return {
+        ok: false as const,
+        error: new McpError('table not found', 'MCP_ERROR'),
+      };
+    },
+  } as unknown as IMcpClient;
+  const bridge = buildMcpBridge([client]);
+  assert.equal(await bridge('GetTable', {}), 'table not found');
+});

--- a/packages/llm-agent-server-libs/src/smart-agent/smart-server.ts
+++ b/packages/llm-agent-server-libs/src/smart-agent/smart-server.ts
@@ -42,6 +42,7 @@ import {
   buildExternalResults,
   type ExternalToolValidationCode,
   type IRag,
+  isMcpUnavailable,
   normalizeAndValidateExternalTools,
   QueryEmbedding,
   toToolCallDelta,
@@ -952,11 +953,19 @@ export function buildMcpBridge(
         : {};
     for (const client of clients) {
       const listed = await client.listTools();
-      if (!listed.ok) continue;
+      if (!listed.ok) {
+        // FAIL LOUD on an availability failure: a transient listTools() outage must
+        // NOT make the tool look merely absent (→ "Tool not found"/tool-blind). A
+        // benign error (this client genuinely can't list) falls through to the next.
+        if (isMcpUnavailable(listed.error)) throw listed.error;
+        continue;
+      }
       const owns = listed.value.some((t) => t.name === name);
       if (!owns) continue;
       const result = await client.callTool(name, safeArgs);
       if (!result.ok) {
+        // Availability failure → fail loud; a tool-level error → LLM feedback text.
+        if (isMcpUnavailable(result.error)) throw result.error;
         return result.error.message;
       }
       const { content } = result.value;


### PR DESCRIPTION
Phase 3 of the MCP readiness & fail-loud design — builds on Phase 1+2 (#201, the `isMcpUnavailable` classifier). Makes an MCP **availability** failure during a request fail loud at EVERY tool-execution surface instead of being stringified back to the LLM as tool text (which led to silent degraded answers). Tool-level errors are unchanged — they stay LLM feedback.

## Tasks (TDD)

**Shared classifier — `classifyToolResult`** (`pipeline/handlers/escalate-if-unavailable.ts`)
A `{ escalate: McpError } | { text: string }` decision USED by both tool loops (not a stub) — `escalate` on an availability code, `text` otherwise. 4 unit tests.

**Task 4 — core SmartAgent tool loop** (`agent.ts`)
On an availability result, **yields** an `OrchestratorError('MCP_UNAVAILABLE')` chunk (→ `process()` returns `ok:false`) instead of stringifying it; a tool-level error stays feedback. Yield (not throw) so it's a real Result error, never a silent `(no response)` or an uncaught escape. Integration test via `SmartAgent` + a failing MCP client.

**Task 5 — pipeline-handler tool loop** (`pipeline/handlers/tool-loop.ts`)
Same escalation via the shared classifier; `ToolLoopHandler.execute()` returns `false` + yields an error chunk. **Real handler regression test** drives `execute()` with a failing MCP client (and a tool-level case that stays `true`).

**Task 6 — `buildMcpBridge`** (`smart-server.ts`, controller/stepper surface)
A transient `listTools()` availability error no longer makes a tool look absent (`Tool not found` / tool-blind) — it **throws**; an availability `callTool` error throws; a tool-level error stays text; a genuine no-owner stays `Tool not found`.

## Test Plan
- [x] `llm-agent` 327/0 · `llm-agent-mcp` 48/0 · `llm-agent-libs` 773/0 · `llm-agent-server-libs` 589/0.
- [x] New: classifier (4), agent escalation (2), tool-loop handler (2), bridge (4).
- [x] `npm run build` green; `npm run lint:check` exit 0.

Next: Phase 4 (readiness registry + monitor + worker hoist), Phase 5 (request gate + /health).

🤖 Generated with [Claude Code](https://claude.com/claude-code)