### PR TITLE
chore(deps-dev): bump the development group, with the Biome 2.5 lint errors fixed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,9 +24,9 @@
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "2.4.16",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.16.tgz",
-      "integrity": "sha512-x9ajFh1zChVybCiM3TN6OD4phAqLgtPZjFrZF+aTMYCPjwBO+k529TX7PPsAqtGNLeV4UgzwQnowEgS7bGmzcA==",
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.12.tgz",
+      "integrity": "sha512-Lw4VHZRebrReBBnlHa12JQjnIBm3JJAA55PDB9LbBVBF0q4RYphm6KfmIjqtPhf61MxZ5Q9KoK8R8x+7per5Aw==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
@@ -40,20 +40,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "2.4.16",
-        "@biomejs/cli-darwin-x64": "2.4.16",
-        "@biomejs/cli-linux-arm64": "2.4.16",
-        "@biomejs/cli-linux-arm64-musl": "2.4.16",
-        "@biomejs/cli-linux-x64": "2.4.16",
-        "@biomejs/cli-linux-x64-musl": "2.4.16",
-        "@biomejs/cli-win32-arm64": "2.4.16",
-        "@biomejs/cli-win32-x64": "2.4.16"
+        "@biomejs/cli-darwin-arm64": "2.5.12",
+        "@biomejs/cli-darwin-x64": "2.5.12",
+        "@biomejs/cli-linux-arm64": "2.5.12",
+        "@biomejs/cli-linux-arm64-musl": "2.5.12",
+        "@biomejs/cli-linux-x64": "2.5.12",
+        "@biomejs/cli-linux-x64-musl": "2.5.12",
+        "@biomejs/cli-win32-arm64": "2.5.12",
+        "@biomejs/cli-win32-x64": "2.5.12"
       }
     },
     "node_modules/@biomejs/biome/node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "2.4.16",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.16.tgz",
-      "integrity": "sha512-wxPvu4XOA85YJk9ixSWUmq/QBHbid85BISbOAqqBM/5xQpPk9ayjk5375tOlSC0BeCwNSbPFafQBm+vBumXq0A==",
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.12.tgz",
+      "integrity": "sha512-lCRY1rwgNeWNgTr4DI/u6ZwXTRwRLHAvbaio1YLLGS+4r1nhvB2ssyPqIpfUSmRveNfv0fn/N58C7CAdK2XVrg==",
       "cpu": [
         "arm64"
       ],
@@ -68,9 +68,9 @@
       }
     },
     "node_modules/@biomejs/biome/node_modules/@biomejs/cli-darwin-x64": {
-      "version": "2.4.16",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.16.tgz",
-      "integrity": "sha512-xFCqGPwYusQJp4N4NJLi1XJiZqjwFdjhT+KqtNy+Ug3qgfczqnTa6MSDvxJF6TkuDLoYJItMapz6tAf7kCekFw==",
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.12.tgz",
+      "integrity": "sha512-vhPgwnh+6tN3ArdAXuET99xaNbFt7CG82Bqn+omHVLC5xdVx45JsYjGPmUIGNzjDek5XdNCP1HKksK7fn8+3bQ==",
       "cpu": [
         "x64"
       ],
@@ -85,9 +85,9 @@
       }
     },
     "node_modules/@biomejs/biome/node_modules/@biomejs/cli-linux-arm64": {
-      "version": "2.4.16",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.16.tgz",
-      "integrity": "sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ==",
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.12.tgz",
+      "integrity": "sha512-2gp8aVwXYKdAtmBfRFCUuyDMcfN1ahHqUkGfLYrZlNRFmryMATLVvJgWKvyA8wu4Rwn5OSxM1UcUmOuOFNGeBQ==",
       "cpu": [
         "arm64"
       ],
@@ -105,9 +105,9 @@
       }
     },
     "node_modules/@biomejs/biome/node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "2.4.16",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.16.tgz",
-      "integrity": "sha512-oYxnW0ARfJkr72ezzF2OR8N/rtkgLUQeYtF8cFhVswbknHxtTcmzSsanVJP8yQKnGpGpc2ck6c5zLvHahL6Cbg==",
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.12.tgz",
+      "integrity": "sha512-couHYjFLL5uuI8ne6zhT7KwEsXo5YP7ry/2xmEqah7qanu0YmfDi3mwJg47YXSuv/NpZj22CZzcRH/5c4gjPSQ==",
       "cpu": [
         "arm64"
       ],
@@ -125,9 +125,9 @@
       }
     },
     "node_modules/@biomejs/biome/node_modules/@biomejs/cli-linux-x64": {
-      "version": "2.4.16",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.16.tgz",
-      "integrity": "sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ==",
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.12.tgz",
+      "integrity": "sha512-SnvOs3TSTiuia4SQOUNe1aWC9RT4+YkjcKnOhL/nsKOV0k5ycgBkDzF0lUxKn1V7Q8CLTRq6iV23ZAivHomRoA==",
       "cpu": [
         "x64"
       ],
@@ -145,9 +145,9 @@
       }
     },
     "node_modules/@biomejs/biome/node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "2.4.16",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.16.tgz",
-      "integrity": "sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg==",
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.12.tgz",
+      "integrity": "sha512-8A0oDW58/w9f/PQNYuq0sGUZtGtGrkNF4Z6n0PUoXpLCshi85vtKTv1XSznQawhdE4MXJ8ufpzHXyLFe87M/+w==",
       "cpu": [
         "x64"
       ],
@@ -165,9 +165,9 @@
       }
     },
     "node_modules/@biomejs/biome/node_modules/@biomejs/cli-win32-arm64": {
-      "version": "2.4.16",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.16.tgz",
-      "integrity": "sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A==",
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.12.tgz",
+      "integrity": "sha512-b9vtoZFsuZt1pdjNwJvXl0f+BpayRzV008uS2+JpmwIKdSE2qdu4A/l04FESwLoou5g2E/Qlec0xwJydZplH+A==",
       "cpu": [
         "arm64"
       ],
@@ -182,9 +182,9 @@
       }
     },
     "node_modules/@biomejs/biome/node_modules/@biomejs/cli-win32-x64": {
-      "version": "2.4.16",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.16.tgz",
-      "integrity": "sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw==",
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.12.tgz",
+      "integrity": "sha512-B1R/l+CwEpKFSuqiwePzPNRk1EiJN8kc0UhdafNz6MZN9v5OFP9HYP1irptvWzHrwVI4blVNGMbxc5zt70m3IA==",
       "cpu": [
         "x64"
       ],
@@ -267,9 +267,9 @@
       "link": true
     },
     "node_modules/@types/node": {
-      "version": "25.9.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
-      "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
+      "version": "25.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
+      "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -405,9 +405,9 @@
       "license": "BlueOak-1.0.0"
     },
     "node_modules/tsx": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
-      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "version": "4.23.13",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.13.tgz",
+      "integrity": "sha512-BL5MGkRln6aDYhb0xbQlEAGw743BaZYWdbWtdJOBriYJboKgUUYCadFp2/FpBBZquBC/ezNBn7wMMPx7FDZUDw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/llm-agent-libs/src/__tests__/builder-tool-namespace-three-routes.test.ts
+++ b/packages/llm-agent-libs/src/__tests__/builder-tool-namespace-three-routes.test.ts
@@ -145,7 +145,7 @@ test('withToolNamespace() reaches all THREE consumers: registry, startup vectori
   assert.equal(res.ok, true, 'process() must complete successfully');
   const toolsSelected = steps.find((s) => s.name === 'tools_selected');
   assert.ok(toolsSelected, 'tools_selected step must be logged');
-  const selectedNames = (toolsSelected?.data as { selectedNames: string[] })
+  const selectedNames = (toolsSelected.data as { selectedNames: string[] })
     .selectedNames;
   assert.deepEqual(
     [...selectedNames].sort(),

--- a/packages/llm-agent-libs/src/coordinator/stepper/__tests__/cyclic-react-executor.test.ts
+++ b/packages/llm-agent-libs/src/coordinator/stepper/__tests__/cyclic-react-executor.test.ts
@@ -1315,7 +1315,7 @@ test('Guard 1: tools offered but final answer made with no tool calls/facts → 
   const flag = steps.find((s) => s.name === 'hallucination_suspected');
   assert.ok(flag, 'emits hallucination_suspected');
   assert.equal(
-    (flag?.data as { finalPromptTokens: number }).finalPromptTokens,
+    (flag.data as { finalPromptTokens: number }).finalPromptTokens,
     42,
     'records the answer-producing call prompt tokens as evidence',
   );

--- a/packages/llm-agent-libs/src/coordinator/stepper/llm-evaluator.ts
+++ b/packages/llm-agent-libs/src/coordinator/stepper/llm-evaluator.ts
@@ -108,10 +108,9 @@ export function parseVerdict(raw: string): EvaluatorVerdict {
     json && typeof json.route === 'string' && ROUTES.has(json.route)
       ? (json.route as EvaluatorRoute)
       : 'needs-work';
-  const missing = Array.isArray(json?.missing)
-    ? (json?.missing as unknown[]).filter(
-        (m): m is string => typeof m === 'string',
-      )
+  const rawMissing = json?.missing;
+  const missing = Array.isArray(rawMissing)
+    ? rawMissing.filter((m): m is string => typeof m === 'string')
     : [];
   const reason =
     json && typeof json.reason === 'string' ? json.reason : undefined;

--- a/packages/llm-agent-libs/src/pipeline/handlers/__tests__/pass-through-debug-trace.test.ts
+++ b/packages/llm-agent-libs/src/pipeline/handlers/__tests__/pass-through-debug-trace.test.ts
@@ -97,10 +97,8 @@ test('runPassThrough emits tagged llm_request_pass and llm_response_pass records
   );
   assert.ok(requestStep, 'expected an llm_request_pass step to be logged');
   assert.equal(requestStep?.area, 'llm');
-  assert.deepEqual(
-    (requestStep?.data as { messages: Message[] }).messages,
-    messages,
-  );
+  const requestData = requestStep?.data as { messages: Message[] } | undefined;
+  assert.deepEqual(requestData?.messages, messages);
 
   const responseStep = spySession.steps.find(
     (s) => s.name === 'llm_response_pass',

--- a/packages/llm-agent-server-libs/src/builders/controller-skill-pipeline-builder.test.ts
+++ b/packages/llm-agent-server-libs/src/builders/controller-skill-pipeline-builder.test.ts
@@ -30,13 +30,14 @@ test('fluent calls translate to the expected SmartServerConfig', () => {
     .withBudgets({ maxToolCalls: 30 })
     .toConfig();
 
-  assert.equal(cfg.pipeline?.name, 'controller');
-  const sub = (cfg.pipeline?.config as any).subagents;
+  assert.ok(cfg.pipeline, 'a pipeline must be configured');
+  assert.equal(cfg.pipeline.name, 'controller');
+  const sub = (cfg.pipeline.config as any).subagents;
   assert.equal(sub.evaluator.provider, 'sap-ai-sdk');
   assert.equal(sub.executor.provider, 'sap-ai-sdk');
   assert.equal(sub.planner.provider, 'openai');
   assert.equal(sub.planner.apiKey, 'k');
-  assert.equal((cfg.pipeline?.config as any).budgets.maxToolCalls, 30);
+  assert.equal((cfg.pipeline.config as any).budgets.maxToolCalls, 30);
   assert.deepEqual(cfg.mcp, [
     { type: 'http', url: 'http://localhost:3001/mcp/stream/http' },
   ]);

--- a/packages/llm-agent-server-libs/src/smart-agent/controller/__tests__/controller-no-response.test.ts
+++ b/packages/llm-agent-server-libs/src/smart-agent/controller/__tests__/controller-no-response.test.ts
@@ -1,11 +1,11 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import {
-  type IKnowledgeRagHandle,
-  type KnowledgeEntry,
-  type LlmStreamChunk,
-  type LlmTool,
-  type Result,
+import type {
+  IKnowledgeRagHandle,
+  KnowledgeEntry,
+  LlmStreamChunk,
+  LlmTool,
+  Result,
 } from '@mcp-abap-adt/llm-agent';
 import type { PipelineContext } from '@mcp-abap-adt/llm-agent-libs';
 import {

--- a/packages/llm-agent-server-libs/src/smart-agent/controller/__tests__/debug-trace-decisions.test.ts
+++ b/packages/llm-agent-server-libs/src/smart-agent/controller/__tests__/debug-trace-decisions.test.ts
@@ -185,7 +185,7 @@ describe('debug-trace controller decision / MCP / RAG capture (Task 5, #213)', (
       d,
       `expected a controller_decision record, got: ${JSON.stringify(steps.map((s) => s.name))}`,
     );
-    assert.ok((d?.data as { reason?: string }).reason, 'it carries a reason');
+    assert.ok((d.data as { reason?: string }).reason, 'it carries a reason');
   });
 
   it('the target-state establishment emits a controller_decision_target-state record', async () => {
@@ -203,7 +203,7 @@ describe('debug-trace controller decision / MCP / RAG capture (Task 5, #213)', (
         s.area === 'controller',
     );
     assert.ok(d, 'expected a target-state decision record');
-    assert.ok((d?.data as { reason?: string }).reason, 'it carries a reason');
+    assert.ok((d.data as { reason?: string }).reason, 'it carries a reason');
   });
 
   it('the controller MCP bridge emits an mcp_tool_call record (area mcp)', async () => {
@@ -221,7 +221,7 @@ describe('debug-trace controller decision / MCP / RAG capture (Task 5, #213)', (
       m,
       `expected an mcp_tool_call record, got: ${JSON.stringify(steps.map((s) => s.name))}`,
     );
-    assert.equal((m?.data as { name?: string }).name, 'GetTable');
+    assert.equal((m.data as { name?: string }).name, 'GetTable');
   });
 
   it('the controller step recall emits a rag_recall record (area rag)', async () => {
@@ -239,7 +239,7 @@ describe('debug-trace controller decision / MCP / RAG capture (Task 5, #213)', (
       `expected a rag_recall record, got: ${JSON.stringify(steps.map((s) => s.name))}`,
     );
     assert.ok(
-      (r?.data as { query?: string }).query,
+      (r.data as { query?: string }).query,
       'it carries the recall query',
     );
   });

--- a/packages/llm-agent-server-libs/src/smart-agent/controller/__tests__/debug-trace-llm.test.ts
+++ b/packages/llm-agent-server-libs/src/smart-agent/controller/__tests__/debug-trace-llm.test.ts
@@ -39,10 +39,10 @@ test('send emits llm_request + llm_response tagged "llm" with content', async ()
   const res = steps.find((s) => s.name.includes('llm_response'));
   assert.ok(req && req.area === 'llm', 'request record tagged llm');
   assert.ok(res && res.area === 'llm', 'response record tagged llm');
-  assert.deepEqual((req?.data as { messages: unknown[] }).messages, [
+  assert.deepEqual((req.data as { messages: unknown[] }).messages, [
     { role: 'user', content: 'hi' },
   ]);
-  assert.equal((res?.data as { content: string }).content, 'hello');
+  assert.equal((res.data as { content: string }).content, 'hello');
 });
 
 test('no sessionLogger → send still works, no throw', async () => {

--- a/packages/sap-aicore-embedder/src/auth.test.ts
+++ b/packages/sap-aicore-embedder/src/auth.test.ts
@@ -42,8 +42,11 @@ test('TokenProvider fetches and returns access_token', async () => {
   assert.equal(token, 'tok-1');
   assert.equal(fetchCalls.length, 1);
   assert.equal(fetchCalls[0].url, 'https://auth.example.com/oauth/token');
+  const headers = fetchCalls[0].init?.headers as
+    | Record<string, string>
+    | undefined;
   assert.equal(
-    (fetchCalls[0].init?.headers as Record<string, string>).Authorization,
+    headers?.Authorization,
     `Basic ${Buffer.from('cid:csec').toString('base64')}`,
   );
 });


### PR DESCRIPTION
Supersedes #278. Same Dependabot commit, plus the fix that makes it pass.

## Why #278 could not merge

The dev-group bump takes `@biomejs/biome` **2.4.16 → 2.5.12**, and 2.5 turns `correctness/noUnsafeOptionalChaining` into **13 errors** that 2.4.16 never raised. CI failed on both legs in 23s — lint, not tests.

The rule is right. Every site is `(x?.y as T).z`: an optional chain whose result is immediately dereferenced. If `x` is nullish, `x?.y` is `undefined` and the member access throws `TypeError`. The `?.` protected nothing — it only moved the failure somewhere less legible.

## Fixed per site, not by disabling the rule

| site | why it was unsafe | fix |
|---|---|---|
| `llm-evaluator.ts` — the **only production site** | `Array.isArray(json?.missing)` already guards the branch, so the inner `?.` was dead | bind once; the redundant chain *and* the cast go away |
| `debug-trace-decisions`, `debug-trace-llm`, `cyclic-react-executor`, `builder-tool-namespace-three-routes` | each sits directly under `assert.ok(x, …)`, an assertion function, so `x` is already narrowed non-nullish | drop the `?.` |
| `controller-skill-pipeline-builder.test.ts` | `assert.equal(cfg.pipeline?.name, …)` narrows nothing | assert `cfg.pipeline` outright — that is the precondition the test actually relies on |
| `auth.test.ts`, `pass-through-debug-trace.test.ts` | no preceding assertion at all | keep the optionality and assert on the optional value, so a missing field fails with a readable diff instead of throwing before the assertion is reached |

`controller-no-response.test.ts` also appears in the diff: a Biome 2.5 autofix consolidating `import { type A, type B }` into `import type { A, B }`. Style only.

## The rewritten assertions are not vacuous

Loosening `(x as T).y` to `x?.y` can quietly turn a test into one that passes on `undefined`, so this was checked rather than assumed — breaking the `Authorization` header in the sap-aicore-embedder **production** code still fails `auth.test.ts`:

```
mutation applied   → ℹ pass 3   ℹ fail 1   ✖ TokenProvider fetches and returns access_token
restored           → ℹ pass 4   ℹ fail 0
```

## Verification

`npm run build` exit 0 · `npm run lint:check` exit 0 (was 13 errors) · `npm test` **2563 pass / 0 fail**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7iRRnT78Xa5j91YRmDJ7W