### PR TITLE
test(#252): collision-throws tests at the 2 mergeOfferedTools call sites

### DIFF
--- a/packages/llm-agent-libs/src/coordinator/stepper/__tests__/cyclic-react-executor.test.ts
+++ b/packages/llm-agent-libs/src/coordinator/stepper/__tests__/cyclic-react-executor.test.ts
@@ -769,6 +769,34 @@ test('#167: client externalTools are MERGED with seeded MCP tools and offered to
   );
 });
 
+test('#252: mergeOfferedTools collision — a client externalTools name equal to a seeded internal tool name throws (fail-fast)', async () => {
+  // Same shape as the #167 disjoint-name test above, but the client-provided
+  // external tool name now COLLIDES with the internal (toolsRag-seeded) tool
+  // name. mergeOfferedTools must fail fast here so classifyToolCalls can never
+  // double-classify the name at call time.
+  const { rag } = knowledgeStub();
+  const exec = new CyclicReActExecutor({
+    llm: scriptedLlm([{ content: 'unused' }]) as never,
+    callMcp: mcp({}).call,
+    component: 'tool-loop',
+    maxIterations: 10,
+  });
+  await assert.rejects(
+    () =>
+      exec.execute({
+        prompt: 'review and save a file',
+        tools: [], // no dispatcher tools → executor seeds MCP from toolsRag
+        externalTools: [{ name: 'GetProgram' }] as never, // collides with the seeded internal tool
+        knowledgeRag: rag as never,
+        toolsRag: toolsStub({ GetProgram: { name: 'GetProgram' } }) as never,
+        budget: { depthRemaining: 0, tokens: new TokenLedger(100000) },
+        ...META_BASE,
+      }),
+    /both an internal MCP tool/,
+    'mergeOfferedTools must throw on the name collision',
+  );
+});
+
 test('scenario: a multi-fetch sequence writes a SEPARATE knowledge-RAG artifact per tool result', async () => {
   // Mirrors the real review shape (read object → list parts → read each part)
   // with neutral tool names: every tool RESULT must be persisted as its own

--- a/packages/llm-agent-server-libs/src/smart-agent/controller/__tests__/controller-coordinator-handler.test.ts
+++ b/packages/llm-agent-server-libs/src/smart-agent/controller/__tests__/controller-coordinator-handler.test.ts
@@ -576,6 +576,41 @@ describe('ControllerCoordinatorHandler', () => {
     );
   });
 
+  it('#252: mergeOfferedTools collision — a selectTools-relevant internal tool name equal to a ctx.externalTools name rejects execute()', async () => {
+    // Same shape as I2 (external routed via per-request ctx.externalTools), but
+    // the semantic selector now surfaces an INTERNAL tool with the SAME name as
+    // the client-provided external tool. mergeOfferedTools must fail fast so
+    // classifyToolCalls can never double-classify the name at call time.
+    const h = harness({
+      evaluator: [{ kind: 'content', content: 'Goal' }],
+      planner: [
+        {
+          kind: 'content',
+          content: JSON.stringify({
+            plan: [{ name: 's1', instructions: 'do' }],
+          }),
+        },
+      ],
+      executor: [], // unreachable — the merge throws before the executor round
+      selectTools: [{ name: 'ExtTool', description: '', inputSchema: {} }],
+    });
+    const handler = new ControllerCoordinatorHandler(h.deps);
+    const { ctx } = fakeCtx({
+      externalTools: [{ name: 'ExtTool' }] as never,
+    });
+
+    await assert.rejects(
+      () => handler.execute(ctx, {}, undefined),
+      /both an internal MCP tool/,
+      'mergeOfferedTools must throw on the name collision',
+    );
+    assert.equal(
+      h.mcpCalls.length,
+      0,
+      'no MCP call — the merge throws before any executor round',
+    );
+  });
+
   it('I1: recalled session-memory artifacts are injected into the executor messages', async () => {
     const seenMessages: Message[][] = [];
     const capturingExecutor: ISubagentClient & { calls: number } = {


### PR DESCRIPTION
Closes #252.

Follow-up to #244 (non-blocking coverage gap flagged in the final whole-branch review). `mergeOfferedTools`'s internal↔external collision fail-fast is unit-tested in `merge-offered-tools.test.ts`, but its two real call sites had only **disjoint-name** integration coverage. This adds a dedicated **collision-throws** test at each:

- `packages/llm-agent-libs/src/coordinator/stepper/cyclic-react-executor.ts` (:214) — seeds an internal `GetProgram` then supplies `externalTools: [{name:'GetProgram'}]` → the run throws the `mergeOfferedTools` diagnostic.
- `packages/llm-agent-server-libs/src/smart-agent/controller/controller-coordinator-handler.ts` (:1298) — internal `ExtTool` + colliding `ctx.externalTools` → throws before any executor round (`mcpCalls === 0`).

Each reuses the file's existing disjoint-name companion harness (unmodified). Test-only; no production change. libs 919/919; cyclic 26/26; controller-coordinator 70/70; build + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)