### PR TITLE
fix(sap-aicore): per-call non-keepAlive agent in chat() — concurrency hardening (#213)

### DIFF
--- a/packages/sap-aicore-llm/src/__tests__/sap-core-ai-provider.test.ts
+++ b/packages/sap-aicore-llm/src/__tests__/sap-core-ai-provider.test.ts
@@ -177,6 +177,74 @@ describe('SapCoreAIProvider — streamChat requestConfig', () => {
 });
 
 // ---------------------------------------------------------------------------
+// chat — requestConfig (concurrency hardening, issue #213)
+// ---------------------------------------------------------------------------
+
+describe('SapCoreAIProvider — chat requestConfig', () => {
+  const fakeResponse = () => ({
+    getToolCalls: () => undefined,
+    getContent: () => 'ok',
+    getFinishReason: () => 'stop',
+    getTokenUsage: () => undefined,
+  });
+
+  it('passes a per-call httpsAgent with keepAlive:false to client.chatCompletion()', async () => {
+    const p = new SapCoreAIProvider({ model: 'test-model' });
+    let chatArgs: unknown[] = [];
+    // biome-ignore lint/suspicious/noExplicitAny: test spy
+    (p as any).createClient = () => ({
+      chatCompletion: (...args: unknown[]) => {
+        chatArgs = args;
+        return Promise.resolve(fakeResponse());
+      },
+    });
+
+    await p.chat([{ role: 'user', content: 'ping' }]);
+
+    const requestConfig = chatArgs[1] as
+      | { httpsAgent?: { keepAlive?: boolean } }
+      | undefined;
+    assert.ok(
+      requestConfig?.httpsAgent,
+      'httpsAgent should be passed to chatCompletion()',
+    );
+    // The fix: chat() must NOT reuse a shared keepAlive agent — a shared
+    // keepAlive connection lets SAP AI Core route a response to the wrong
+    // in-flight request when concurrent requests share the same XSUAA user.
+    assert.equal(
+      requestConfig.httpsAgent.keepAlive,
+      false,
+      'chat() must use a non-keepAlive agent (mirrors streamChat)',
+    );
+  });
+
+  it('uses a fresh agent instance per call (no shared agent across calls)', async () => {
+    const p = new SapCoreAIProvider({ model: 'test-model' });
+    const agents: unknown[] = [];
+    // biome-ignore lint/suspicious/noExplicitAny: test spy
+    (p as any).createClient = () => ({
+      chatCompletion: (...args: unknown[]) => {
+        agents.push(
+          (args[1] as { httpsAgent?: unknown } | undefined)?.httpsAgent,
+        );
+        return Promise.resolve(fakeResponse());
+      },
+    });
+
+    await p.chat([{ role: 'user', content: 'a' }]);
+    await p.chat([{ role: 'user', content: 'b' }]);
+
+    assert.equal(agents.length, 2);
+    assert.ok(agents[0] && agents[1], 'both calls should pass an agent');
+    assert.notEqual(
+      agents[0],
+      agents[1],
+      'each chat() call must get its own agent instance (not a shared one)',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // createClient (private — tested via casting to any)
 // ---------------------------------------------------------------------------
 

--- a/packages/sap-aicore-llm/src/sap-core-ai-provider.ts
+++ b/packages/sap-aicore-llm/src/sap-core-ai-provider.ts
@@ -68,7 +68,6 @@ export class SapCoreAIProvider extends BaseLLMProvider<SapCoreAIConfig> {
   readonly resourceGroup?: string;
   private log?: SapCoreAIConfig['log'];
   private readonly destination?: Record<string, unknown>;
-  private readonly httpsAgent: https.Agent;
   private modelsCache: IModelInfo[] | null = null;
   private modelsCacheExpiry = 0;
   private static readonly MODELS_CACHE_TTL_MS = 300_000; // 5 min
@@ -161,11 +160,6 @@ export class SapCoreAIProvider extends BaseLLMProvider<SapCoreAIConfig> {
     this.resourceGroup = config.resourceGroup;
     this.log = config.log;
 
-    this.httpsAgent = new https.Agent({
-      keepAlive: true,
-      timeout: 60_000,
-    });
-
     if (config.credentials) {
       this.destination = {
         url: config.credentials.servicUrl,
@@ -189,8 +183,13 @@ export class SapCoreAIProvider extends BaseLLMProvider<SapCoreAIConfig> {
 
       const formatted = this.formatMessages(messages);
       const client = this.createClient(formatted, tools);
+      // Each non-streaming call gets its own agent to prevent connection
+      // multiplexing. A shared keepAlive agent can cause SAP AI Core to route a
+      // response to the wrong in-flight request when concurrent requests share
+      // the same XSUAA user (mirrors streamChat's per-stream agent below).
+      const callAgent = new https.Agent({ keepAlive: false, timeout: 60_000 });
       const response = await client.chatCompletion(undefined, {
-        httpsAgent: this.httpsAgent,
+        httpsAgent: callAgent,
       });
 
       const toolCalls = response.getToolCalls();


### PR DESCRIPTION
**Concurrency hardening for the SAP AI Core provider — related to issue #213.**

## Context

Issue #213 reported that concurrent controller tool-use requests could return empty (`"(no response)"`, 0 tokens). **On current `main` (20.1.0) that symptom no longer reproduces** — I ran 2, 3, and 5 concurrent `controller` + SAP AI Core + MCP tool-use requests and every one returned a correct answer (the empty-response path was closed by the readiness/fail-loud work #201–#205 and the per-role `makeLlm` seam merged since v20.0.0).

But a root-cause investigation found a **real latent defect** worth closing defensively.

## The fix

`SapCoreAIProvider.chat()` (non-streaming) sent its request over the **shared** `keepAlive:true` `this.httpsAgent`, while `streamChat()` already uses a **fresh per-call** `keepAlive:false` agent — with an explicit comment:

> *Each stream gets its own agent to prevent connection multiplexing. A shared keepAlive agent can cause SAP AI Core to route SSE chunks to the wrong stream when multiple requests share the same XSUAA user.*

The controller subagents (executor/planner/evaluator) run **entirely on the non-streaming `chat()` path**, so it was the one execution surface still missing this mitigation. Under concurrency with a single XSUAA user (one `AICORE_SERVICE_KEY`), a shared keepAlive connection is exactly the cross-routing vector the streaming comment names.

This PR brings `chat()` to parity: a per-call `new https.Agent({ keepAlive: false, timeout: 60_000 })`; the now-unused shared `httpsAgent` field is removed. Provider-level fix, per the "provider quirks solved point-by-point" convention — no server-glue change.

## Verification

- Provider unit tests: **16/16 pass**.
- Live: **5 concurrent** `controller` + SAP AI Core + MCP tool-use requests → all 5 correct answers (0 empty), **before and after** the change — no regression; concurrency remains healthy.
- `npm run build` clean; `npm run lint:check` exit 0.

## Note on #213

The reported empty-response symptom is **not reproducible on 20.1.0**; this PR removes the latent cross-routing vector (concurrency bugs are probabilistic — 5 clean runs don't prove it can never occur). Suggest asking the reporter to re-test on 20.1.0 and closing #213 as resolved, with this hardening as belt-and-suspenders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
