### PR TITLE
feat(server): readiness gate + /health 503 when MCP not ready (Phase 5 — final)

### DIFF
--- a/packages/llm-agent-server-libs/src/smart-agent/__tests__/readiness-gate.test.ts
+++ b/packages/llm-agent-server-libs/src/smart-agent/__tests__/readiness-gate.test.ts
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import { request } from 'node:http';
+import { describe, it, test } from 'node:test';
+import { SmartServer, writeNotReady } from '../smart-server.js';
+
+function httpRequest(
+  port: number,
+  method: string,
+  path: string,
+  body?: string,
+): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = request(
+      {
+        host: '127.0.0.1',
+        port,
+        method,
+        path,
+        headers: { 'Content-Type': 'application/json' },
+      },
+      (res) => {
+        let data = '';
+        res.on('data', (c) => {
+          data += c;
+        });
+        res.on('end', () =>
+          resolve({ status: res.statusCode ?? 0, body: data }),
+        );
+      },
+    );
+    req.on('error', reject);
+    if (body !== undefined) req.write(body);
+    req.end();
+  });
+}
+
+test('writeNotReady writes a 503 service_unavailable JSON error', () => {
+  const written: { code?: number; body?: string } = {};
+  const res = {
+    writeHead(code: number) {
+      written.code = code;
+      return res;
+    },
+    end(b?: string) {
+      written.body = b;
+    },
+  };
+  writeNotReady(res as never);
+  assert.equal(written.code, 503);
+  assert.match(written.body ?? '', /service_unavailable/);
+  assert.match(written.body ?? '', /not ready/i);
+});
+
+describe('readiness gate — MCP unreachable ⇒ NOT_READY', () => {
+  it('GET /health → 503 ready:false and POST /v1/chat/completions → 503 (pre-dispatch)', async () => {
+    const server = new SmartServer({
+      port: 0,
+      llm: { apiKey: 'test', model: 'test-model' },
+      skipModelValidation: true,
+      // Unreachable MCP → the connection strategy never connects → not ready.
+      mcp: { type: 'http', url: 'http://127.0.0.1:7779/mcp/stream/http' },
+    });
+    const handle = await server.start();
+    try {
+      const health = await httpRequest(handle.port, 'GET', '/health');
+      assert.equal(health.status, 503, '/health is 503 when MCP is down');
+      assert.equal(JSON.parse(health.body).ready, false);
+
+      const chat = await httpRequest(
+        handle.port,
+        'POST',
+        '/v1/chat/completions',
+        JSON.stringify({
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'hi' }],
+        }),
+      );
+      assert.equal(chat.status, 503, 'chat is gated 503 pre-dispatch');
+      assert.match(chat.body, /service_unavailable/);
+    } finally {
+      await handle.close();
+    }
+  });
+});

--- a/packages/llm-agent-server-libs/src/smart-agent/smart-server.ts
+++ b/packages/llm-agent-server-libs/src/smart-agent/smart-server.ts
@@ -43,6 +43,7 @@ import {
   type ExternalToolValidationCode,
   type IRag,
   isMcpUnavailable,
+  isReadinessReporter,
   normalizeAndValidateExternalTools,
   QueryEmbedding,
   toToolCallDelta,
@@ -973,6 +974,27 @@ export function buildMcpBridge(
     }
     return `Tool not found: ${name}`;
   };
+}
+
+/**
+ * Pre-dispatch readiness gate response: HTTP 503 with an OpenAI-shaped error,
+ * written BEFORE any pipeline run or SSE stream is opened. Used when the server is
+ * NOT_READY (MCP unavailable) so a request fails loud instead of being served
+ * tool-blind / returning a silent "(no response)".
+ */
+export function writeNotReady(res: {
+  writeHead(code: number, headers?: Record<string, string>): unknown;
+  end(body?: string): unknown;
+}): void {
+  res.writeHead(503, { 'Content-Type': 'application/json' });
+  res.end(
+    JSON.stringify({
+      error: {
+        type: 'service_unavailable',
+        message: 'MCP unavailable — server not ready',
+      },
+    }),
+  );
 }
 
 export class SmartServer {
@@ -3109,14 +3131,20 @@ export class SmartServer {
       );
       return;
     }
+    // Server readiness: derived from the agent's MCP connection strategy (it
+    // implements IReadinessReporter). No strategy / non-reporting ⇒ ready
+    // (readiness unknown). Consumed by /health and the pre-dispatch request gate.
+    const ready = isReadinessReporter(smartAgent) ? smartAgent.isReady() : true;
     if (
       req.method === 'GET' &&
       (urlPath === '/health' || urlPath === '/v1/health')
     ) {
       const status = await healthChecker.check();
-      const httpCode = status.status === 'unhealthy' ? 503 : 200;
+      // MCP-down ⇒ NOT_READY ⇒ 503 too (not just LLM-unhealthy), so a load
+      // balancer stops routing while MCP is unreachable.
+      const httpCode = status.status === 'unhealthy' || !ready ? 503 : 200;
       res.writeHead(httpCode, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify(status));
+      res.end(JSON.stringify({ ...status, ready }));
       return;
     }
     // POST /v1/messages or /messages → Anthropic adapter
@@ -3124,6 +3152,11 @@ export class SmartServer {
       req.method === 'POST' &&
       (urlPath === '/v1/messages' || urlPath === '/messages')
     ) {
+      // Pre-dispatch readiness gate: fail loud (503) BEFORE opening any stream.
+      if (!ready) {
+        writeNotReady(res);
+        return;
+      }
       const anthropicAdapter = adapterMap?.get('anthropic');
       if (!anthropicAdapter) {
         res.writeHead(404, { 'Content-Type': 'application/json' });
@@ -3145,6 +3178,11 @@ export class SmartServer {
       req.method === 'POST' &&
       (urlPath === '/v1/chat/completions' || urlPath === '/chat/completions')
     ) {
+      // Pre-dispatch readiness gate: fail loud (503) BEFORE opening any SSE stream.
+      if (!ready) {
+        writeNotReady(res);
+        return;
+      }
       await this._withSession(req, res, async (graph, sessionId, traceId) => {
         await this._handleChat(
           req,


### PR DESCRIPTION
Final phase of MCP readiness. The server now **consumes** the readiness component (Phase 4b) — no bespoke readiness machinery — to fail loud and stop routing when MCP is unreachable.

## What changed (thin)
The server reads `isReadinessReporter(smartAgent) ? smartAgent.isReady() : true` (the agent delegates to its MCP connection strategy). When NOT_READY:
- **GET `/health` → 503** with `{ ready: false }` (was 503 only on LLM-unhealthy) — a load balancer stops routing while MCP is down.
- **POST `/v1/chat/completions` and `/v1/messages` → 503** via `writeNotReady` **before** any pipeline run or SSE stream is opened (pre-dispatch gate) — fail loud instead of a tool-blind silent `(no response)`.

`writeNotReady` is a small exported helper (unit-tested).

## Architecture-principle self-check (docs/ARCHITECTURE.md)
1. Build-on-components ✓ (consumes `IReadinessReporter`; zero new readiness machinery in the server) · 2. App-is-example ✓ (the server demonstrates reading the component) · 3/4 Interfaces/ISP ✓ (small `IReadinessReporter`, detected via guard) · 5 Variation→strategy ✓ · 6 File size — the server additions are ~20 lines reading a component (the god-object is tracked separately in *Current Technical Debt*; not grown by bespoke logic here) · 7 Don't-break ✓ (no-MCP / DI-clients ⇒ ready, unchanged).

## Test Plan
- [x] Unit: `writeNotReady` → 503 `service_unavailable`.
- [x] **Integration:** a `SmartServer` with an unreachable MCP starts NOT_READY → `/health` 503 `ready:false`, `POST /v1/chat/completions` → 503 pre-dispatch.
- [x] `llm-agent-server-libs` 591/0; `npm run build` green; `npm run lint:check` exit 0.

## Feature complete
Phases 1–5 deliver: classify MCP availability errors → fail loud at every execution surface → resilient connection strategy with readiness → proactive `/health` 503 + request gate. In-flight failures (Phase 3) and proactive gating (Phase 5) together close the silent-`(no response)` gap; auto-reconnect comes from the strategy. **Next: the monolith hunt** (smart-server.ts et al.) per the recorded tech debt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)