### PR TITLE
fix(#259): knowledge-write path survives an embed failure (never crashes execute())

### DIFF
--- a/packages/llm-agent-libs/src/rag/__tests__/knowledge-rag.test.ts
+++ b/packages/llm-agent-libs/src/rag/__tests__/knowledge-rag.test.ts
@@ -105,9 +105,7 @@ test('#259: InMemoryKnowledgeBackend.put() survives a semantic upsert failure â€
   const kr = new KnowledgeRag(backend, 'session-1');
 
   // put() must NOT reject even though the semantic upsert throws.
-  await assert.doesNotReject(() =>
-    kr.write({ content: 'A', metadata: META }),
-  );
+  await assert.doesNotReject(() => kr.write({ content: 'A', metadata: META }));
 
   // The entry is still durably retained even though it could not be indexed.
   const durable = await backend.scan('session-1');

--- a/packages/llm-agent-libs/src/rag/__tests__/knowledge-rag.test.ts
+++ b/packages/llm-agent-libs/src/rag/__tests__/knowledge-rag.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
+import type { CallOptions, KnowledgeEntry } from '@mcp-abap-adt/llm-agent';
 import {
   InMemoryKnowledgeBackend,
   KnowledgeRag,

--- a/packages/llm-agent-libs/src/rag/__tests__/knowledge-rag.test.ts
+++ b/packages/llm-agent-libs/src/rag/__tests__/knowledge-rag.test.ts
@@ -91,6 +91,30 @@ test('ToolsRag delegates query and lookup', async () => {
   assert.equal(notFound, undefined);
 });
 
+test('#259: InMemoryKnowledgeBackend.put() survives a semantic upsert failure — entry retained (durable), unindexed, does not reject', async () => {
+  const semantic = {
+    async upsert(_sid: string, _e: KnowledgeEntry, _options?: CallOptions) {
+      throw new Error('embed rejected');
+    },
+    async query(_sid: string, _text: string) {
+      return [] as readonly KnowledgeEntry[];
+    },
+    deleteSession() {},
+  };
+  const backend = new InMemoryKnowledgeBackend(semantic);
+  const kr = new KnowledgeRag(backend, 'session-1');
+
+  // put() must NOT reject even though the semantic upsert throws.
+  await assert.doesNotReject(() =>
+    kr.write({ content: 'A', metadata: META }),
+  );
+
+  // The entry is still durably retained even though it could not be indexed.
+  const durable = await backend.scan('session-1');
+  assert.equal(durable.length, 1);
+  assert.equal(durable[0].content, 'A');
+});
+
 test('#Phase2: hasArtifact + listArtifacts track fetched identities (dedup)', async () => {
   const backend = new InMemoryKnowledgeBackend();
   const kr = new KnowledgeRag(backend, 'session-d');

--- a/packages/llm-agent-libs/src/rag/knowledge-rag.ts
+++ b/packages/llm-agent-libs/src/rag/knowledge-rag.ts
@@ -237,8 +237,18 @@ export class InMemoryKnowledgeBackend implements KnowledgeBackend {
     return a;
   }
   async put(sid: string, entry: KnowledgeEntry, options?: CallOptions) {
+    // A durable append is the success point: an index upsert failure does NOT
+    // rethrow (mirrors JsonlKnowledgeBackend.put()) — the entry is already
+    // retained above, just left unindexed; only the semantic recall misses it.
     this.of(sid).push(entry);
-    await this.semantic?.upsert(sid, entry, options);
+    try {
+      await this.semantic?.upsert(sid, entry, options);
+    } catch (e) {
+      if (process.env.DEBUG_CONTROLLER)
+        console.error(
+          `[knowledge-index] upsert failed (entry retained, unindexed): ${String(e)}`,
+        );
+    }
   }
   async semanticQuery(
     sid: string,

--- a/packages/llm-agent-libs/src/rag/knowledge-rag.ts
+++ b/packages/llm-agent-libs/src/rag/knowledge-rag.ts
@@ -7,6 +7,7 @@ import type {
   KnowledgeFilter,
   LlmTool,
 } from '@mcp-abap-adt/llm-agent';
+import { isDebugArea } from '../logger/debug-areas.js';
 
 /**
  * Persistence + retrieval port for the knowledge blackboard. The server
@@ -240,11 +241,15 @@ export class InMemoryKnowledgeBackend implements KnowledgeBackend {
     // A durable append is the success point: an index upsert failure does NOT
     // rethrow (mirrors JsonlKnowledgeBackend.put()) — the entry is already
     // retained above, just left unindexed; only the semantic recall misses it.
+    // NB: unlike the jsonl backend (which unsets `built` and re-embeds every
+    // durable entry on the next touch), this in-memory backend has no rebuild,
+    // so a failed entry stays retained-but-unindexed for the process lifetime —
+    // a recall-quality degradation, never a crash.
     this.of(sid).push(entry);
     try {
       await this.semantic?.upsert(sid, entry, options);
     } catch (e) {
-      if (process.env.DEBUG_CONTROLLER)
+      if (isDebugArea('rag'))
         console.error(
           `[knowledge-index] upsert failed (entry retained, unindexed): ${String(e)}`,
         );

--- a/packages/llm-agent-server-libs/src/smart-agent/__tests__/jsonl-knowledge-backend.test.ts
+++ b/packages/llm-agent-server-libs/src/smart-agent/__tests__/jsonl-knowledge-backend.test.ts
@@ -121,6 +121,54 @@ test('lazy rehydration build() forwards request options into the rebuild upserts
   );
 });
 
+test('build() rebuild survives a per-entry embed failure: other entries stay indexed and the session is not marked built (retries next time)', async () => {
+  await rm(TEST_DIR, { recursive: true, force: true });
+
+  // 1. Persist durable entries, one of which will be rejected by the semantic
+  //    index during the lazy rebuild (simulates a transient/provider-specific
+  //    embed failure on a NON-empty entry — e.g. rate-limit 429).
+  const seed = new JsonlKnowledgeBackend(TEST_DIR);
+  await seed.put('sessF', makeEntry('a', 'alpha'));
+  await seed.put('sessF', makeEntry('bad', 'BOOM'));
+  await seed.put('sessF', makeEntry('b', 'beta'));
+
+  const indexed: string[] = [];
+  let deleteCalls = 0;
+  const semantic = {
+    async upsert(_sid: string, e: KnowledgeEntry, _options?: unknown) {
+      if (e.content === 'BOOM') throw new Error('embed rejected');
+      indexed.push(e.content);
+    },
+    async query() {
+      return [] as readonly KnowledgeEntry[];
+    },
+    deleteSession() {
+      deleteCalls++;
+      indexed.length = 0;
+    },
+  };
+  const backend = new JsonlKnowledgeBackend(TEST_DIR, semantic as never);
+
+  // The rebuild must NOT reject the caller — one bad entry is skipped, not fatal.
+  await backend.semanticQuery('sessF', 'q');
+  assert.deepEqual(
+    indexed,
+    ['alpha', 'beta'],
+    'the two healthy entries were still indexed despite the BOOM entry failing',
+  );
+
+  // Since one entry failed, the session must NOT be marked built — the next
+  // touch retries the rebuild from the durable JSONL (source of truth) rather
+  // than caching a partial index.
+  await backend.semanticQuery('sessF', 'q');
+  assert.equal(
+    deleteCalls,
+    2,
+    'rebuild ran again on the second call (session was not marked built after a failed entry)',
+  );
+  assert.deepEqual(indexed, ['alpha', 'beta']);
+});
+
 test('cleanup temp dir', async () => {
   await rm(TEST_DIR, { recursive: true, force: true });
 });

--- a/packages/llm-agent-server-libs/src/smart-agent/jsonl-knowledge-backend.ts
+++ b/packages/llm-agent-server-libs/src/smart-agent/jsonl-knowledge-backend.ts
@@ -59,13 +59,27 @@ export class JsonlKnowledgeBackend implements KnowledgeBackend {
   /** Lazy rehydration of the in-process index from the durable JSONL. `options`
    *  is forwarded into every re-index `upsert` so the embedder receives the
    *  triggering request's requestLogger — the lazy rebuild's embedding cost is
-   *  metered against the request that triggered it (not silently dropped). */
+   *  metered against the request that triggered it (not silently dropped).
+   *  Each entry's upsert is individually guarded: a single rejected embed
+   *  (rate-limit, transient network, provider-specific rejection) must skip
+   *  that entry and continue, never abort the rebuild or crash the caller —
+   *  the durable JSONL (scan()) remains the source of truth regardless. */
   private async build(sid: string, options?: CallOptions): Promise<void> {
     if (!this.semantic || this.built.has(sid)) return;
     this.semantic.deleteSession(sid); // clear any partial state → idempotent
-    for (const e of await this.scan(sid))
-      await this.semantic.upsert(sid, e, options);
-    this.built.add(sid); // mark built ONLY on success
+    let failed = false;
+    for (const e of await this.scan(sid)) {
+      try {
+        await this.semantic.upsert(sid, e, options);
+      } catch (err) {
+        failed = true;
+        if (process.env.DEBUG_CONTROLLER)
+          console.error(
+            `[jsonl-index] rebuild upsert failed (entry skipped): ${String(err)}`,
+          );
+      }
+    }
+    if (!failed) this.built.add(sid); // mark built ONLY when every entry indexed
   }
   private async append(sid: string, entry: KnowledgeEntry): Promise<void> {
     const f = this.file(sid);


### PR DESCRIPTION
Closes #259. Follow-up hardening from the #243 fix review.

## Problem
A single embed failure during a knowledge write must not crash the controller's `execute()`. Two backends had the gap (same crash/`(no response)` shape as #243, different trigger — a rate-limit/transient/provider rejection on **non-empty** content):
- **`JsonlKnowledgeBackend.build()`** — its lazy-rebuild loop rethrew on any per-entry `upsert` failure, escaping `put()`/`semanticQuery()` uncaught.
- **`InMemoryKnowledgeBackend.put()`** — no try/catch around `semantic?.upsert` (wired by `makeKnowledgeBackend` whenever an embedder is set without a `logDir`).

## Fix
- `build()`: per-entry `try/catch` — a failing entry is skipped+logged, the rebuild continues; `built` is set ONLY on full success (so a failed entry rebuilds next touch — retry contract preserved). Success path byte-for-byte unchanged.
- `InMemoryKnowledgeBackend.put()`: `try/catch` around the upsert (entry already pushed to the durable array → retained; skip+log, no rethrow) — mirrors `JsonlKnowledgeBackend.put()`. Noted: in-memory has no rebuild, so a failed entry stays retained-but-unindexed (recall-quality degradation, never a crash).

This + `put()`'s existing tolerance makes the control-failure→terminal path independent of RAG-write success (reporter's fix-direction #2).

## Verification
TDD: two RED reproductions (embed throws during rebuild / on put) → GREEN. `llm-agent-libs` 920/920, `llm-agent-server-libs` 895/897 (2 pre-existing skips), fail 0; build + lint clean. Review clean (partial-build can't cache as 'built'; array/index skew only omits the unindexed entry from semantic recall by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)