### PR TITLE
docs: refresh /health sample version to 20.9.0 (DEPLOYMENT.md)

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -258,7 +258,7 @@ curl http://localhost:4004/health
 {
   "status": "healthy",
   "uptime": 3600000,
-  "version": "20.7.0",
+  "version": "20.9.0",
   "timestamp": "2026-07-16T10:00:00.000Z",
   "components": {
     "llm": true,


### PR DESCRIPTION
The `/health` example in `docs/DEPLOYMENT.md` still showed `"version": "20.7.0"` while the current release is 20.9.0. A version in a sample response is a factual claim, not cosmetic — refreshed to 20.9.0.

Verified it's the only such occurrence: other version strings in docs are correct historical references (`@12.0.0`, `@11.0.0–11.1.0`, `since v20.4.0`, etc.). Doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)