### PR TITLE
fix(#243): control-failure→replan no longer dead-ends with (no response) on the live path (empty-content embed poison)

### DIFF
--- a/packages/llm-agent-server-libs/src/smart-agent/__tests__/embedder-knowledge-index.test.ts
+++ b/packages/llm-agent-server-libs/src/smart-agent/__tests__/embedder-knowledge-index.test.ts
@@ -239,6 +239,86 @@ describe('makeKnowledgeSemanticIndex — bounded embed input (large-result guard
   });
 });
 
+describe('makeKnowledgeSemanticIndex — empty/whitespace content skip (#243)', () => {
+  it('empty content is NOT embedded and NOT returned by ranked query', async () => {
+    const embedTexts: string[] = [];
+    const recording = {
+      embed: async (t: string) => {
+        embedTexts.push(t);
+        return { vector: VOCAB[t.trim().toLowerCase()] ?? [0, 0, 0] };
+      },
+    } as never;
+    const idx = makeKnowledgeSemanticIndex(recording);
+    await idx.upsert('s', {
+      content: '',
+      metadata: meta({ artifactType: 'step-result', runId: 'R' }),
+    });
+    assert.equal(
+      embedTexts.length,
+      0,
+      'embedder never called for empty content',
+    );
+    const hits = await idx.query('s', 'alpha', 10, { runId: 'R' });
+    assert.equal(
+      hits.length,
+      0,
+      'empty-content entry not returned by ranked query',
+    );
+  });
+
+  it('whitespace-only content (spaces / newlines / tabs) is NOT embedded and NOT returned by ranked query', async () => {
+    const embedTexts: string[] = [];
+    const recording = {
+      embed: async (t: string) => {
+        embedTexts.push(t);
+        return { vector: VOCAB[t.trim().toLowerCase()] ?? [0, 0, 0] };
+      },
+    } as never;
+    const idx = makeKnowledgeSemanticIndex(recording);
+    await idx.upsert('s', {
+      content: '   ',
+      metadata: meta({ artifactType: 'step-result', runId: 'R' }),
+    });
+    await idx.upsert('s', {
+      content: '\n\t\n',
+      metadata: meta({ artifactType: 'step-result', runId: 'R' }),
+    });
+    assert.equal(
+      embedTexts.length,
+      0,
+      'embedder never called for whitespace-only content',
+    );
+    const hits = await idx.query('s', 'alpha', 10, { runId: 'R' });
+    assert.equal(
+      hits.length,
+      0,
+      'whitespace-only entries not returned by ranked query',
+    );
+  });
+
+  it('non-empty content is still embedded exactly as before (no regression)', async () => {
+    const embedTexts: string[] = [];
+    const recording = {
+      embed: async (t: string) => {
+        embedTexts.push(t);
+        return { vector: VOCAB[t.trim().toLowerCase()] ?? [0, 0, 0] };
+      },
+    } as never;
+    const idx = makeKnowledgeSemanticIndex(recording);
+    await idx.upsert('s', {
+      content: 'alpha',
+      metadata: meta({ artifactType: 'step-result', runId: 'R' }),
+    });
+    assert.ok(
+      embedTexts.includes('alpha'),
+      'embedder called with the non-empty text',
+    );
+    const hits = await idx.query('s', 'alpha', 10, { runId: 'R' });
+    assert.equal(hits.length, 1, 'non-empty entry is ranked and returned');
+    assert.equal(hits[0].content, 'alpha');
+  });
+});
+
 describe('JsonlKnowledgeBackend index lifecycle', () => {
   const withDir = async (fn: (dir: string) => Promise<void>) => {
     const dir = await mkdtemp(join(tmpdir(), 'ctrl-idx-'));

--- a/packages/llm-agent-server-libs/src/smart-agent/controller/__tests__/control-failure-embed-repro.test.ts
+++ b/packages/llm-agent-server-libs/src/smart-agent/controller/__tests__/control-failure-embed-repro.test.ts
@@ -11,7 +11,10 @@ import type {
   Result,
 } from '@mcp-abap-adt/llm-agent';
 import type { PipelineContext } from '@mcp-abap-adt/llm-agent-libs';
-import { KnowledgeRag, SessionRequestLogger } from '@mcp-abap-adt/llm-agent-libs';
+import {
+  KnowledgeRag,
+  SessionRequestLogger,
+} from '@mcp-abap-adt/llm-agent-libs';
 import { makeKnowledgeSemanticIndex } from '../../embedder-knowledge-index.js';
 import { JsonlKnowledgeBackend } from '../../jsonl-knowledge-backend.js';
 import {
@@ -200,7 +203,10 @@ describe('#243 REOPENED — control-failure write hits a real embedder-backed RA
     );
 
     const body = surfacedContent(captured);
-    assert.ok(body, 'a body must have been surfaced (captured a content chunk)');
+    assert.ok(
+      body,
+      'a body must have been surfaced (captured a content chunk)',
+    );
     assert.notEqual(
       body.trim(),
       '',

--- a/packages/llm-agent-server-libs/src/smart-agent/controller/__tests__/control-failure-embed-repro.test.ts
+++ b/packages/llm-agent-server-libs/src/smart-agent/controller/__tests__/control-failure-embed-repro.test.ts
@@ -1,0 +1,218 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { after, before, describe, it } from 'node:test';
+import type {
+  IEmbedder,
+  KnowledgeEntry,
+  LlmStreamChunk,
+  LlmTool,
+  Result,
+} from '@mcp-abap-adt/llm-agent';
+import type { PipelineContext } from '@mcp-abap-adt/llm-agent-libs';
+import { KnowledgeRag, SessionRequestLogger } from '@mcp-abap-adt/llm-agent-libs';
+import { makeKnowledgeSemanticIndex } from '../../embedder-knowledge-index.js';
+import { JsonlKnowledgeBackend } from '../../jsonl-knowledge-backend.js';
+import {
+  ControllerCoordinatorHandler,
+  type ControllerHandlerDeps,
+} from '../controller-coordinator-handler.js';
+import { hydrateBundle } from '../session-bundle.js';
+import type { ISubagentClient } from '../subagent-client.js';
+import type { ControllerConfig, SubagentResult } from '../types.js';
+
+/**
+ * #243 REOPENED — reproduction of the LIVE control-failure → replan dead-end.
+ *
+ * `writeControlFailure` (controller-coordinator-handler.ts) writes a
+ * `step-result` artifact with `content: ''`. On the live path the knowledge
+ * backend is `JsonlKnowledgeBackend` wired with an embedder-backed semantic
+ * index (`makeKnowledgeBackend` → `makeKnowledgeSemanticIndex(embedder)`,
+ * see smart-server.ts `buildKnowledgeBackend`). A REAL embedder (e.g. SAP AI
+ * Core) rejects empty text with an HTTP 400. This test wires that SAME
+ * production chain — JsonlKnowledgeBackend + makeKnowledgeSemanticIndex +
+ * an embedder fake that throws on empty/whitespace text — and drives the
+ * exact control-failure → replan scenario used by
+ * `controller-no-response.test.ts` "Symptom A". It asserts the CORRECT
+ * behavior (a non-empty answer surfacing the captured tool error) which is
+ * expected to FAIL on main.
+ */
+
+type Captured = Result<LlmStreamChunk, unknown>;
+
+function fakeCtx(overrides: Partial<PipelineContext> = {}): {
+  ctx: PipelineContext;
+  captured: Captured[];
+} {
+  const captured: Captured[] = [];
+  const requestLogger = new SessionRequestLogger();
+  requestLogger.startRequest('sess-1');
+  const ctx = {
+    sessionId: 'sess-1',
+    textOrMessages: 'do the thing',
+    options: undefined,
+    externalResults: undefined,
+    requestLogger,
+    yield: (c: Captured) => {
+      captured.push(c);
+    },
+    ...overrides,
+  } as unknown as PipelineContext;
+  return { ctx, captured };
+}
+
+/** Subagent stub backed by a scripted queue; each send() shifts one result. */
+function scriptedClient(queue: SubagentResult[]): ISubagentClient & {
+  calls: number;
+} {
+  let calls = 0;
+  return {
+    get calls() {
+      return calls;
+    },
+    async send() {
+      calls++;
+      const next = queue.shift();
+      if (!next) return { kind: 'content', content: '' };
+      return next;
+    },
+  };
+}
+
+function baseConfig(
+  over: Partial<ControllerConfig['budgets']> = {},
+): ControllerConfig {
+  return {
+    subagents: {} as never,
+    targetState: { strategy: 'semantic-distance', distanceThreshold: 0.9 },
+    sessionMemory: { collection: 'controller' },
+    budgets: { maxSteps: 10, maxRetries: 2, maxRewinds: 3, ...over },
+  };
+}
+
+const toolCall = (
+  name: string,
+  args: Record<string, unknown>,
+): SubagentResult => ({
+  kind: 'tool_call',
+  toolCalls: [{ id: 'c1', name, arguments: args }],
+});
+
+function surfacedContent(
+  captured: ReturnType<typeof fakeCtx>['captured'],
+): string | undefined {
+  const c = captured.find(
+    (x): x is { ok: true; value: { content: string } } =>
+      x.ok === true &&
+      typeof (x.value as { content?: unknown }).content === 'string',
+  );
+  return c?.value.content;
+}
+
+/** Embedder fake mirroring a REAL provider (e.g. SAP AI Core): rejects
+ *  empty/whitespace text with an error resembling the live 400, embeds
+ *  non-empty text fine. */
+function makeEmptyRejectingEmbedder(): IEmbedder & { calls: KnowledgeEntry[] } {
+  const calls: KnowledgeEntry[] = [];
+  return {
+    calls,
+    async embed(text: string) {
+      if (text.trim().length === 0) {
+        throw new Error('400 Bad Request: The text content is empty');
+      }
+      return { vector: [1, 0, 0] };
+    },
+  };
+}
+
+describe('#243 REOPENED — control-failure write hits a real embedder-backed RAG', () => {
+  let logDir: string;
+
+  before(async () => {
+    logDir = await mkdtemp(join(tmpdir(), 'issue243-repro-'));
+  });
+
+  after(async () => {
+    await rm(logDir, { recursive: true, force: true });
+  });
+
+  it('Symptom A with a LIVE-shaped RAG (JsonlKnowledgeBackend + embedder-backed semantic index): control-failure(tool error) → replan → finalizer EMPTY must still surface the real tool error, never (no response)', async () => {
+    const embedder = makeEmptyRejectingEmbedder();
+    const semantic = makeKnowledgeSemanticIndex(embedder);
+    const backend = new JsonlKnowledgeBackend(logDir, semantic);
+    const rag = new KnowledgeRag(backend, 'sess-1');
+    const mcpCalls: Array<{ name: string; args: unknown }> = [];
+
+    const deps: ControllerHandlerDeps = {
+      evaluator: scriptedClient([
+        { kind: 'content', content: 'Goal: read a class, report errors' },
+      ]),
+      planner: scriptedClient([
+        {
+          kind: 'content',
+          content: JSON.stringify({
+            plan: [{ name: 's1', instructions: 'read' }],
+          }),
+        },
+        { kind: 'content', content: JSON.stringify({ plan: [] }) }, // replan → empty
+        { kind: 'content', content: '' }, // finalizer → EMPTY (no progress)
+      ]),
+      executor: scriptedClient([toolCall('ReadClass', { name: 'ZZ_QX9B7' })]),
+      backend,
+      knowledgeRagFor: () => rag,
+      embedder,
+      callMcp: async (name, args) => {
+        mcpCalls.push({ name, args });
+        return { text: 'Class ZZ_QX9B7 not found', isError: true };
+      },
+      selectTools: async (): Promise<LlmTool[]> => [
+        { name: 'ReadClass', description: '', inputSchema: {} },
+      ],
+      isExternalTool: () => false,
+      config: baseConfig(),
+      models: { evaluator: 'm-eval', planner: 'm-plan', executor: 'm-exec' },
+    };
+
+    const { ctx, captured } = fakeCtx();
+
+    let thrown: unknown;
+    try {
+      await new ControllerCoordinatorHandler(deps).execute(ctx, {}, undefined);
+    } catch (e) {
+      thrown = e;
+    }
+
+    // Diagnostic dump — captured in the phase-1 report regardless of outcome.
+    // eslint-disable-next-line no-console
+    console.log('captured chunks:', JSON.stringify(captured, null, 2));
+    if (thrown) {
+      // eslint-disable-next-line no-console
+      console.log('execute() THREW:', thrown);
+    }
+
+    assert.equal(
+      thrown,
+      undefined,
+      `execute() must not reject — the control-failure write must not crash the run (it did: ${String(
+        thrown,
+      )})`,
+    );
+
+    const body = surfacedContent(captured);
+    assert.ok(body, 'a body must have been surfaced (captured a content chunk)');
+    assert.notEqual(
+      body.trim(),
+      '',
+      'never (no response) / GENERIC_NO_ANSWER — the empty-embed 400 must not swallow the captured tool error',
+    );
+    assert.match(
+      body,
+      /Class ZZ_QX9B7 not found/,
+      `expected the captured tool error to surface; got: ${JSON.stringify(body)}`,
+    );
+
+    const bundle = await hydrateBundle(backend, 'sess-1');
+    assert.ok(bundle.runId, 'a runId must have been minted');
+  });
+});

--- a/packages/llm-agent-server-libs/src/smart-agent/controller/controller-coordinator-handler.ts
+++ b/packages/llm-agent-server-libs/src/smart-agent/controller/controller-coordinator-handler.ts
@@ -1329,7 +1329,13 @@ export class ControllerCoordinatorHandler implements IStageHandler {
             stepId: step.stepId,
             digest: reason.slice(0, cfg.maxDigestChars ?? 500),
             writeOrdinal: bundle.writeOrdinal,
-            content: '',
+            // NEVER empty: an empty `content` is handed to the RAG's embedder,
+            // and a real embedder (e.g. SAP AI Core) rejects empty text with an
+            // HTTP 400 — poisoning the store and dead-ending the run (#243). The
+            // failure `reason` is itself a meaningful, always non-empty string
+            // (see the `noteFor`/literal-reason callers above) and improves
+            // recall over an empty record.
+            content: reason,
           },
           ctx.options,
         );

--- a/packages/llm-agent-server-libs/src/smart-agent/embedder-knowledge-index.ts
+++ b/packages/llm-agent-server-libs/src/smart-agent/embedder-knowledge-index.ts
@@ -64,6 +64,13 @@ export function makeKnowledgeSemanticIndex(
     ): Promise<void> {
       // Skip infrastructure artifact types — never embed, never index.
       if (skipArtifactTypes.includes(e.metadata.artifactType)) return;
+      // Skip empty/whitespace content — a real embedder (e.g. SAP AI Core)
+      // rejects empty text with an HTTP 400, which would poison the index (the
+      // in-memory upsert throws, and a later lazy JsonlKnowledgeBackend rebuild
+      // re-throws it out of an unrelated call). The entry is still durably
+      // persisted by the backend's own append/scan; it simply never ranks in
+      // semantic recall, which is correct — there is no text to rank on. #243.
+      if (e.content.trim().length === 0) return;
       const { vector } = await embedder.embed(embedInput(e.content), options);
       const arr = bySession.get(sid);
       if (arr) arr.push({ entry: e, vector });


### PR DESCRIPTION
Reopens/fixes #243. The #245 fix (empty-success terminal guard) was correct but **never reached** on the live path — a distinct, live-only root cause slipped past its in-memory-RAG tests.

## Root cause (reproduced)
The controller's failed-step write `writeControlFailure` persisted a RAG step-result artifact with **empty `content: ''`**. A real embedder (SAP AI Core) rejects empty text with HTTP 400 ("The text content is empty"). On the live path this is swallowed (`[jsonl-index] will rebuild lazily`) and the run dead-ends with `(no response)` / usage {0,0,0} — the #245 guard is never reached because control never gets to a terminal writer. The in-memory RAG in the #245 tests never embeds, so CI stayed green.

RED reproduction committed (`control-failure-embed-repro.test.ts`): an empty-rejecting embedder in the real control-failure→replan path reproduces the dead-end/crash; GREEN after the fix.

## Fix (root cause + defense-in-depth)
- **(a)** `writeControlFailure` embeds the failure **reason** (already present as `note`/`digest`) instead of `''` — non-empty, and it *improves* recall (the planner also gets the failure via `plannerPrivate` + the typed `controlFailure`, unchanged).
- **(b)** `makeKnowledgeSemanticIndex.upsert` — the single chokepoint to `embedder.embed` — now **skips empty/whitespace content** (durable entry still stored; only the vector is skipped). This structurally backstops **every** control-failure path, including the ones whose reason is dynamic (an MCP tool's error text or a swappable `IStepExecutionControl` — either could be empty). Blast-radius verified safe for all upsert callers (entry preserved before upsert; only ranked recall omits empty, which is correct).

## Verification
- Repro RED→GREEN; guard-(b) unit test 18/18 (confirmed load-bearing by neutering the guard); pre-existing #243 tests 10/10; full controller `__tests__/` 301/301.
- Build clean; lint clean of new findings; `llm-agent-libs` 919/919, `llm-agent-server-libs` 894/896 (2 pre-existing skips) — fail 0.

## Follow-up (separate)
#259 — `jsonl-knowledge build()`'s per-entry re-embed has no per-entry try/catch, and the failed path should reach the terminal guard even if a RAG write fails (reporter's fix-direction #2) — moot for the empty-content trigger, open for any other embed failure.

**Live gate pending** (the step skipped on #245 that let this regress) — see PR discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)