### PR TITLE
docs(skill-plugins): inline record example uses required `id` (not `name`)

### DIFF
--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -375,8 +375,9 @@ skillPlugins:
   sources:
     - id: my-skills
       records:
-        - { group: abap, name: read-include, content: "To read an include, first read the main program, then fetch each include by name." }
-        - { group: abap, name: where-used, content: "Resolve where-used via the cross-reference tool, not by scanning sources." }
+        # `id` is required (per-record stable id); `group` is required; `name` is optional (defaults to `id`).
+        - { group: abap, id: read-include, content: "To read an include, first read the main program, then fetch each include by name." }
+        - { group: abap, id: where-used, content: "Resolve where-used via the cross-reference tool, not by scanning sources." }
 ```
 
 **Durable — Qdrant vectors + Postgres catalog + a real embedder:**


### PR DESCRIPTION
## Problem

The `skillPlugins:` quick-start in `docs/EXAMPLES.md` shows inline records as
`{ group, name, content }`. But the host validation (`makeRecordsSource` in
`packages/llm-agent-server-libs/src/smart-agent/skill-plugins-host-factory.ts`)
requires a non-empty **`id`** and fails loud without it:

```
Error: skillPlugins source '<id>': record[0] is missing a non-empty 'id'
```

`name` is optional (defaults to `id`). So copying the documented example verbatim
crashes the server at startup.

## Fix

Doc-only: use `id` in the inline-records example and note the field contract
(`id` + `group` required, `name` optional). No code change.

## Repro

A `skillPlugins:` config with `records: [{ group: abap, name: ..., content: ... }]`
(name, no id) → fail-loud at boot. Switching `name` → `id` boots clean and the
record is recalled by the controller planner.

Found while wiring `skillPlugins:` into a downstream PoC on 20.0.0.