### PR TITLE
docs(#244): user-facing multi-MCP-server config + tool namespacing

### DIFF
--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -134,6 +134,40 @@ mcp:
 
 You can also convey server-side intent (e.g., "willing to wait longer") by passing a custom `IMcpRequestHeadersStrategy` programmatically via `builder.withMcpRequestHeadersStrategy(...)`.
 
+### MCP Configuration — Multiple Servers & Tool Namespacing
+
+`mcp:` accepts a **list** of servers. Give each an optional `name` for readable,
+durable tool prefixes:
+
+```yaml
+mcp:
+  - name: erp                                   # ^[a-zA-Z0-9_-]+$, unique per server
+    type: http
+    url: http://localhost:3001/mcp/stream/http
+  - name: crm
+    type: http
+    url: http://localhost:3002/mcp/stream/http
+```
+
+When two connected servers expose a tool with the **same name** (e.g. both offer
+`Search`), the runtime keeps both individually callable by exposing **namespaced**
+names to the model:
+
+- Colliding name → `name__tool` (e.g. `erp__Search`, `crm__Search`). Without a
+  `name`, the fallback prefix is the server's slot index: `s0__Search`, `s1__Search`.
+- A **unique** tool name stays **bare** (`Search`) — single-server setups are
+  unchanged.
+- The model sees the namespaced name; the call is routed to the right server with
+  the **original** name (`Search`) on the wire. No tool is silently dropped.
+
+`name` is validated at startup: charset `^[a-zA-Z0-9_-]+$`, non-empty, and unique
+across servers (`:` is rejected — it is illegal in an LLM tool name). To swap the
+naming rule entirely, inject a custom `IToolNamespace` (see
+[INTEGRATION.md → IToolNamespace](INTEGRATION.md#itoolnamespace)).
+
+> The snapshot of exposed names is built once at startup. A tool that first appears
+> after a mid-session MCP reconnect is picked up on the next server start.
+
 ## Programmatic Examples
 
 ### Dynamic RAG stores

--- a/packages/llm-agent-server/src/mcp/README.md
+++ b/packages/llm-agent-server/src/mcp/README.md
@@ -148,7 +148,7 @@ mcp:
     type: http
     url: http://localhost:3001/mcp/stream/http
   - name: crm
-    type: stream-http
+    type: http
     url: http://localhost:3002/mcp/stream/http
 ```
 
@@ -163,8 +163,7 @@ individually callable (before, only the first server's copy was reachable):
 - Colliding name → `${name}__${tool}` (e.g. `erp__Search` / `crm__Search`). With
   no `name`, the fallback prefix is the server's slot index: `s0__Search`,
   `s1__Search`.
-- A **unique** tool name stays **bare** — single-server deployments are byte-for-byte
-  unchanged.
+- A **unique** tool name stays **bare** — single-server tool names remain unchanged.
 - The exposed (namespaced) name is what the model selects; the call is dispatched to
   the owning server with the **original** tool name on the wire.
 

--- a/packages/llm-agent-server/src/mcp/README.md
+++ b/packages/llm-agent-server/src/mcp/README.md
@@ -136,3 +136,40 @@ try {
   //   - url (will auto-detect transport)
 }
 ```
+
+## Multiple MCP Servers & Tool Namespacing
+
+The server-level `mcp:` config accepts either a single server or a **list**. Each
+entry may carry an optional `name`:
+
+```yaml
+mcp:
+  - name: erp                                   # optional label
+    type: http
+    url: http://localhost:3001/mcp/stream/http
+  - name: crm
+    type: stream-http
+    url: http://localhost:3002/mcp/stream/http
+```
+
+- **`name`** — optional per-server label. Validated at startup: `^[a-zA-Z0-9_-]+$`,
+  non-empty, and **unique** across servers. Used as the tool-name prefix on a
+  collision (see below); has no effect on transport/routing otherwise.
+
+When more than one connected server exposes a tool with the **same name**, the
+runtime exposes **namespaced** names to the model so every colliding tool stays
+individually callable (before, only the first server's copy was reachable):
+
+- Colliding name → `${name}__${tool}` (e.g. `erp__Search` / `crm__Search`). With
+  no `name`, the fallback prefix is the server's slot index: `s0__Search`,
+  `s1__Search`.
+- A **unique** tool name stays **bare** — single-server deployments are byte-for-byte
+  unchanged.
+- The exposed (namespaced) name is what the model selects; the call is dispatched to
+  the owning server with the **original** tool name on the wire.
+
+The naming rule is a swappable strategy (`IToolNamespace`) — inject a custom one via
+`SmartAgentBuilder.withToolNamespace(...)` or `BuildAgentDeps.toolNamespace`. Custom
+connectors that need to carry per-server labels/descriptors implement the additive
+`BuildAgentDeps.connectMcpWithDescriptors` seam (the bare `connectMcp` seam still
+works, with slot-index prefixes).


### PR DESCRIPTION
Follow-up to #249 — completes the **user-facing** documentation for #244 before the v20.9.0 publish.

#249 documented the strategy/DI (INTEGRATION.md → `IToolNamespace`), the architecture (ARCHITECTURE.md), and the symptom→fix (TROUBLESHOOTING.md), but **not** the user-facing config: how to list multiple `mcp[]` servers with `name` labels and what colliding tools look like to the model. This adds that.

- **docs/EXAMPLES.md** — new "MCP Configuration — Multiple Servers & Tool Namespacing" subsection: the `mcp:` list form with `name:`, and the exposed-name behaviour (`name__tool` / `s0__tool` on collision, bare when unique, original name on the wire).
- **packages/llm-agent-server/src/mcp/README.md** — new "Multiple MCP Servers & Tool Namespacing" section in the MCP config reference: the `name` field (validation + role), the namespacing rule, and the `IToolNamespace` / `connectMcpWithDescriptors` DI seams.

All concrete claims verified against source: separator `__`, charset `^[a-zA-Z0-9_-]+$`, prefix = `mcp[].name` else `s${slotIndex}` (`tool-namespace.ts`, `build-namespaced-tools.ts`), `SmartServerMcpConfig.name?` (`smart-server.ts:193`). Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
