### PR TITLE
feat(mcp): builder defaults MCP to a connection strategy + agent readiness (Phase 4b)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1131,3 +1131,7 @@ See `docs/examples/coordinator-orchestration.yaml` for a complete configuration.
   **reimplementing on existing components** (e.g. MCP lifecycle/health via
   `IMcpConnectionStrategy` + `IReadinessReporter`, not bespoke server modules) — NOT by
   carving it into ad-hoc fragments.
+- **`builder.ts` (~1.5k) and `agent.ts` (~2.1k) are large too.** Follow-up extraction
+  targets: the builder's MCP block (connect + **tool vectorization** — pull the
+  vectorization into its own small module consumed by the builder) and the agent's
+  tool-loop. Keep the extraction component-shaped (Principle 1/6), not ad-hoc.

--- a/packages/llm-agent-libs/src/__tests__/agent-readiness.test.ts
+++ b/packages/llm-agent-libs/src/__tests__/agent-readiness.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import type { IMcpConnectionStrategy } from '@mcp-abap-adt/llm-agent';
+import { isReadinessReporter } from '@mcp-abap-adt/llm-agent';
+import type { SmartAgent } from '../agent.js';
+import { SmartAgentBuilder } from '../builder.js';
+import { makeLlm } from '../testing/index.js';
+
+/** A connection strategy that also reports readiness via IReadinessReporter. */
+function strategyReporting(ready: boolean): IMcpConnectionStrategy {
+  return {
+    async resolve() {
+      return { clients: [], toolsChanged: false };
+    },
+    isReady() {
+      return ready;
+    },
+  } as IMcpConnectionStrategy;
+}
+
+test('agent implements IReadinessReporter (detectable via the guard)', async () => {
+  const handle = await new SmartAgentBuilder({})
+    .withMainLlm(makeLlm([{ content: 'x' }]))
+    .build();
+  assert.equal(isReadinessReporter(handle.agent), true);
+  await handle.close();
+});
+
+test('agent.isReady() reflects the connection strategy (down ⇒ not ready)', async () => {
+  const handle = await new SmartAgentBuilder({})
+    .withMainLlm(makeLlm([{ content: 'x' }]))
+    .withMcpConnectionStrategy(strategyReporting(false))
+    .build();
+  assert.equal((handle.agent as SmartAgent).isReady(), false);
+  await handle.close();
+});
+
+test('agent.isReady() is true with no strategy (readiness unknown ⇒ ready)', async () => {
+  const handle = await new SmartAgentBuilder({})
+    .withMainLlm(makeLlm([{ content: 'x' }]))
+    .build();
+  assert.equal((handle.agent as SmartAgent).isReady(), true);
+  await handle.close();
+});

--- a/packages/llm-agent-libs/src/__tests__/builder-mcp-failure-logging.test.ts
+++ b/packages/llm-agent-libs/src/__tests__/builder-mcp-failure-logging.test.ts
@@ -76,7 +76,10 @@ describe('SmartAgentBuilder — MCP setup failure logging (#118)', () => {
         mcpWarning,
         `expected a 'warning' log entry mentioning ${unreachableUrl}, got: ${JSON.stringify(warnings)}`,
       );
-      assert.match(mcpWarning.message, /MCP setup failed/);
+      // #118 contract: the failure is logged with the target URL, not swallowed.
+      // Connection is now owned by the connection strategy, which logs
+      // "MCP connection failed for <url>" (was the builder's "MCP setup failed").
+      assert.match(mcpWarning.message, /MCP connection failed/);
 
       // Agent still builds (graceful degradation contract preserved).
       const health = await handle.agent.healthCheck();

--- a/packages/llm-agent-libs/src/agent.ts
+++ b/packages/llm-agent-libs/src/agent.ts
@@ -32,6 +32,7 @@ import {
   type AgentCallOptions,
   getStreamToolCallName,
   type IQueryExpander,
+  isReadinessReporter,
   NoopQueryExpander,
   NoopToolCache,
   normalizeExternalTools,
@@ -467,6 +468,17 @@ export class SmartAgent {
       historyAutoSummarizeLimit: this.config.historyAutoSummarizeLimit,
       classificationEnabled: this.config.classificationEnabled,
     };
+  }
+
+  /**
+   * Readiness (implements `IReadinessReporter`): delegate to the MCP connection
+   * strategy when it reports readiness, else `true` (no strategy / non-reporting ⇒
+   * readiness unknown → ready). Consumers (e.g. a server's `/health` + request
+   * gate) detect this via `isReadinessReporter(agent)` — no growth of `ISmartAgent`.
+   */
+  isReady(): boolean {
+    const strategy = this.deps.connectionStrategy;
+    return isReadinessReporter(strategy) ? strategy.isReady() : true;
   }
 
   async healthCheck(options?: CallOptions): Promise<

--- a/packages/llm-agent-libs/src/builder.ts
+++ b/packages/llm-agent-libs/src/builder.ts
@@ -56,10 +56,7 @@ import {
   SimpleRagProviderRegistry,
   SimpleRagRegistry,
 } from '@mcp-abap-adt/llm-agent';
-import {
-  MCPClientWrapper,
-  McpClientAdapter,
-} from '@mcp-abap-adt/llm-agent-mcp';
+import { makeConnectionStrategy } from '@mcp-abap-adt/llm-agent-mcp';
 import { wrapEmbedder } from './adapters/usage-logging-embedder.js';
 import { SmartAgent, type SmartAgentConfig } from './agent.js';
 import {
@@ -79,7 +76,10 @@ import {
 } from './coordinator/index.js';
 import { HistoryMemory } from './history/history-memory.js';
 import { HistorySummarizer } from './history/history-summarizer.js';
-import type { IMcpConnectionStrategy } from './interfaces/mcp-connection-strategy.js';
+import type {
+  IMcpConnectionStrategy,
+  McpConnectionConfig,
+} from './interfaces/mcp-connection-strategy.js';
 import type { IPipeline } from './interfaces/pipeline.js';
 import { DefaultRequestLogger } from './logger/default-request-logger.js';
 import type { IMetrics } from './metrics/types.js';
@@ -939,45 +939,40 @@ export class SmartAgentBuilder {
     // ---- MCP clients + tool vectorization --------------------------------
     let mcpClients: IMcpClient[];
     const closeFns: Array<() => Promise<void>> = [];
-    const connectionStrategy = this._connectionStrategy;
+    let connectionStrategy = this._connectionStrategy;
 
     if (this._mcpClients) {
       // Caller-provided clients: skip auto-connect and vectorization
       mcpClients = this._mcpClients;
     } else {
-      const mcpList = this.cfg.mcp
-        ? Array.isArray(this.cfg.mcp)
-          ? this.cfg.mcp
-          : [this.cfg.mcp]
-        : [];
-      const connected: IMcpClient[] = [];
-      for (const mcpCfg of mcpList) {
-        try {
-          let wrapper: MCPClientWrapper;
-          if (mcpCfg.type === 'stdio') {
-            wrapper = new MCPClientWrapper({
-              transport: 'stdio',
-              command: mcpCfg.command,
-              args: mcpCfg.args ?? [],
-            });
-          } else {
-            wrapper = new MCPClientWrapper({
-              transport: 'auto',
-              url: mcpCfg.url,
-              headers: mcpCfg.headers,
-            });
-          }
-          await wrapper.connect();
-          const adapter = new McpClientAdapter(wrapper);
-          log?.log({
-            type: 'pipeline_done',
-            traceId: 'builder',
-            stopReason: 'stop',
-            iterations: 0,
-            toolCallCount: 0,
-            durationMs: 0,
-          });
+      // YAML `mcp:` → route connection through an IMcpConnectionStrategy
+      // (build-on-components). Default to a resilient `makeConnectionStrategy`
+      // (connect + periodic reconnect + readiness via IReadinessReporter) unless
+      // the consumer injected their own. The strategy OWNS lifecycle: its initial
+      // `resolve([])` connects the targets and the agent resolves through it each
+      // iteration; disposal is `connectionStrategy.dispose()` (no per-client
+      // closeFns). `BuilderMcpConfig` is structurally `McpConnectionConfig`.
+      const mcpConfigs = (
+        this.cfg.mcp
+          ? Array.isArray(this.cfg.mcp)
+            ? this.cfg.mcp
+            : [this.cfg.mcp]
+          : []
+      ) as McpConnectionConfig[];
+      if (mcpConfigs.length > 0 && !connectionStrategy) {
+        connectionStrategy = makeConnectionStrategy(
+          mcpConfigs,
+          log ? { logger: log } : undefined,
+        );
+      }
+      const resolved = connectionStrategy
+        ? await connectionStrategy.resolve([])
+        : { clients: [] as IMcpClient[], toolsChanged: false };
+      mcpClients = resolved.clients;
 
+      // Vectorize each connected client's tools into the tools RAG store.
+      for (const adapter of mcpClients) {
+        try {
           // Vectorize tools into the tools RAG store
           if (toolsRag) {
             const toolsResult = await adapter.listTools();
@@ -1131,25 +1126,17 @@ export class SmartAgentBuilder {
               }
             }
           }
-
-          connected.push(adapter);
-          closeFns.push(() => wrapper.disconnect?.() ?? Promise.resolve());
         } catch (err) {
-          // Skip failed MCP setup — agent continues without that server, but
-          // surface why: silently swallowing this leaves operators chasing
-          // "agent has no tools" with no log line to point at the cause
-          // (unreachable host, bad auth, container-network mismatch, etc.).
-          // Note: this try-block also covers tool/skill vectorization, so the
-          // failure could be either connect or post-connect setup.
-          const target = mcpCfg.type === 'stdio' ? mcpCfg.command : mcpCfg.url;
+          // Tool vectorization failed for this client — skip it; the agent
+          // continues. (Connection failures are handled inside the strategy,
+          // which skips a down target and reconnects it later.)
           log?.log({
             type: 'warning',
             traceId: 'builder',
-            message: `MCP setup failed for ${target}: ${err instanceof Error ? err.message : String(err)}`,
+            message: `Tool vectorization failed: ${err instanceof Error ? err.message : String(err)}`,
           });
         }
       }
-      mcpClients = connected;
     }
 
     // ---- SmartAgent Config ------------------------------------------------

--- a/packages/llm-agent-mcp/src/__tests__/lazy-connection-strategy.test.ts
+++ b/packages/llm-agent-mcp/src/__tests__/lazy-connection-strategy.test.ts
@@ -375,3 +375,50 @@ describe('LazyConnectionStrategy.isReady()', () => {
     assert.equal(strategy.isReady(), false, 'one target down ⇒ not ready');
   });
 });
+
+describe('LazyConnectionStrategy — closes stale transport on unhealthy reconnect', () => {
+  it('calls the old close handle before clearing/reconnecting an unhealthy client', async () => {
+    let healthy = true;
+    let closeCalls = 0;
+    let factoryCalls = 0;
+    const client: IMcpClient = {
+      async listTools(): Promise<Result<McpTool[], McpError>> {
+        return { ok: true, value: [] };
+      },
+      async callTool(): Promise<Result<McpToolResult, McpError>> {
+        return { ok: true, value: { content: 'ok' } };
+      },
+      async healthCheck(): Promise<Result<boolean, McpError>> {
+        return healthy
+          ? { ok: true, value: true }
+          : {
+              ok: false,
+              error: { message: 'down' } as McpError,
+            };
+      },
+    };
+    const factory: McpClientFactory = async () => {
+      factoryCalls++;
+      return {
+        client,
+        close: () => {
+          closeCalls++;
+        },
+      };
+    };
+    const strategy = new LazyConnectionStrategy(
+      [httpConfig],
+      { cooldownMs: 0 },
+      factory,
+    );
+
+    await strategy.resolve([]); // initial connect
+    assert.equal(factoryCalls, 1);
+    assert.equal(closeCalls, 0, 'no close on first connect');
+
+    healthy = false; // next health probe fails
+    await strategy.resolve([]); // unhealthy → close stale, then reconnect
+    assert.equal(closeCalls, 1, 'stale transport closed before reconnect');
+    assert.equal(factoryCalls, 2, 'reconnected after closing the stale one');
+  });
+});

--- a/packages/llm-agent-mcp/src/factory.ts
+++ b/packages/llm-agent-mcp/src/factory.ts
@@ -18,6 +18,7 @@ export async function createDefaultMcpClient(
       : new MCPClientWrapper({
           transport: 'auto',
           url: config.url,
+          ...(config.headers ? { headers: config.headers } : {}),
         });
 
   await wrapper.connect();

--- a/packages/llm-agent-mcp/src/strategies/lazy-connection-strategy.ts
+++ b/packages/llm-agent-mcp/src/strategies/lazy-connection-strategy.ts
@@ -1,5 +1,6 @@
 import type {
   ConnectionStrategyOptions,
+  ILogger,
   IMcpClient,
   IMcpConnectionStrategy,
   IReadinessReporter,
@@ -24,6 +25,7 @@ export class LazyConnectionStrategy
   private readonly _skipRevectorize: boolean;
   private readonly _cooldownMs: number;
   private readonly _factory: McpClientFactory;
+  private readonly _logger?: ILogger;
   private _resolving: Promise<McpConnectionResult> | null = null;
 
   constructor(
@@ -34,6 +36,7 @@ export class LazyConnectionStrategy
     this._skipRevectorize = options?.skipRevectorize ?? false;
     this._cooldownMs = options?.cooldownMs ?? 30000;
     this._factory = factory ?? createDefaultMcpClient;
+    this._logger = options?.logger;
     this._slots = configs.map((config) => ({
       config,
       lastAttempt: 0,
@@ -86,8 +89,21 @@ export class LazyConnectionStrategy
           slot.closeHandle = result.close;
           slot.healthy = true;
           anyNewlyHealthy = true;
-        } catch {
+        } catch (err) {
           slot.healthy = false;
+          // Surface WHY a target is down — otherwise operators chase "agent has no
+          // tools" with no log line pointing at the cause (unreachable host, bad
+          // auth, container-network mismatch, …). Logged through the injected
+          // logger, once per (cooled-down) attempt.
+          const target =
+            slot.config.type === 'stdio'
+              ? slot.config.command
+              : slot.config.url;
+          this._logger?.log({
+            type: 'warning',
+            traceId: 'mcp-connection-strategy',
+            message: `MCP connection failed for ${target}: ${err instanceof Error ? err.message : String(err)}`,
+          });
         }
       }
     }

--- a/packages/llm-agent-mcp/src/strategies/lazy-connection-strategy.ts
+++ b/packages/llm-agent-mcp/src/strategies/lazy-connection-strategy.ts
@@ -73,10 +73,22 @@ export class LazyConnectionStrategy
           slot.healthy = true;
           continue;
         }
-        // Client is unhealthy — clear it and attempt reconnect
+        // Client is unhealthy — CLOSE the old transport before clearing it, then
+        // attempt reconnect. Skipping the close leaks the previous HTTP/stdio
+        // connection on every health-failure reconnect (this strategy is now the
+        // default YAML `mcp:` lifecycle path). Best-effort: a failing close must
+        // not abort the resolve pass.
+        const staleClose = slot.closeHandle;
         slot.client = undefined;
         slot.closeHandle = undefined;
         slot.healthy = false;
+        if (staleClose) {
+          try {
+            await staleClose();
+          } catch {
+            /* best-effort — the transport is already considered dead */
+          }
+        }
       }
 
       // No client or just cleared — try reconnect if cooldown expired

--- a/packages/llm-agent-mcp/src/strategies/periodic-connection-strategy.ts
+++ b/packages/llm-agent-mcp/src/strategies/periodic-connection-strategy.ts
@@ -16,6 +16,10 @@ export class PeriodicConnectionStrategy
   private _cachedResult: McpConnectionResult;
   private _changed: boolean;
   private readonly _interval: ReturnType<typeof setInterval>;
+  /** The initial probe — `resolve()` awaits it so the FIRST call (e.g. a builder's
+   *  build-time tool vectorization) sees the connected clients, not the empty
+   *  pre-probe cache. Subsequent resolves return the cache without blocking. */
+  private readonly _firstProbe: Promise<void>;
 
   constructor(
     configs: McpConnectionConfig[],
@@ -36,8 +40,8 @@ export class PeriodicConnectionStrategy
       void this._probe();
     }, intervalMs);
 
-    // Run first probe immediately
-    void this._probe();
+    // Run the first probe immediately; capture it so resolve() can await it once.
+    this._firstProbe = this._probe();
   }
 
   private async _probe(): Promise<void> {
@@ -55,6 +59,8 @@ export class PeriodicConnectionStrategy
   }
 
   async resolve(_currentClients?: IMcpClient[]): Promise<McpConnectionResult> {
+    // Ensure the initial connect has completed before the first resolve returns.
+    await this._firstProbe;
     if (this._changed) {
       this._changed = false;
       return {

--- a/packages/llm-agent/src/interfaces/mcp-connection-strategy.ts
+++ b/packages/llm-agent/src/interfaces/mcp-connection-strategy.ts
@@ -19,6 +19,9 @@ export interface McpConnectionConfig {
   url?: string;
   command?: string;
   args?: string[];
+  /** HTTP transport headers (e.g. `Accept`, reverse-proxy routing like
+   *  `x-sap-destination`). Additive — strategies that ignore it are unaffected. */
+  headers?: Record<string, string>;
 }
 
 export interface McpClientFactoryResult {


### PR DESCRIPTION
Phase 4b — the SmartServer/builder now **consume** the readiness components from #203 instead of bespoke glue. The builder routes MCP through an `IMcpConnectionStrategy` (defaulting to the reusable `makeConnectionStrategy`), and the agent reports readiness via the small `IReadinessReporter`. This is the resilient-connection + readiness plumbing; Phase 5 wires `/health` 503 + the request gate to it.

## What changed

**Builder defaults MCP to a connection strategy (single source).**
YAML `mcp:` no longer eager-connects a wrapper per config. When no strategy is injected, the builder creates `makeConnectionStrategy(cfg.mcp)`; its first `resolve([])` connects the targets (build-time tool vectorization runs over them), the agent resolves through it each iteration (auto-reconnect), and disposal is `strategy.dispose()`. No double-connect; the consumer can still inject their own strategy. **The builder's MCP block net-shrank (−54 lines).**

**Supporting component changes (additive, don't-break):**
- `McpConnectionConfig` carries `headers`; `createDefaultMcpClient` forwards them (so routing through the strategy doesn't drop `Accept` / reverse-proxy headers like `x-sap-destination`).
- `LazyConnectionStrategy` logs a connect failure through the injected logger (`MCP connection failed for <target>`) — **preserves the #118 don't-swallow contract**, now owned by the strategy.
- `PeriodicConnectionStrategy.resolve()` awaits the first probe so a build-time resolve sees connected clients (subsequent resolves stay non-blocking).
- `SmartAgent` implements `IReadinessReporter`: `isReady()` delegates to the connection strategy (no strategy ⇒ ready). Detected via `isReadinessReporter(agent)` — **no growth of `ISmartAgent` (ISP)**.

## Architecture-principle self-check (per docs/ARCHITECTURE.md)
1. Build-on-components ✓ (consumes `makeConnectionStrategy`/`IMcpConnectionStrategy`; deletes the eager bespoke loop) · 2. App-is-example ✓ (logic in libs; builder uses the component) · 3. Interfaces ✓ · 4. Small interfaces/ISP ✓ (`IReadinessReporter`, no `ISmartAgent` growth) · 5. Variation→strategy ✓ (injected strategy wins) · 6. File size ✓ (builder block shrank) · 7. Don't-break ✓ (additive config/log; #118 contract kept).

## Test Plan
- [x] `llm-agent` 327/0 · `llm-agent-mcp` 54/0 · `llm-agent-libs` 776/0 · `llm-agent-server-libs` 589/0.
- [x] New: 3 agent-readiness tests; #118 test kept (wording updated to the strategy's message).
- [x] `npm run build` green; `npm run lint:check` exit 0.

**Follow-up (Phase 5):** SmartServer reads `isReadinessReporter(agent)` for `/health` (503 on MCP-down) and a pre-dispatch request gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)