### PR TITLE
chore(deps): clear the new advisories and make Dependabot open the next ones

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,57 @@
+# Dependabot configuration.
+#
+# History this guards: security advisories piled up unnoticed twice — once
+# cleared by hand in v20.9.5 (npm audit 8 -> 0), and again right after v22.0.0
+# (fast-uri, qs) — because the repository had no configuration here and
+# automated security fixes were switched off, so Dependabot never opened a PR.
+#
+# Everything is grouped on purpose: this monorepo has 17 workspaces, and
+# ungrouped updates mean a pull request per package per bump.
+version: 2
+
+updates:
+  # npm resolves the whole workspace tree from the root lockfile, so one entry
+  # covers every package under packages/.
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    versioning-strategy: increase-if-necessary
+    groups:
+      # Patch and minor bumps of runtime dependencies travel together; a single
+      # PR is reviewable, seventeen are not.
+      production-minor-patch:
+        applies-to: version-updates
+        dependency-type: production
+        update-types: [minor, patch]
+      development:
+        applies-to: version-updates
+        dependency-type: development
+        update-types: [minor, patch]
+      # Security fixes are grouped separately so they are never queued behind a
+      # routine version bump.
+      security:
+        applies-to: security-updates
+        patterns: ['*']
+    ignore:
+      # Majors are a deliberate, reviewed decision in a lockstep monorepo —
+      # Dependabot should not open them unprompted.
+      - dependency-name: '*'
+        update-types: [version-update:semver-major]
+    commit-message:
+      prefix: chore
+      prefix-development: chore
+      include: scope
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 3
+    groups:
+      actions:
+        patterns: ['*']
+    commit-message:
+      prefix: ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -1547,9 +1547,9 @@
       "license": "MIT"
     },
     "packages/llm-agent-mcp/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -2136,18 +2136,28 @@
       }
     },
     "packages/llm-agent-mcp/node_modules/@modelcontextprotocol/sdk/node_modules/express/node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "packages/llm-agent-mcp/node_modules/@modelcontextprotocol/sdk/node_modules/express/node_modules/qs/node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "packages/llm-agent-mcp/node_modules/@modelcontextprotocol/sdk/node_modules/express/node_modules/qs/node_modules/side-channel": {
@@ -2295,15 +2305,6 @@
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
       },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "packages/llm-agent-mcp/node_modules/@modelcontextprotocol/sdk/node_modules/express/node_modules/qs/node_modules/side-channel/node_modules/side-channel-map/node_modules/get-intrinsic/node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -2491,15 +2492,6 @@
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
       },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "packages/llm-agent-mcp/node_modules/@modelcontextprotocol/sdk/node_modules/express/node_modules/qs/node_modules/side-channel/node_modules/side-channel-weakmap/node_modules/get-intrinsic/node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -3381,9 +3373,9 @@
       "license": "MIT"
     },
     "packages/llm-agent-server/node_modules/@modelcontextprotocol/sdk/node_modules/ajv/node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -3970,18 +3962,28 @@
       }
     },
     "packages/llm-agent-server/node_modules/@modelcontextprotocol/sdk/node_modules/express/node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "packages/llm-agent-server/node_modules/@modelcontextprotocol/sdk/node_modules/express/node_modules/qs/node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "packages/llm-agent-server/node_modules/@modelcontextprotocol/sdk/node_modules/express/node_modules/qs/node_modules/side-channel": {
@@ -4129,15 +4131,6 @@
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
       },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "packages/llm-agent-server/node_modules/@modelcontextprotocol/sdk/node_modules/express/node_modules/qs/node_modules/side-channel/node_modules/side-channel-map/node_modules/get-intrinsic/node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -4325,15 +4318,6 @@
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
       },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "packages/llm-agent-server/node_modules/@modelcontextprotocol/sdk/node_modules/express/node_modules/qs/node_modules/side-channel/node_modules/side-channel-weakmap/node_modules/get-intrinsic/node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }


### PR DESCRIPTION
## The advisories

`npm audit` had drifted back to **2 vulnerabilities** (v20.9.5 cleared 8 → 0 by hand; these were published since).

| severity | package | ours | fixed in | reached via |
|---|---|---|---|---|
| **HIGH** ×4 — SSRF via malformed IPv6 normalization and repeated percent-decoding; host confusion via percent-encoded scheme and skipped IDN canonicalization | `fast-uri` | 3.1.5 | ≥3.1.6 | `@modelcontextprotocol/sdk` → `ajv` |
| **MODERATE** ×2 — DoS via attacker-controlled `isBuffer`; array-limit bypass | `qs` | 6.15.2 | ≥6.16.0 | `@modelcontextprotocol/sdk` → `express` |

Both transitive. Nothing in our source, no declared dependency changed — `npm audit fix` touches `package-lock.json` only.

## Consumers of 22.0.0 were never exposed

The intermediate ranges already admit the patched versions (`ajv` wants `fast-uri: ^3.0.1`, `express` wants `qs: ^6.14.0`), and our packages publish no lockfile, so npm resolves fresh. Verified against the registry:

```
$ npm i @mcp-abap-adt/llm-agent-server@22.0.0     # clean dir
fast-uri 3.1.7   qs 6.16.0   →   found 0 vulnerabilities
```

So this is repo and CI hygiene, not a product defect, and it needs no re-release: the packed tarballs are **content-identical before and after** this change, checked across all 17 — because no tarball contains a lockfile.

## Why it recurred, and what stops it now

The repository had **no `.github/dependabot.yml`** and **automated security fixes were OFF**, so Dependabot never opened a PR and the backlog had to be found by running `npm audit` by hand — twice.

- Automated security fixes **enabled** on the repository (`{"enabled": true}`).
- `.github/dependabot.yml` added, everything grouped on purpose: with 17 workspaces an ungrouped config means a PR per package per bump. Security updates form **their own group**, so a fix is never queued behind a routine version bump, and majors are ignored — in a lockstep monorepo those are a reviewed decision, not a bot's.

## Verification

`npm run lint:check` exit 0 · `npm test` **2563 pass / 0 fail** · `npm audit` **0 vulnerabilities**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7iRRnT78Xa5j91YRmDJ7W