### PR TITLE
docs: fix stale CLI/script references (verified vs code)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,14 +94,14 @@ npm run test
 # Development with hot-reload
 npm run dev
 
-# Smart server production entrypoint
-npm run start
+# Smart server production entrypoint (installed bin; from a checkout use
+# `npm run start --workspace @mcp-abap-adt/llm-agent-server` after a build)
+npx llm-agent
 
 # Use specific example configs
 npm run dev:ollama        # examples/docker-ollama (fully local, no API keys)
 npm run dev:deepseek      # examples/docker-deepseek
 npm run dev:sap-ai-core   # examples/docker-sap-ai-core
-npm run test
 ```
 
 ## License

--- a/docs/ASSISTANT_GUIDELINES.md
+++ b/docs/ASSISTANT_GUIDELINES.md
@@ -36,12 +36,18 @@
 
 ## Repository Commands
 
-- `npm run build`
-- `npm run dev`
-- `npm run start`
-- `npm run test:server`
-- `npm run test:all`
-- `npm run release:check`
+Root (repo-wide):
+
+- `npm run build` — compile every package
+- `npm run dev` — run the server via tsx (hot reload)
+- `npm test` — run every workspace's tests
+- `npm run lint` / `npm run lint:check` — Biome
+
+Server package (qualify with `--workspace @mcp-abap-adt/llm-agent-server`, or run from `packages/llm-agent-server`):
+
+- `npm run start --workspace @mcp-abap-adt/llm-agent-server` — `node dist/.../cli.js` (build first)
+- `npm run test:server --workspace @mcp-abap-adt/llm-agent-server`
+- `npm run release:check --workspace @mcp-abap-adt/llm-agent-server` — `tsc --noEmit`
 
 ## Documentation Sources of Truth
 

--- a/docs/CLIENT_SETUP.md
+++ b/docs/CLIENT_SETUP.md
@@ -46,14 +46,21 @@ export ANTHROPIC_BASE_URL=http://localhost:4004
 claude
 ```
 
-Or use the launcher script:
+Or use the launcher script. After a global install it is on your PATH as the
+`claude-via-agent` bin:
+
+```bash
+claude-via-agent
+```
+
+From a repo checkout the scripts live under the server package:
 
 ```bash
 # Linux / macOS
-./tools/claude-via-agent.sh
+./packages/llm-agent-server/tools/claude-via-agent.sh
 
 # Windows (PowerShell)
-./tools/claude-via-agent.ps1
+./packages/llm-agent-server/tools/claude-via-agent.ps1
 ```
 
 The launcher reads `.env` from the project root and auto-selects the pipeline config based on `LLM_PROVIDER`:
@@ -67,7 +74,8 @@ The launcher reads `.env` from the project root and auto-selects the pipeline co
 To override the auto-selected pipeline, pass `--config`:
 
 ```bash
-./tools/claude-via-agent.sh --config pipelines/sap-ai-core.yaml
+claude-via-agent --config pipelines/sap-ai-core.yaml
+# from a checkout: ./packages/llm-agent-server/tools/claude-via-agent.sh --config pipelines/sap-ai-core.yaml
 ```
 
 To verify the agent is running with the correct model, check the startup log line:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -8,8 +8,8 @@ This guide covers production deployment patterns for the SmartAgent monorepo (`@
 # 1. Install
 npm install -g @mcp-abap-adt/llm-agent-server
 
-# 2. Generate config
-npx llm-agent --init   # creates smart-server.yaml
+# 2. Generate config — the first run with no config writes a template and exits
+npx llm-agent   # creates smart-server.yaml with defaults, then exits
 
 # 3. Set environment variables
 #    Place all credentials in a single .env file at the project root.

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -710,11 +710,20 @@ subagent pair and loop until the reviewer approves. References
 
 ## Current npm scripts
 
+Root scripts (run from the repo root):
+
 ```bash
-npm run build
-npm run dev
-npm run start
-npm run test:server
-npm run test:all
-npm run release:check
+npm run build     # compile every package
+npm run dev       # run the server via tsx (hot reload)
+npm test          # run every workspace's tests
+npm run lint      # Biome check + autofix
+```
+
+Server-package scripts — qualify with `--workspace @mcp-abap-adt/llm-agent-server`
+(or run from `packages/llm-agent-server`):
+
+```bash
+npm run start        --workspace @mcp-abap-adt/llm-agent-server   # node dist/.../cli.js (build first)
+npm run test:server  --workspace @mcp-abap-adt/llm-agent-server
+npm run release:check --workspace @mcp-abap-adt/llm-agent-server  # tsc --noEmit
 ```

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -422,42 +422,22 @@ When the embedder circuit opens, RAG stores automatically fall back to `InMemory
 
 ## Benchmarking
 
-### RAG evaluation
+The repository does not currently ship a packaged benchmark harness (no
+`test:rag-eval` / `test:classifier-bench` npm scripts or an `e2e-rag-search`
+runner). Evaluate against your own golden corpus using the metrics below; the
+building blocks — configurable `IToolSelectionStrategy` / `ISearchStrategy`,
+swappable embedders, and the classifier — are all injectable for offline
+measurement (see [docs/INTEGRATION.md](INTEGRATION.md)).
 
-Run the golden corpus evaluation to measure retrieval quality:
-
-```bash
-npm run test:rag-eval    # Golden corpus (16 entries, 8 queries, all strategies)
-npm run test:mcp-eval    # MCP tools benchmark (40 tools, 15+ queries, all strategies)
-```
-
-Metrics: MRR (Mean Reciprocal Rank), precision@1, recall@k.
-
-### E2E search benchmark
-
-Test with real LLM translation + real embeddings against live MCP server:
-
-```bash
-node --import tsx/esm scripts/e2e-rag-search.ts
-```
-
-Requires: DeepSeek API key, Ollama with `bge-m3`, MCP server on localhost:3001.
-
-### Classifier benchmark
-
-Run the intent classification benchmark:
-
-```bash
-npm run test:classifier-bench
-```
-
-Metrics: type accuracy, count accuracy, per-type precision/recall across 20+ golden corpus entries covering all 5 intent types (action, fact, chat, state, feedback).
-
-### Full suite
-
-```bash
-npm run test:all   # Runs all tests including RAG eval and classifier bench
-```
+- **RAG / tool retrieval quality** — score retrieval over a labelled query→tool
+  (or query→document) set with **MRR** (Mean Reciprocal Rank), **precision@1**,
+  and **recall@k**. Compare embedders and search strategies on the same corpus.
+- **E2E search** — for a realistic measurement, run the full path (LLM query
+  translation + real embeddings against a live MCP catalog) and score the ranked
+  tool list against the expected tool per query.
+- **Intent classifier** — score the classifier over a labelled corpus with type
+  accuracy, count accuracy, and per-type precision/recall across the intent types
+  (action, fact, chat, state, feedback).
 
 ## Coordinator orchestration: when it pays off
 


### PR DESCRIPTION
Fixes documentation review findings — all verified against the actual code/package.json before editing.

**P1**
- `docs/DEPLOYMENT.md` — removed `npx llm-agent --init` (no such option; strict `parseArgs`). Real first run: `npx llm-agent` with no config writes `smart-server.yaml` and exits (`cli.ts:180/189`).
- `README.md`, `docs/EXAMPLES.md`, `docs/ASSISTANT_GUIDELINES.md` — root `package.json` has no `start` / `test:server` / `test:all` / `release:check`. Split into real **root** scripts (`build`, `dev`, `test`, `lint`) vs **server-package** scripts qualified with `--workspace @mcp-abap-adt/llm-agent-server` (`start`, `test:server`, `release:check`). `test:all` doesn't exist anywhere → root `npm test` (all workspaces). Also dropped a duplicate `npm run test` in the README block.

**P2**
- `docs/CLIENT_SETUP.md` — launcher is the installed `claude-via-agent` bin (or `packages/llm-agent-server/tools/claude-via-agent.{sh,ps1}`), not a root `./tools/` dir (two occurrences fixed).
- `docs/PERFORMANCE.md` — the Benchmarking section referenced non-existent scripts (`test:rag-eval`, `test:mcp-eval`, `test:classifier-bench`, `test:all`, `scripts/e2e-rag-search.ts`). Rewritten to state no packaged harness ships and to describe the metrics (MRR, precision@1, recall@k; classifier accuracy) to measure against your own corpus.

No product/code change. Verified: root & server `package.json` scripts, `cli.ts` arg parsing + template generation, `packages/llm-agent-server/tools/` contents + `bin`, and absence of the eval scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)