### PR TITLE
docs(readme): add the badge header to all 17 package READMEs

### DIFF
--- a/packages/anthropic-llm/README.md
+++ b/packages/anthropic-llm/README.md
@@ -1,5 +1,8 @@
 # @mcp-abap-adt/anthropic-llm
 
+[![Stand With Ukraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/badges/StandWithUkraine.svg)](https://stand-with-ukraine.pp.ua)
+[![License: LGPL v3](https://img.shields.io/badge/License-LGPL_v3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0)
+
 Anthropic (Claude) LLM provider for @mcp-abap-adt/llm-agent / @mcp-abap-adt/llm-agent-libs.
 
 Exports:

--- a/packages/deepseek-llm/README.md
+++ b/packages/deepseek-llm/README.md
@@ -1,5 +1,8 @@
 # @mcp-abap-adt/deepseek-llm
 
+[![Stand With Ukraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/badges/StandWithUkraine.svg)](https://stand-with-ukraine.pp.ua)
+[![License: LGPL v3](https://img.shields.io/badge/License-LGPL_v3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0)
+
 DeepSeek LLM provider for @mcp-abap-adt/llm-agent / @mcp-abap-adt/llm-agent-libs.
 
 Extends `OpenAIProvider` from `@mcp-abap-adt/openai-llm`. Calls DeepSeek /v1/chat/completions API (OpenAI-compatible).

--- a/packages/hana-vector-rag/README.md
+++ b/packages/hana-vector-rag/README.md
@@ -1,5 +1,8 @@
 # @mcp-abap-adt/hana-vector-rag
 
+[![Stand With Ukraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/badges/StandWithUkraine.svg)](https://stand-with-ukraine.pp.ua)
+[![License: LGPL v3](https://img.shields.io/badge/License-LGPL_v3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0)
+
 SAP HANA Cloud Vector Engine backend for [@mcp-abap-adt/llm-agent](https://www.npmjs.com/package/@mcp-abap-adt/llm-agent).
 
 Provides:

--- a/packages/llm-agent-libs/README.md
+++ b/packages/llm-agent-libs/README.md
@@ -1,5 +1,8 @@
 # @mcp-abap-adt/llm-agent-libs
 
+[![Stand With Ukraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/badges/StandWithUkraine.svg)](https://stand-with-ukraine.pp.ua)
+[![License: LGPL v3](https://img.shields.io/badge/License-LGPL_v3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0)
+
 Core SmartAgent composition runtime. Builder, agent runtime, pipeline, sessions, history, resilience, observability, plugins, skills.
 
 ## Top-level exports

--- a/packages/llm-agent-mcp/README.md
+++ b/packages/llm-agent-mcp/README.md
@@ -1,5 +1,8 @@
 # @mcp-abap-adt/llm-agent-mcp
 
+[![Stand With Ukraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/badges/StandWithUkraine.svg)](https://stand-with-ukraine.pp.ua)
+[![License: LGPL v3](https://img.shields.io/badge/License-LGPL_v3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0)
+
 MCP client wrapper, adapter, factory, and connection strategies for the SmartAgent runtime.
 
 ## Exports

--- a/packages/llm-agent-rag/README.md
+++ b/packages/llm-agent-rag/README.md
@@ -1,5 +1,8 @@
 # @mcp-abap-adt/llm-agent-rag
 
+[![Stand With Ukraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/badges/StandWithUkraine.svg)](https://stand-with-ukraine.pp.ua)
+[![License: LGPL v3](https://img.shields.io/badge/License-LGPL_v3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0)
+
 RAG and embedder composition for the SmartAgent runtime.
 
 ## Exports

--- a/packages/llm-agent-server-libs/README.md
+++ b/packages/llm-agent-server-libs/README.md
@@ -1,5 +1,8 @@
 # @mcp-abap-adt/llm-agent-server-libs
 
+[![Stand With Ukraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/badges/StandWithUkraine.svg)](https://stand-with-ukraine.pp.ua)
+[![License: LGPL v3](https://img.shields.io/badge/License-LGPL_v3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0)
+
 The SmartServer composition runtime as an **importable library**. It sits between the binary `@mcp-abap-adt/llm-agent-server` and the core `@mcp-abap-adt/llm-agent-libs`, so the SmartServer/coordinator composition can be reused in other projects without depending on the CLI/HTTP binary.
 
 ## Top-level exports

--- a/packages/llm-agent-server/README.md
+++ b/packages/llm-agent-server/README.md
@@ -1,5 +1,8 @@
 # @mcp-abap-adt/llm-agent-server
 
+[![Stand With Ukraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/badges/StandWithUkraine.svg)](https://stand-with-ukraine.pp.ua)
+[![License: GPL v3](https://img.shields.io/badge/License-GPL_v3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+
 Runnable distribution of SmartAgent (CLI + HTTP server). **Binary-only.**
 
 ## Library imports are not supported

--- a/packages/llm-agent/README.md
+++ b/packages/llm-agent/README.md
@@ -1,5 +1,8 @@
 # @mcp-abap-adt/llm-agent
 
+[![Stand With Ukraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/badges/StandWithUkraine.svg)](https://stand-with-ukraine.pp.ua)
+[![License: LGPL v3](https://img.shields.io/badge/License-LGPL_v3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0)
+
 Core interfaces, types, and lightweight default implementations for LLM agent orchestration.
 
 This package is the abstraction layer consumed by `@mcp-abap-adt/llm-agent-libs` (and transitively by `@mcp-abap-adt/llm-agent-server`) and by downstream applications that want to build their own agent on our interfaces. It ships:

--- a/packages/ollama-embedder/README.md
+++ b/packages/ollama-embedder/README.md
@@ -1,5 +1,8 @@
 # @mcp-abap-adt/ollama-embedder
 
+[![Stand With Ukraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/badges/StandWithUkraine.svg)](https://stand-with-ukraine.pp.ua)
+[![License: LGPL v3](https://img.shields.io/badge/License-LGPL_v3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0)
+
 Ollama embedding provider for @mcp-abap-adt/llm-agent. Implements `IEmbedderBatch`; uses native `fetch`.
 
 ## Exports

--- a/packages/ollama-llm/README.md
+++ b/packages/ollama-llm/README.md
@@ -1,5 +1,8 @@
 # @mcp-abap-adt/ollama-llm
 
+[![Stand With Ukraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/badges/StandWithUkraine.svg)](https://stand-with-ukraine.pp.ua)
+[![License: LGPL v3](https://img.shields.io/badge/License-LGPL_v3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0)
+
 Ollama LLM provider for `@mcp-abap-adt/llm-agent`. Thin wrapper over
 `@mcp-abap-adt/openai-llm` targeting Ollama's OpenAI-compatible `/v1` endpoint
 (default `http://localhost:11434/v1`). No API key required.

--- a/packages/openai-embedder/README.md
+++ b/packages/openai-embedder/README.md
@@ -1,5 +1,8 @@
 # @mcp-abap-adt/openai-embedder
 
+[![Stand With Ukraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/badges/StandWithUkraine.svg)](https://stand-with-ukraine.pp.ua)
+[![License: LGPL v3](https://img.shields.io/badge/License-LGPL_v3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0)
+
 OpenAI embedding provider for @mcp-abap-adt/llm-agent. Implements `IEmbedderBatch`; uses native `fetch`.
 
 ## Exports

--- a/packages/openai-llm/README.md
+++ b/packages/openai-llm/README.md
@@ -1,5 +1,8 @@
 # @mcp-abap-adt/openai-llm
 
+[![Stand With Ukraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/badges/StandWithUkraine.svg)](https://stand-with-ukraine.pp.ua)
+[![License: LGPL v3](https://img.shields.io/badge/License-LGPL_v3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0)
+
 OpenAI LLM provider for `@mcp-abap-adt/llm-agent` / `@mcp-abap-adt/llm-agent-libs`.
 
 Exports:

--- a/packages/pg-vector-rag/README.md
+++ b/packages/pg-vector-rag/README.md
@@ -1,5 +1,8 @@
 # @mcp-abap-adt/pg-vector-rag
 
+[![Stand With Ukraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/badges/StandWithUkraine.svg)](https://stand-with-ukraine.pp.ua)
+[![License: LGPL v3](https://img.shields.io/badge/License-LGPL_v3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0)
+
 PostgreSQL + pgvector backend for @mcp-abap-adt/llm-agent.
 
 Provides:

--- a/packages/qdrant-rag/README.md
+++ b/packages/qdrant-rag/README.md
@@ -1,5 +1,8 @@
 # @mcp-abap-adt/qdrant-rag
 
+[![Stand With Ukraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/badges/StandWithUkraine.svg)](https://stand-with-ukraine.pp.ua)
+[![License: LGPL v3](https://img.shields.io/badge/License-LGPL_v3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0)
+
 QdrantRag vector store and QdrantRagProvider for @mcp-abap-adt/llm-agent.
 
 Provides vector search capabilities using Qdrant as the backend.

--- a/packages/sap-aicore-embedder/README.md
+++ b/packages/sap-aicore-embedder/README.md
@@ -1,5 +1,8 @@
 # @mcp-abap-adt/sap-aicore-embedder
 
+[![Stand With Ukraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/badges/StandWithUkraine.svg)](https://stand-with-ukraine.pp.ua)
+[![License: LGPL v3](https://img.shields.io/badge/License-LGPL_v3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0)
+
 SAP AI Core embedding provider (IEmbedderBatch) for @mcp-abap-adt/llm-agent.
 
 Generates text embeddings via SAP AI Core embedding model deployments using the @sap-ai-sdk/orchestration client.

--- a/packages/sap-aicore-llm/README.md
+++ b/packages/sap-aicore-llm/README.md
@@ -1,5 +1,8 @@
 # @mcp-abap-adt/sap-aicore-llm
 
+[![Stand With Ukraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/badges/StandWithUkraine.svg)](https://stand-with-ukraine.pp.ua)
+[![License: LGPL v3](https://img.shields.io/badge/License-LGPL_v3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0)
+
 SAP AI Core LLM provider for @mcp-abap-adt/llm-agent / @mcp-abap-adt/llm-agent-libs.
 
 Exports:

--- a/test/repo/readme-badges.test.ts
+++ b/test/repo/readme-badges.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Every package README is an npm landing page, so the badge header has to be
+ * on all of them — it drifted once already, sitting only on the root README
+ * while all 17 package READMEs had none.
+ *
+ * The licence badge is per package, not a copy of the root's pair: the root
+ * carries both because the monorepo holds both licences, but a reader landing
+ * on a single package must see that package's own licence, not a choice of two.
+ */
+import assert from 'node:assert/strict';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const PACKAGES_DIR = join(ROOT, 'packages');
+
+const SWU_BADGE = 'stand-with-ukraine.pp.ua';
+const LGPL_BADGE = 'https://www.gnu.org/licenses/lgpl-3.0';
+const GPL_BADGE = 'https://www.gnu.org/licenses/gpl-3.0';
+
+/** The badge header sits directly under the H1, so only the top matters. */
+const HEADER_LINES = 6;
+
+type Pkg = { name?: string; private?: boolean; license?: string };
+
+function packageReadmes(): Array<{ name: string; license: string; readme: string }> {
+  return readdirSync(PACKAGES_DIR)
+    .map((dir) => join(PACKAGES_DIR, dir))
+    .filter((dir) => existsSync(join(dir, 'package.json')))
+    .map((dir) => ({
+      dir,
+      pkg: JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8')) as Pkg,
+    }))
+    .filter(({ pkg }) => !pkg.private)
+    .map(({ dir, pkg }) => {
+      const path = join(dir, 'README.md');
+      assert.ok(existsSync(path), `${pkg.name}: no README.md`);
+      return {
+        name: pkg.name ?? dir,
+        license: pkg.license ?? '',
+        readme: readFileSync(path, 'utf8'),
+      };
+    });
+}
+
+const header = (readme: string): string =>
+  readme.split('\n').slice(0, HEADER_LINES).join('\n');
+
+test('every package README carries the Stand With Ukraine badge', () => {
+  const readmes = packageReadmes();
+  assert.ok(readmes.length > 0, 'no package READMEs found');
+
+  for (const { name, readme } of readmes) {
+    assert.ok(
+      header(readme).includes(SWU_BADGE),
+      `${name}: Stand With Ukraine badge missing from the README header`,
+    );
+  }
+  assert.ok(
+    header(readFileSync(join(ROOT, 'README.md'), 'utf8')).includes(SWU_BADGE),
+    'root README: Stand With Ukraine badge missing from the header',
+  );
+});
+
+test('each package README shows its own licence badge, and only that one', () => {
+  for (const { name, license, readme } of packageReadmes()) {
+    const head = header(readme);
+    const isGpl = license === 'GPL-3.0-only';
+
+    // `lgpl-3.0` contains `gpl-3.0`, so match the LGPL first and rule it out.
+    const hasLgpl = head.includes(LGPL_BADGE);
+    const hasGpl = head.replaceAll(LGPL_BADGE, '').includes(GPL_BADGE);
+
+    assert.equal(
+      isGpl ? hasGpl : hasLgpl,
+      true,
+      `${name}: README header is missing the ${license} badge`,
+    );
+    assert.equal(
+      isGpl ? hasLgpl : hasGpl,
+      false,
+      `${name}: README header shows a licence badge other than its own (${license})`,
+    );
+  }
+});


### PR DESCRIPTION
The Stand With Ukraine banner sat only on the root README; none of the 17 package READMEs carried it — even though each is an npm landing page and is what a consumer actually lands on.

Each package now shows the banner plus the licence badge for **its own** licence:

- **LGPL v3** on the sixteen libraries
- **GPL v3** on `llm-agent-server`

The root keeps both licence badges, because the monorepo holds both. Repeating that pair on a single package would present a reader with a choice of two licences where only one applies.

## Guard

`test/repo/readme-badges.test.ts` — the banner must be in every package README header (and the root's), and the licence badge must match that package's declared `license`, with the other absent. Both assertions were proven to fail on the real defects before being kept:

| injected defect | result |
|---|---|
| banner stripped from one package (the actual drift) | ✖ fails |
| GPL package given an LGPL badge | ✖ fails |
| restored | ✔ 2 pass |

Note the badge URLs need care: `lgpl-3.0` contains `gpl-3.0` as a substring, so the test matches the LGPL URL first and rules it out before checking for the GPL one.

## Verification

`npm run build` exit 0 · `npm run lint:check` exit 0 · `npm test` **2563 pass / 0 fail**

## Release note

`22.0.0` is tagged but **not yet on npm**, so this lands inside the same release rather than needing a `22.0.1` — the `v22.0.0` tag should move to this merge commit before publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7iRRnT78Xa5j91YRmDJ7W